### PR TITLE
fixing crit/hit/graze linking issues

### DIFF
--- a/text/game/abilities.stringtable
+++ b/text/game/abilities.stringtable
@@ -1221,12 +1221,12 @@
     </Entry>
     <Entry>
       <ID>251</ID>
-      <DefaultText>Quälender Zweifel am unerschütterlichen Glauben überfällt Feinde im Wirkungsbereich und verringert ihre Nahkampfgenauigkeit und die Reichweite ihrer kritischen Treffer.</DefaultText>
+      <DefaultText>Quälender Zweifel am unerschütterlichen Glauben überfällt Feinde im Wirkungsbereich und verringert ihre Nahkampfgenauigkeit und die Reichweite ihrer Kritischen Treffer.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>252</ID>
-      <DefaultText>Verstärkt die Entschlossenheit aller Verbündeten im Kampf und erhöht die Wahrscheinlichkeit eines kritischen Treffers.</DefaultText>
+      <DefaultText>Verstärkt die Entschlossenheit aller Verbündeten im Kampf und erhöht die Wahrscheinlichkeit eines Kritischen Treffers.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1291,7 +1291,7 @@
     </Entry>
     <Entry>
       <ID>268</ID>
-      <DefaultText>Der Zauberwirker ist in der Lage, die Schwächen und Schwachstellen eines Feindes zu erkennen, als ob sie physikalisch greifbar wären, wodurch die Wahrscheinlichkeit eines kritischen Treffers erhöht wird.</DefaultText>
+      <DefaultText>Der Zauberwirker ist in der Lage, die Schwächen und Schwachstellen eines Feindes zu erkennen, als ob sie physikalisch greifbar wären, wodurch die Wahrscheinlichkeit eines Kritischen Treffers erhöht wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1411,7 +1411,7 @@
     </Entry>
     <Entry>
       <ID>295</ID>
-      <DefaultText>Verstärkt den Arm des Kämpfers, wodurch ein Teil seiner leichten Treffer zu Treffern wird und der Mindestschaden von Nahkampfwaffen erhöht wird.</DefaultText>
+      <DefaultText>Verstärkt den Arm des Kämpfers, wodurch ein Teil seiner Leichten Treffer zu Treffern wird und der Mindestschaden von Nahkampfwaffen erhöht wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1421,7 +1421,7 @@
     </Entry>
     <Entry>
       <ID>297</ID>
-      <DefaultText>Der Kämpfer bemüht sich zusätzlich, die wildesten Schläge abzuwehren, wodurch ein Teil aller eingehenden kritischen Treffer zu Treffern umgewandelt wird und alle eingehenden Treffer zu leichten Treffern.</DefaultText>
+      <DefaultText>Der Kämpfer bemüht sich zusätzlich, die wildesten Schläge abzuwehren, wodurch ein Teil aller eingehenden Kritischen Treffer zu Treffern umgewandelt wird und alle eingehenden Treffer zu Leichten Treffern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4331,7 +4331,7 @@
     </Entry>
     <Entry>
       <ID>883</ID>
-      <DefaultText>Der Kämpfer erlangt einen besonderen Vorteil gegenüber Feinden, die versuchen, die Kampfhandlung zu vereiteln, indem er auf die Beine zielt. Führt dazu, dass Ziele von Treffern oder kritischen Treffern durch Absetzangriffe behindert werden.</DefaultText>
+      <DefaultText>Der Kämpfer erlangt einen besonderen Vorteil gegenüber Feinden, die versuchen, die Kampfhandlung zu vereiteln, indem er auf die Beine zielt. Führt dazu, dass Ziele von Treffern oder Kritischen Treffern durch Absetzangriffe behindert werden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4501,7 +4501,7 @@
     </Entry>
     <Entry>
       <ID>917</ID>
-      <DefaultText>Nutzt den Vorteil der Ablenkung des Feindes, während dieser vom tierischen Gefährten des Waldläufers angegriffen wird, um den Feind zu betäuben (als Zweitangriff), wenn dem Waldläufer ein Treffer oder kritischer Treffer gelingt.</DefaultText>
+      <DefaultText>Nutzt den Vorteil der Ablenkung des Feindes, während dieser vom tierischen Gefährten des Waldläufers angegriffen wird, um den Feind zu betäuben (als Zweitangriff), wenn dem Waldläufer Treffer oder Kritische Treffer gelingen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4516,7 +4516,7 @@
     </Entry>
     <Entry>
       <ID>920</ID>
-      <DefaultText>Der Schurke nutzt eine Vielzahl hinterhältiger Taktiken, durch die ein Teil seiner Treffer zu kritischen Treffern wird.</DefaultText>
+      <DefaultText>Der Schurke nutzt eine Vielzahl hinterhältiger Taktiken, durch die ein Teil seiner Treffer zu Kritischen Treffern wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4546,7 +4546,7 @@
     </Entry>
     <Entry>
       <ID>926</ID>
-      <DefaultText>Der Schurke zeigt sich besonders geschickt darin, Angriffen auszuweichen, und verwandelt viele leichte Treffer in Fehlschläge.</DefaultText>
+      <DefaultText>Der Schurke zeigt sich besonders geschickt darin, Angriffen auszuweichen, und verwandelt viele Leichte Treffer in Fehlschläge.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4696,7 +4696,7 @@
     </Entry>
     <Entry>
       <ID>956</ID>
-      <DefaultText>Verbündete erkennen den Eifer des Paladins und werden dadurch besonders inspiriert. Von dem eifrigen Fokus betroffene Verbündete wandeln 5&#160;% der gewöhnlichen Treffer in kritische Treffer um.</DefaultText>
+      <DefaultText>Verbündete erkennen den Eifer des Paladins und werden dadurch besonders inspiriert. Von dem eifrigen Fokus betroffene Verbündete wandeln 5&#160;% der gewöhnlichen Treffer in Kritische Treffer um.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4741,7 +4741,7 @@
     </Entry>
     <Entry>
       <ID>965</ID>
-      <DefaultText>Verbessert die Fertigkeit des Schurken zu verschlagenen Manövern, wodurch die Wahrscheinlichkeit erhöht wird, dass die Treffer des Schurken bei einem schmutzigen Kampf zu kritischen Treffern werden.</DefaultText>
+      <DefaultText>Verbessert die Fertigkeit des Schurken zu verschlagenen Manövern, wodurch die Wahrscheinlichkeit erhöht wird, dass die Treffer des Schurken bei einem schmutzigen Kampf zu Kritischen Treffern werden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5515,7 +5515,7 @@ Trotz dieser Vorteile ist die Beziehung aber auch mit Risiken behaftet. Waldläu
     </Entry>
     <Entry>
       <ID>1115</ID>
-      <DefaultText>Wenn er eine Einhand-Nahkampfwaffe einsetzt, werden einige der leichten Treffer des Angreifers in Treffer umgewandelt.</DefaultText>
+      <DefaultText>Wenn er eine Einhand-Nahkampfwaffe einsetzt, werden einige der Leichten Treffer des Angreifers in Treffer umgewandelt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/cyclopedia.stringtable
+++ b/text/game/cyclopedia.stringtable
@@ -482,7 +482,7 @@ Xaurips verehren Drachen als Gottheiten und errichten ihre Gemeinden um die Nest
     </Entry>
     <Entry>
       <ID>84</ID>
-      <DefaultText>Die Genauigkeit spielt bei fast jedem Angriff eine Rolle. Sie beeinflusst, wie wahrscheinlich es ist, dass der Angriff eine Wirkung auf das Ziel hat. Genauigkeit wird hauptsächlich durch die Klasse und die Stufe eines Charakters festgelegt, wird aber auch durch Talente und andere aktive Effekte wie Zauber oder Gegenstände beeinflusst. Wird ein Angriff unternommen, wird die Genauigkeit mit der jeweiligen Verteidigung des Ziels verglichen, um festzustellen, wie der Angriffswurf modifiziert wird. Liegt die Genauigkeit über der Verteidigung des Ziels, erhöht sich die Wahrscheinlichkeit eines Treffers oder kritischen Treffers und die Wahrscheinlichkeit eines leichten Treffers oder Fehlschlags sinkt.
+      <DefaultText>Die Genauigkeit spielt bei fast jedem Angriff eine Rolle. Sie beeinflusst, wie wahrscheinlich es ist, dass der Angriff eine Wirkung auf das Ziel hat. Genauigkeit wird hauptsächlich durch die Klasse und die Stufe eines Charakters festgelegt, wird aber auch durch Talente und andere aktive Effekte wie Zauber oder Gegenstände beeinflusst. Wird ein Angriff unternommen, wird die Genauigkeit mit der jeweiligen Verteidigung des Ziels verglichen, um festzustellen, wie der Angriffswurf modifiziert wird. Liegt die Genauigkeit über der Verteidigung des Ziels, erhöht sich die Wahrscheinlichkeit von T&#2060;reffer&#2060;n oder Kritischen Treffer&#2060;n und die Wahrscheinlichkeit von Leichten Treffer&#2060;n oder Fehlschläge&#2060;n sinkt.
 Fähigkeiten oder Talente, die keine Waffen als Teil des Angriffs einsetzen, werden mit einem kleinen Genauigkeitsbonus verstärkt, der auf der Stufe des Charakters basiert.</DefaultText>
       <FemaleText />
     </Entry>
@@ -759,27 +759,27 @@ Fähigkeiten oder Talente, die keine Waffen als Teil des Angriffs einsetzen, wer
     </Entry>
     <Entry>
       <ID>139</ID>
-      <DefaultText>Kritischer Treffer</DefaultText>
+      <DefaultText>Kritische Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>140</ID>
-      <DefaultText>Ein kritischer Treffer ist jeder Angriffswurf über 100. Ein kritischer Treffer, der Schaden verursacht, erhöht dessen Gesamtschaden um 50%. Ein kritischer Treffer bei Effekten mit einer Dauer (meistens Wirkungen wie Erkrankt oder Gelähmt) erhöht die Laufzeit um 50%.</DefaultText>
+      <DefaultText>Ein Kritischer Treffer ist jeder Angriffswurf über 100. Ein Kritischer Treffer, der Schaden verursacht, erhöht dessen Gesamtschaden um 50%. Ein Kritischer Treffer bei Effekten mit einer Dauer (meistens Wirkungen wie Erkrankt oder Gelähmt) erhöht die Laufzeit um 50%.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>141</ID>
-      <DefaultText>Leichter Treffer</DefaultText>
+      <DefaultText>Leichte Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>142</ID>
-      <DefaultText>Ein leichter Treffer ist jeder Angriffswurf zwischen 16 und 50. Ein leichter Treffer verringert Schaden und Dauer um 50%.</DefaultText>
+      <DefaultText>Ein Leichter Treffer ist jeder Angriffswurf zwischen 16 und 50. Ein Leichter Treffer verringert Schaden und Dauer um 50%.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>143</ID>
-      <DefaultText>Treffer</DefaultText>
+      <DefaultText>T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -846,14 +846,14 @@ Einige Kreaturen können manchen Wirkungen gegenüber immun sein. In diesem Fall
       <ID>154</ID>
       <DefaultText>Alle Angriffe in Pillars of Eternity vergleichen den Genauigkeitswert des Angreifers mit einer von vier Verteidigungen des Ziels: Abwehr (direkte Nah- und Fernkampfangriffe), Tapferkeit (Angriffe gegen das Immunsystem wie Gift oder Krankheit), Reflexe (Wirkungsbereichangriffe) und Wille (mentale Angriffe). 
 
-Es wird eine Zahl zwischen 1 und 100 generiert und zu der Differenz zwischen Genauigkeit und Verteidigung addiert, um das Ergebnis des Angriffs zu berechnen. Bis 15 = Fehlschlag, 16 - 50 = leichter Treffer, 51-100 = Treffer, ab 100 = Kritischer Treffer. 
+Es wird eine Zahl zwischen 1 und 100 generiert und zu der Differenz zwischen Genauigkeit und Verteidigung addiert, um das Ergebnis des Angriffs zu berechnen. Bis 15 = Fehlschläge, 16 - 50 = Leichte Treffer, 51-100 = T&#2060;reffer, ab 100 = Kritische Treffer. 
 
-In einem ausgeglichenen Angriff-/Verteidigung-Szenario werden die meisten Angriffe Treffer oder leichte Treffer sein. Wenn die Genauigkeit über der Verteidigung liegt, ist die Wahrscheinlichkeit von Kritischen Treffern höher. Wenn die Verteidigung über der Genauigkeit liegt, ist die Wahrscheinlichkeit von Fehlschlägen höher.</DefaultText>
+In einem ausgeglichenen Angriff-/Verteidigung-Szenario werden die meisten Angriffe Treffer oder Leichte Treffer sein. Wenn die Genauigkeit über der Verteidigung liegt, ist die Wahrscheinlichkeit von Kritischen Treffern höher. Wenn die Verteidigung über der Genauigkeit liegt, ist die Wahrscheinlichkeit von Fehlschlägen höher.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>155</ID>
-      <DefaultText>Fehlschlag</DefaultText>
+      <DefaultText>Fehlschläge</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/gui.stringtable
+++ b/text/game/gui.stringtable
@@ -6640,12 +6640,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1322</ID>
-      <DefaultText>... aber {1} mit zusätzlichem Effekt.</DefaultText>
+      <DefaultText>... jedoch ohne zusätzlichen Effekt.</DefaultText> <!-- {1}: ID 811 ('verfehlt') -->
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1323</ID>
-      <DefaultText>... und {1} mit zusätzlichem Effekt.</DefaultText>
+      <DefaultText>... sowie {1} für zusätzlichen Effekt:</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/gui.stringtable
+++ b/text/game/gui.stringtable
@@ -3870,7 +3870,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>766</ID>
-      <DefaultText>T&#2060;reffer</DefaultText> <!-- persönliche Statistiken -->
+      <DefaultText>T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6040,7 +6040,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1202</ID>
-      <DefaultText>Kritische Treffer können Betäubt bewirken</DefaultText>
+      <DefaultText>Chance auf Betäubung bei Kritischen Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/gui.stringtable
+++ b/text/game/gui.stringtable
@@ -266,12 +266,12 @@
     </Entry>
     <Entry>
       <ID>52</ID>
-      <DefaultText>{0} {1} {2} für {3} {4}schaden{5}.</DefaultText>
+      <DefaultText>{0} landet {1} bei {2} für {3} {4}schaden{5}.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>53</ID>
-      <DefaultText>{0} {1} {2} für {3} {4}schaden beim Absetzen.</DefaultText>
+      <DefaultText>{0} landet {1} bei {2} für {3} {4}schaden beim Absetzen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1651,7 +1651,7 @@
     </Entry>
     <Entry>
       <ID>330</ID>
-      <DefaultText>Treffer</DefaultText>
+      <DefaultText>T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2476,7 +2476,7 @@ Silberflut - In jeder Begegnung generieren Mond-Gottähnliche, wenn sie auf unte
       <ID>492</ID>
       <DefaultText>Sesshafte Orlaner sind in Readceras und in den Vailianischen Republiken oftmals Sklaven. Eine der Vertragsbedingungen zwischen dem Dyrwald und dem Volk aus Eír&#160;Glanfath war die Befreiung der orlanischen Sklaven, und obwohl diese eingehalten wurde, leben im Dyrwald noch immer viele sesshafte Orlaner als Schuldknechte .
 
-Geringe Bedrohung - Greift ein sesshafter Orlaner ein Ziel an, das von einem Gruppenmitglied ebenfalls als Ziel ausgewählt worden ist, verwandelt der sesshafte Orlaner einen Teil seiner Treffer in Kritische Treffer.</DefaultText>
+Geringe Bedrohung - Greift ein sesshafter Orlaner ein Ziel an, das von einem Gruppenmitglied ebenfalls als Ziel ausgewählt worden ist, verwandelt der sesshafte Orlaner einen Teil seiner T&#2060;reffer in Kritische Treffer.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3620,12 +3620,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>716</ID>
-      <DefaultText>Meiste kritische Treffer</DefaultText>
+      <DefaultText>Meiste Kritische Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>717</ID>
-      <DefaultText>Meiste Treffer</DefaultText>
+      <DefaultText>Meiste T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3870,7 +3870,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>766</ID>
-      <DefaultText>Treffer</DefaultText>
+      <DefaultText>T&#2060;reffer</DefaultText> <!-- persönliche Statistiken -->
       <FemaleText />
     </Entry>
     <Entry>
@@ -4100,17 +4100,17 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>812</ID>
-      <DefaultText>streift</DefaultText>
+      <DefaultText>Leichten Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>813</ID>
-      <DefaultText>trifft</DefaultText>
+      <DefaultText>T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>814</ID>
-      <DefaultText>landet einen kritischen Treffer bei</DefaultText>
+      <DefaultText>Kritischen Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5155,7 +5155,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1025</ID>
-      <DefaultText>Verursacht bei Treffer {0}.</DefaultText>
+      <DefaultText>Verursacht bei T&#2060;reffer {0}.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5710,7 +5710,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1136</ID>
-      <DefaultText>{0} Chance auf Betäubung bei Treffer</DefaultText>
+      <DefaultText>{0} Chance auf Betäubung bei T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5720,7 +5720,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1138</ID>
-      <DefaultText>{0} Chance auf Verkrüppelung bei Treffer</DefaultText>
+      <DefaultText>{0} Chance auf Verkrüppelung bei T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5755,7 +5755,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1145</ID>
-      <DefaultText>{0} Konzentration bei Treffer</DefaultText>
+      <DefaultText>{0} Konzentration bei T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5885,7 +5885,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1171</ID>
-      <DefaultText>{0} Treffer umgewandelt in Kritische Treffer, wenn das gleiche Ziel eines Verbündeten angegriffen wird</DefaultText>
+      <DefaultText>{0} T&#2060;reffer umgewandelt in Kritische Treffer, wenn das gleiche Ziel eines Verbündeten angegriffen wird</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5895,7 +5895,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1173</ID>
-      <DefaultText>{0} erlittener Kritischer Treffer umgewandelt in Treffer</DefaultText>
+      <DefaultText>{0} erlittene Kritische Treffer umgewandelt in T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5905,12 +5905,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1175</ID>
-      <DefaultText>{0} erlittener Treffer umgewandelt in Leichte Treffer (nur Abwehr und Reflexe)</DefaultText>
+      <DefaultText>{0} erlittener T&#2060;reffer umgewandelt in Leichte Treffer (nur Abwehr und Reflexe)</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1176</ID>
-      <DefaultText>{0} erlittener Treffer umgewandelt in Leichte Treffer (nur Tapferkeit und Wille)</DefaultText>
+      <DefaultText>{0} erlittener T&#2060;reffer umgewandelt in Leichte Treffer (nur Tapferkeit und Wille)</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6035,22 +6035,22 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1201</ID>
-      <DefaultText>{0} Leichte Treffer umgewandelt in Treffer</DefaultText>
+      <DefaultText>{0} Leichte Treffer umgewandelt in T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1202</ID>
-      <DefaultText>Angriffe können bei kritischem Treffer betäuben</DefaultText>
+      <DefaultText>Kritische Treffer können Betäubt bewirken</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1203</ID>
-      <DefaultText>{0} Leichte Treffer umgewandelt in Fehlschlag </DefaultText>
+      <DefaultText>{0} Leichte Treffer umgewandelt in Fehlschläge</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1204</ID>
-      <DefaultText>{0} Kritische Treffer umgewandelt in Treffer</DefaultText>
+      <DefaultText>{0} Kritische Treffer umgewandelt in T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6060,12 +6060,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1206</ID>
-      <DefaultText>{0} Treffer umgewandelt in Kritische Treffer</DefaultText>
+      <DefaultText>{0} T&#2060;reffer umgewandelt in Kritische Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1207</ID>
-      <DefaultText>{0} Treffer umgewandelt in Leichte Treffer</DefaultText>
+      <DefaultText>{0} T&#2060;reffer umgewandelt in Leichte Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6100,7 +6100,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1214</ID>
-      <DefaultText>{0} erlittener Leichter Treffer umgewandelt in Fehlschläge (nur Reflexe)</DefaultText>
+      <DefaultText>{0} erlittene Leichte Treffer umgewandelt in Fehlschläge (nur Reflexe)</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6120,7 +6120,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1218</ID>
-      <DefaultText>{0} {1}-Zeitschaden bei Treffer</DefaultText>
+      <DefaultText>{0} {1}-Zeitschaden bei T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6220,12 +6220,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1238</ID>
-      <DefaultText>Leichte Fernkampftreffer zurück auf den Angreifer reflektiert</DefaultText>
+      <DefaultText>Leichte Treffer im Fernkampf zurück auf den Angreifer reflektiert</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1239</ID>
-      <DefaultText>{0} erlittener Treffer umgewandelt in Leichte Treffer</DefaultText>
+      <DefaultText>{0} erlittener T&#2060;reffer umgewandelt in Leichte Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6375,7 +6375,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1269</ID>
-      <DefaultText>{0} erlittener Schaden durch kritische Treffer</DefaultText>
+      <DefaultText>{0} erlittener Schaden durch Kritische Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8392,7 +8392,7 @@ Trotz dieser Vorteile ist die Beziehung aber auch mit Risiken behaftet. Waldläu
     </Entry>
     <Entry>
       <ID>1675</ID>
-      <DefaultText>{0} Leichter Treffer umgewandelt zu Treffer mit Einhand-Nahkampfwaffen</DefaultText>
+      <DefaultText>{0} Leichte Treffer mit Einhand-Nahkampfwaffen umgewandelt in T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8482,7 +8482,7 @@ Trotz dieser Vorteile ist die Beziehung aber auch mit Risiken behaftet. Waldläu
     </Entry>
     <Entry>
       <ID>1693</ID>
-      <DefaultText>{0} Treffer werden gegen Ziele mit niedriger Ausdauer zu Kritischen Treffern umgewandelt</DefaultText>
+      <DefaultText>{0} T&#2060;reffer gegen Ziele mit niedriger Ausdauer umgewandelt in Kritische Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9119,12 +9119,12 @@ Willst du die Charaktererstellung wirklich abschließen?</DefaultText>
     </Entry>
     <Entry>
       <ID>1821</ID>
-      <DefaultText>Wird bei kritischem Treffer ausgelöst.</DefaultText>
+      <DefaultText>Wird ausgelöst durch Kritischen Treffer.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1822</ID>
-      <DefaultText>Wird bei erlittenem kritischem Treffer ausgelöst.</DefaultText>
+      <DefaultText>Wird ausgelöst durch erlittenen Kritischen Treffer.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/itemmods.stringtable
+++ b/text/game/itemmods.stringtable
@@ -741,7 +741,7 @@
     </Entry>
     <Entry>
       <ID>147</ID>
-      <DefaultText>Schaden durch kritischen Treffern verringern</DefaultText>
+      <DefaultText>Schaden durch Kritischen Treffer verringern</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1181,7 +1181,7 @@
     </Entry>
     <Entry>
       <ID>235</ID>
-      <DefaultText>Umwandlung Leichter Treffer zu Treffer</DefaultText>
+      <DefaultText>Umwandlung Leichte Treffer zu T&#2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/items.stringtable
+++ b/text/game/items.stringtable
@@ -10077,7 +10077,7 @@ Yngmar wird "IING-mar" gesprochen, mit einem langen Vokallaut zu Beginn.</Defaul
     </Entry>
     <Entry>
       <ID>1752</ID>
-      <DefaultText>Der Zauberwirker ist in der Lage, die Schwächen und Schwachstellen eines Feindes zu erkennen, als ob sie physikalisch greifbar wären, wodurch die Wahrscheinlichkeit eines kritischen Treffers erhöht wird.</DefaultText>
+      <DefaultText>Der Zauberwirker ist in der Lage, die Schwächen und Schwachstellen eines Feindes zu erkennen, als ob sie physikalisch greifbar wären, wodurch die Wahrscheinlichkeit eines Kritischen Treffers erhöht wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/loadingtips.stringtable
+++ b/text/game/loadingtips.stringtable
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>Wenn ein Angriff einen Treffer verursacht, richtet dieser Treffer normalen Schaden an und hat eine normale Dauer. Ein leichter Treffer verringert Schaden und Dauer um 50%. Ein kritischer Treffer erhöht Schaden und Dauer um 50%.</DefaultText>
+      <DefaultText>Wenn ein Angriff einen T&#2060;reffer verursacht, richtet dieser T&#2060;reffer normalen Schaden an und hat eine normale Dauer. Leichte Treffer verringern Schaden und Dauer um 50%. Kritische Treffer erhöhen Schaden und Dauer um 50%.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -216,7 +216,7 @@
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>Durch ihre Schleichangriff-Fähigkeit besitzen Schurken den höchsten Waffenschaden aller Klassen. Trifft ein Schurke einen Feind, der an einem Gebrechen leidet, das einen Schleichangriff ermöglicht, verursacht der Treffer automatisch zusätzlichen Schaden.</DefaultText>
+      <DefaultText>Durch ihre Schleichangriff-Fähigkeit besitzen Schurken den höchsten Waffenschaden aller Klassen. Trifft ein Schurke einen Feind, der an einem Gebrechen leidet, das einen Schleichangriff ermöglicht, verursacht der T&#2060;reffer automatisch zusätzlichen Schaden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -261,7 +261,7 @@
     </Entry>
     <Entry>
       <ID>57</ID>
-      <DefaultText>Das Führen von zwei Nahkampfwaffen gleichzeitig bietet zwar die schnellste Angriffsrate, nicht aber den Pro-Treffer-Schaden von Zweihandwaffen, die Genauigkeit einer einzelnen Einhand-Waffe oder den Abwehrbonus eines Schilds.</DefaultText>
+      <DefaultText>Das Führen von zwei Nahkampfwaffen gleichzeitig bietet zwar die schnellste Angriffsrate, nicht aber den Pro-T&#2060;reffer-Schaden von Zweihandwaffen, die Genauigkeit einer einzelnen Einhand-Waffe oder den Abwehrbonus eines Schilds.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -271,7 +271,7 @@
     </Entry>
     <Entry>
       <ID>59</ID>
-      <DefaultText>Zweihand-Nahkampfwaffen richten den größten Pro-Treffer-Schaden an und können auch hohe Schadensreduktionen durchbrechen.</DefaultText>
+      <DefaultText>Zweihand-Nahkampfwaffen richten den größten Pro-T&#2060;reffer-Schaden an und können auch hohe Schadensreduktionen durchbrechen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -291,7 +291,7 @@
     </Entry>
     <Entry>
       <ID>63</ID>
-      <DefaultText>Das Glossar enthält Definitionen und Erklärungen zu vielen Begriffen der Spielmechanik. Wenn du noch einmal genau wissen willst, wie kritische Treffer berechnet werden oder wie die Schadensreduktion funktioniert, öffne das Tagebuch und sieh nach!</DefaultText>
+      <DefaultText>Das Glossar enthält Definitionen und Erklärungen zu vielen Begriffen der Spielmechanik. Wenn du noch einmal genau wissen willst, wie Kritische Treffer berechnet werden oder wie die Schadensreduktion funktioniert, öffne das Tagebuch und sieh nach!</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/tutorial.stringtable
+++ b/text/game/tutorial.stringtable
@@ -61,7 +61,7 @@
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Alle Charaktere im Spiel - Freund wie Feind - haben vier primäre Verteidigungen gegen Angriffe: Abwehr, Tapferkeit, Reflexe und Wille. Diese Verteidigungen basieren auf den Attributen des Charakters, seiner Stufe, seinen Gegenständen und anderen Effekten. Erfolgt ein Angriff, wird die Genauigkeit mit den jeweiligen Verteidigungen verglichen. Wenn die Genauigkeit unter der entsprechenden Verteidigung liegt, wird der Angriff mit einem Malus belegt und verfehlt mit höherer Wahrscheinlichkeit sein Ziel. Liegt die Genauigkeit über der entsprechenden Verteidigung, führt der Angriff mit einer höheren Wahrscheinlichkeit zu einem kritischen Treffer.</DefaultText>
+      <DefaultText>Alle Charaktere im Spiel - Freund wie Feind - haben vier primäre Verteidigungen gegen Angriffe: Abwehr, Tapferkeit, Reflexe und Wille. Diese Verteidigungen basieren auf den Attributen des Charakters, seiner Stufe, seinen Gegenständen und anderen Effekten. Erfolgt ein Angriff, wird die Genauigkeit mit den jeweiligen Verteidigungen verglichen. Wenn die Genauigkeit unter der entsprechenden Verteidigung liegt, wird der Angriff mit einem Malus belegt und verfehlt mit höherer Wahrscheinlichkeit sein Ziel. Liegt die Genauigkeit über der entsprechenden Verteidigung, führt der Angriff mit einer höheren Wahrscheinlichkeit zu einem Kritischen Treffer.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -71,17 +71,17 @@
     </Entry>
     <Entry>
       <ID>13</ID>
-      <DefaultText>Manchmal sind eine Waffe oder ein Zauber einfach nicht geeignet, um die Schadensreduktion eines Feindes zu durchdringen. Wenn der Angriff ein Treffer ist, hebt die SR den gesamten theoretisch erlittenen Schaden bis auf einen kleinen Prozentsatz auf. Du hörst, wie deine Charaktere sich beschweren, wenn das passiert. Halte die Ohren offen, achte darauf, welche Schadensart abgeblockt wurde, und versuche es mit einer anderen Waffe oder einem anderen Zauber noch einmal.</DefaultText>
+      <DefaultText>Manchmal sind eine Waffe oder ein Zauber einfach nicht geeignet, um die Schadensreduktion eines Feindes zu durchdringen. Wenn der Angriff ein T&#2060;reffer ist, hebt die SR den gesamten theoretisch erlittenen Schaden bis auf einen kleinen Prozentsatz auf. Du hörst, wie deine Charaktere sich beschweren, wenn das passiert. Halte die Ohren offen, achte darauf, welche Schadensart abgeblockt wurde, und versuche es mit einer anderen Waffe oder einem anderen Zauber noch einmal.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>14</ID>
-      <DefaultText>Du hast einen kritischen Treffer gelandet! Ein kritischer Treffer ist ein besseres Ergebnis als ein Treffer. Die Wahrscheinlichkeit, dass du einen kritischen Treffer landest, ist höher, wenn die Genauigkeit des Angriffs über der Verteidigung des Ziels liegt. Angriffe, die Schaden anrichten, richten höheren Schaden an, wenn sie als kritischer Treffer landen. Angriffe, die Statuseffekte oder Wirkungen auslösen, haben eine längere Dauer, wenn sie als kritischer Treffer landen. Leichte Treffer sind schwächer als Treffer - ihr Schaden ist niedriger, Effekte und Wirkungen halten weniger lang an.</DefaultText>
+      <DefaultText>Du hast einen Kritischen Treffer gelandet! Ein Kritischer Treffer ist ein besseres Ergebnis als ein T&#2060;reffer. Die Wahrscheinlichkeit, dass du einen Kritischen Treffer landest, ist höher, wenn die Genauigkeit des Angriffs über der Verteidigung des Ziels liegt. Angriffe, die Schaden anrichten, richten höheren Schaden an, wenn sie als Kritischer Treffer landen. Angriffe, die Statuseffekte oder Wirkungen auslösen, haben eine längere Dauer, wenn sie als Kritischer Treffer landen. Leichte Treffer sind schwächer als T&#2060;reffer - ihr Schaden ist niedriger, Effekte und Wirkungen halten weniger lang an.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>15</ID>
-      <DefaultText>Du greifst gerade einen Feind mit mindestens einer Verteidigung (Abwehr, Tapferkeit, Reflexe, Wille) an, die deutlich über der Genauigkeit des angreifenden Charakters liegt. Wenn die Verteidigung deutlich über der Genauigkeit liegt, kann es sehr schwer sein, einen Treffer zu landen - und unmöglich, einen kritischen Treffer zu landen. Versuche, die Genauigkeit des Angreifers zu erhöhen, oder verwende Zauber oder Fähigkeiten, die eine andere Verteidigung angreifen.</DefaultText>
+      <DefaultText>Du greifst gerade einen Feind mit mindestens einer Verteidigung (Abwehr, Tapferkeit, Reflexe, Wille) an, die deutlich über der Genauigkeit des angreifenden Charakters liegt. Wenn die Verteidigung deutlich über der Genauigkeit liegt, kann es sehr schwer sein, einen T&#2060;reffer zu landen - und unmöglich, einen Kritischen Treffer zu landen. Versuche, die Genauigkeit des Angreifers zu erhöhen, oder verwende Zauber oder Fähigkeiten, die eine andere Verteidigung angreifen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
1. Korrekte Verlinkung für **Kritische(n) Treffer**, **Leichte(n) Treffer**, **Treffer** und **Fehlschläge**
2. vereinheitlichte Großschreibung (groß, weil das imo mehr Fokus auf das Leicht/Kritisch legt)
### Erklärung:

Es gibt jeweils zwei IDs für die Treffer-Arten, die nicht nur als sichtbarer Text, sondern auch als Verlinkung zur Enzyklopädie genutzt werden:
- eine Gruppe steht in der cyclopedia.stringtable: ID 139, 141, 143 und 155. Im Spiel sichtbar als Enzyklopädie-Titel (_Fehlschlag_, _Leichter Treffer_, _Treffer_, _Kritischer Treffer_
- die andere Gruppe in der gui.stringtable: ID 811, 812, 813 und 814. Im Spiel bisher im Kampf-Log sichtbar (_verfehlt_, _streift_, _trifft_, _landet kritischen Treffer bei_)

Probleme bisher waren:
- die gewöhnliche Treffer-Verlinkung (ID143) überschreibt gefundene Übereinstimmungen mit 139 und 141
  - einzige Lösung (bisher): `T&#2060;reffer` - Bereits mit @benniii1337 im Forum angesprochen... Das sieht nicht hübsch aus, aber tut, was es soll: Die Treffer-Verlinkung erfolgt nur noch, wenn auch `T&#2060;reffer` im Text steht
- Deklination - Kritische Treffer, Kritischer Treffer, Kritischen Treffer. Die meisten Fälle können durch "Kritische Treffer" und "Kritischen Treffer" abgedeckt werden<sup>1</sup>, aber dazu brauchte ich zwei verschiedene Schlüsselwörter, aaaalso:
  - ID 812 `streift` => `Leichten Treffer`
  - ID 813 `trifft` => `T&#2060;reffer`
  - ID 814 `landet kritischen Treffer bei` => `Kritischen Treffer`
  - ID 52/53 `{0} {1} {2} für {3} {4}schaden{5}.` => `{0} landet {1} bei {2} für {3} {4}schaden{5}.` (lol)

Ergebnis:
- das Kampflog zeigt nun _Durlachion landet Leichten Treffer bei Bösewicht für 123 Brandschaden_ statt _Durlachion streift Bösewicht für 123 Brandschaden_. Das ist hoffentlich noch verkraftbar. Insbesondere da sich bei Kritischen Treffern überhaupt nichts am Text ändert ;)

![grazes](https://cloud.githubusercontent.com/assets/8644150/7106418/fc67c484-e13f-11e4-9c21-ac663a254f33.jpg)

<sup>1</sup> Die anderen Texte mit 'Kritische**r** Treffer' konnten abgeändert werden in 'kritische' oder 'kritische**n**' :)
