### PR TITLE
convert Elfin to Elfe

### DIFF
--- a/text/conversations/01_defiance_bay_copperlane/01_cv_orimanth.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_orimanth.stringtable
@@ -75,7 +75,7 @@
     </Entry>
     <Entry>
       <ID>18</ID>
-      <DefaultText>Die Elfin grinst verächtlich. "Wenn wir erwischt werden - was nicht sehr oft passiert - sorgen wir dafür, dass die Glanfathaner nicht sehr lange wütend bleiben. Augenzeugen wären zu lästig."</DefaultText>
+      <DefaultText>Die Elfe grinst verächtlich. "Wenn wir erwischt werden - was nicht sehr oft passiert - sorgen wir dafür, dass die Glanfathaner nicht sehr lange wütend bleiben. Augenzeugen wären zu lästig."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_niah.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_niah.stringtable
@@ -223,7 +223,7 @@ Sie seufzt. "Also gut. Als ich gesehen habe, wie zwei Aumaua-Matrosen den Pier e
     </Entry>
     <Entry>
       <ID>87</ID>
-      <DefaultText>Niah deutet auf ein Schiff, das in der Ferne vor Anker liegt. "Das ist sie. Wenn sie im Hafen liegt, macht der Kapitän, eine Elfin namens Maerwith Landurlaub im Verkohlten Fass in Farnheim. Kaum zu glauben, aber sie sorgt gerne ordentlich für ihr leibliches Wohl."
+      <DefaultText>Niah deutet auf ein Schiff, das in der Ferne vor Anker liegt. "Das ist sie. Wenn sie im Hafen liegt, macht der Kapitän, eine Elfe namens Maerwith Landurlaub im Verkohlten Fass in Farnheim. Kaum zu glauben, aber sie sorgt gerne ordentlich für ihr leibliches Wohl."
 
 Sie schüttelt den Kopf. "Genau das meine ich. Wenn nicht einmal eine Piratin einen Fuß in die Taverne in diesem Bezirk setzt, ist es höchste Zeit für ein neues Gasthaus."</DefaultText>
       <FemaleText />

--- a/text/conversations/08_wilderness/08_cv_downwind_fang_leader.stringtable
+++ b/text/conversations/08_wilderness/08_cv_downwind_fang_leader.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Eine Elfin steht neben einem Hirschen und streichelt den Nacken des großen Tieres. Als du dich näherst, hebt der Hirsch den Kopf in deine Richtung und stellt sich auf die Hinterbeine.
+      <DefaultText>Eine Elfe steht neben einem Hirschen und streichelt den Nacken des großen Tieres. Als du dich näherst, hebt der Hirsch den Kopf in deine Richtung und stellt sich auf die Hinterbeine.
 
 "Ruhig!", befiehlt die Frau und zieht an der Haut am Nacken des Hirschen, bis er sich beruhigt. "Ganz ruhig ... kein Grund für einen Kampf ... noch nicht."</DefaultText>
       <FemaleText />
@@ -45,8 +45,8 @@ Sie deutet nach Norden, auf die Ruinen engwithanischer Gebäude, die aus dem Unt
     </Entry>
     <Entry>
       <ID>8</ID>
-      <DefaultText>Die Elfin steckt ihr Schwert weg und streckt die Hand zu ihrem Hirschen aus. Das Tier neigt den Kopf, um der Liebkosung ihrer Hand zu begegnen. "Sanft. Stark. Wir warten hier, um dich als Krieger und Freund wieder willkommen zu heißen." </DefaultText>
-      <FemaleText>Die Elfin steckt ihr Schwert weg und streckt die Hand zu ihrem Hirschen aus. Das Tier neigt den Kopf, um der Liebkosung ihrer Hand zu begegnen. "Sanft. Stark. Wir warten hier, um dich als Kriegerin und Freundin wieder willkommen zu heißen." </FemaleText>
+      <DefaultText>Die Elfe steckt ihr Schwert weg und streckt die Hand zu ihrem Hirschen aus. Das Tier neigt den Kopf, um der Liebkosung ihrer Hand zu begegnen. "Sanft. Stark. Wir warten hier, um dich als Krieger und Freund wieder willkommen zu heißen." </DefaultText>
+      <FemaleText>Die Elfe steckt ihr Schwert weg und streckt die Hand zu ihrem Hirschen aus. Das Tier neigt den Kopf, um der Liebkosung ihrer Hand zu begegnen. "Sanft. Stark. Wir warten hier, um dich als Kriegerin und Freundin wieder willkommen zu heißen." </FemaleText>
     </Entry>
     <Entry>
       <ID>9</ID>

--- a/text/conversations/11_hearthsong/11_cv_alarhi.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_alarhi.stringtable
@@ -6,8 +6,8 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Eine alte Elfin in dicken Roben winkt dich heran. "Willkommen, Fremder. Willkommen!" Ihre Unterarme, voller grüner und blauer Flecken, zappeln aus ihren hängenden Ärmeln heraus wie Raupen aus reifem Obst.</DefaultText>
-      <FemaleText>Eine alte Elfin in dicken Roben winkt dich heran. "Willkommen, Fremde. Willkommen!" Ihre Unterarme, voller grüner und blauer Flecken, zappeln aus ihren hängenden Ärmeln heraus wie Raupen aus reifem Obst.</FemaleText>
+      <DefaultText>Eine alte Elfe in dicken Roben winkt dich heran. "Willkommen, Fremder. Willkommen!" Ihre Unterarme, voller grüner und blauer Flecken, zappeln aus ihren hängenden Ärmeln heraus wie Raupen aus reifem Obst.</DefaultText>
+      <FemaleText>Eine alte Elfe in dicken Roben winkt dich heran. "Willkommen, Fremde. Willkommen!" Ihre Unterarme, voller grüner und blauer Flecken, zappeln aus ihren hängenden Ärmeln heraus wie Raupen aus reifem Obst.</FemaleText>
     </Entry>
     <Entry>
       <ID>2</ID>
@@ -102,7 +102,7 @@ Alarhî hebt ihre mit Farbflecken gesprenkelten Hände, als eine ihrer Wachen na
     </Entry>
     <Entry>
       <ID>47</ID>
-      <DefaultText>Eine alte Elfin steht aufrecht und stolz, umgeben von glanfathanischen Kriegern, die jede deiner Bewegungen genau beobachten. "Du sprichst in Rinattos Namen, nehme ich an? Ich wusste, er würde jemanden überzeugen, für ihn aufzutreten ... Ich nahm nur nicht an, dass es der Estramor sein würde, der in das ganze Chaos in Trutzbucht verwickelt ist."</DefaultText>
+      <DefaultText>Eine alte Elfe steht aufrecht und stolz, umgeben von glanfathanischen Kriegern, die jede deiner Bewegungen genau beobachten. "Du sprichst in Rinattos Namen, nehme ich an? Ich wusste, er würde jemanden überzeugen, für ihn aufzutreten ... Ich nahm nur nicht an, dass es der Estramor sein würde, der in das ganze Chaos in Trutzbucht verwickelt ist."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/11_hearthsong/11_cv_arthwn.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_arthwn.stringtable
@@ -6,12 +6,12 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Ein schlaksiger Jäger pflegt sich den Bart, einen lückenhaften blonden Flaum, während er aufmerksam einer jungen Elfin lauscht. Sie flüstert ihm etwas in die geröteten Ohren und kichert. Den Kopf noch immer gesenkt antwortet er mit einem breiten Grinsen.</DefaultText>
+      <DefaultText>Ein schlaksiger Jäger pflegt sich den Bart, einen lückenhaften blonden Flaum, während er aufmerksam einer jungen Elfe lauscht. Sie flüstert ihm etwas in die geröteten Ohren und kichert. Den Kopf noch immer gesenkt antwortet er mit einem breiten Grinsen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Mein Stamm hat mir gesagt, dass du die Wahrheit über Fîorms Exil sagen sollst." Er kämmt sich seine spärlichen Stoppeln und wirft der Elfin einen Blick zu. "Nun, Arthwn versteckt sich nicht vor der Wahrheit. Frage, und ich werde antworten."</DefaultText>
+      <DefaultText>"Mein Stamm hat mir gesagt, dass du die Wahrheit über Fîorms Exil sagen sollst." Er kämmt sich seine spärlichen Stoppeln und wirft der Elfe einen Blick zu. "Nun, Arthwn versteckt sich nicht vor der Wahrheit. Frage, und ich werde antworten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -91,7 +91,7 @@
     </Entry>
     <Entry>
       <ID>19</ID>
-      <DefaultText>Die junge Elfin blickt zu dem Jäger hinauf und packt ihn an der Schulter. "Arthwn, mit dir machen wir uns einen Namen. Das weiß ich gewiss!"</DefaultText>
+      <DefaultText>Die junge Elfe blickt zu dem Jäger hinauf und packt ihn an der Schulter. "Arthwn, mit dir machen wir uns einen Namen. Das weiß ich gewiss!"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -116,7 +116,7 @@
     </Entry>
     <Entry>
       <ID>24</ID>
-      <DefaultText>Die Elfin tritt einen Schritt zurück und blickt Arthwn mit offenem Mund ungläubig an. "Das kann doch nicht ... " Sie blickt rasch zu dir, dann wieder zurück zu dem Jäger. "Ist dir klar, was die Stämme über uns denken werden, über unser Volk?!"</DefaultText>
+      <DefaultText>Die Elfe tritt einen Schritt zurück und blickt Arthwn mit offenem Mund ungläubig an. "Das kann doch nicht ... " Sie blickt rasch zu dir, dann wieder zurück zu dem Jäger. "Ist dir klar, was die Stämme über uns denken werden, über unser Volk?!"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -151,7 +151,7 @@
     </Entry>
     <Entry>
       <ID>31</ID>
-      <DefaultText>Arthwn beißt sich auf die Lippe. Auf seinem goldenen Flaum glänzt etwas Speichel. Er wischt ihn mit dem Handrücken weg und blickt dich hilfeflehend an. "Für das Wohl meines Volkes, sprich für uns mit den Anamenfath. Sprich die ..." Seine Augen huschen zur Seite, als würde er auf die Elfin hinter sich deuten wollen. "Für uns ... sprich deine Wahrheit."</DefaultText>
+      <DefaultText>Arthwn beißt sich auf die Lippe. Auf seinem goldenen Flaum glänzt etwas Speichel. Er wischt ihn mit dem Handrücken weg und blickt dich hilfeflehend an. "Für das Wohl meines Volkes, sprich für uns mit den Anamenfath. Sprich die ..." Seine Augen huschen zur Seite, als würde er auf die Elfe hinter sich deuten wollen. "Für uns ... sprich deine Wahrheit."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/11_hearthsong/11_cv_glanfathan_locals_gate.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_glanfathan_locals_gate.stringtable
@@ -76,7 +76,7 @@
     </Entry>
     <Entry>
       <ID>15</ID>
-      <DefaultText>Eine Elfin hebt ihre Augen von ihrem pelzigen Begleiter und nickt in deine Richtung. "Noch ein Fremder. Sah er so aus?" Der Orlaner dreht sich um.</DefaultText>
+      <DefaultText>Eine Elfe hebt ihre Augen von ihrem pelzigen Begleiter und nickt in deine Richtung. "Noch ein Fremder. Sah er so aus?" Der Orlaner dreht sich um.</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/11_hearthsong/11_cv_pensi.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_pensi.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Die junge Elfin blinzelt überrascht, als du sie mit deiner Anwesenheit aus ihren Gedanken reißt. "Kann ich dir helfen?"</DefaultText>
+      <DefaultText>Die junge Elfe blinzelt überrascht, als du sie mit deiner Anwesenheit aus ihren Gedanken reißt. "Kann ich dir helfen?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/12_oldsong/12_cv_irensi.stringtable
+++ b/text/conversations/12_oldsong/12_cv_irensi.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Eine Elfin fängt dich ab, als du weitergehst. Hinter ihr liegt die größte Löwin, die du je gesehen hast, eine Bestie mit Zähnen so lang wie Tranchiermesser.
+      <DefaultText>Eine Elfe fängt dich ab, als du weitergehst. Hinter ihr liegt die größte Löwin, die du je gesehen hast, eine Bestie mit Zähnen so lang wie Tranchiermesser.
 
 Die Frau versperrt dir den Weg zu der Löwin. Sie scheint keinerlei Angst vor dem Monster zu haben. "Das ist Suls Reich, Estramor. Sie wird es nicht verlassen, weder für Oernos noch für einen anderen Herausforderer."</DefaultText>
       <FemaleText />

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_berath.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_berath.stringtable
@@ -72,7 +72,7 @@ Die Skulpturen drehen die Köpfe zu dir. Ihre Finger krümmen sich langsam, sie 
       <ID>25</ID>
       <DefaultText>Die Straße führt durch den Mund in eine weitere sich stetig wandelnde Landschaft unter einem Sternenhimmel. Als du durch den Mund trittst, siehst du in der Ferne eine identische Tür. Ein Zwerg steht reglos davor.
 
-Du drehst dich um und blickst hinter dich, wo du das Schädeltor vor dir siehst, das du eben passiert hast. Eine Elfin wartet auf der Straße. Genau wie der Zwerg steht sie reglos da.</DefaultText>
+Du drehst dich um und blickst hinter dich, wo du das Schädeltor vor dir siehst, das du eben passiert hast. Eine Elfe wartet auf der Straße. Genau wie der Zwerg steht sie reglos da.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -87,7 +87,7 @@ Du drehst dich um und blickst hinter dich, wo du das Schädeltor vor dir siehst,
     </Entry>
     <Entry>
       <ID>30</ID>
-      <DefaultText>[Die Elfin ansprechen.]</DefaultText>
+      <DefaultText>[Die Elfe ansprechen.]</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -181,7 +181,7 @@ Erst jetzt, da er tot ist, kannst du weitergehen.</DefaultText>
     </Entry>
     <Entry>
       <ID>46</ID>
-      <DefaultText>Das Blut sammelt sich um deine Füße herum. Du blickst auf und siehst die Elfin ein Stück weiter die Straße hinab auf dich warten.</DefaultText>
+      <DefaultText>Das Blut sammelt sich um deine Füße herum. Du blickst auf und siehst die Elfe ein Stück weiter die Straße hinab auf dich warten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -254,7 +254,7 @@ Du reißt dich von ihrem brüchigen Griff los.</DefaultText>
     </Entry>
     <Entry>
       <ID>57</ID>
-      <DefaultText>Ihre Füße stehen wie angewurzelt da, aber sie windet sich und zuckt, als würde sie versuchen, vor ihren eigenen sterbenden Gliedern zu fliehen. Die Versteinerung erreicht ihre Schulter und breitet sich schmerzvoll nach unten über ihren Körper aus. Sie kriecht ihren Nacken hinauf und die Elfin wirft ihr Gesicht nach oben gen Himmel wie ein Ertrinkender. 
+      <DefaultText>Ihre Füße stehen wie angewurzelt da, aber sie windet sich und zuckt, als würde sie versuchen, vor ihren eigenen sterbenden Gliedern zu fliehen. Die Versteinerung erreicht ihre Schulter und breitet sich schmerzvoll nach unten über ihren Körper aus. Sie kriecht ihren Nacken hinauf und die Elfe wirft ihr Gesicht nach oben gen Himmel wie ein Ertrinkender. 
 
 Das Grau bedeckt ihr Gesicht und friert ihren letzten entsetzten Atemzug in Stein ein.
 
@@ -325,7 +325,7 @@ Die leere Hülle seines Leichnams fällt auf die Straße.</DefaultText>
     </Entry>
     <Entry>
       <ID>68</ID>
-      <DefaultText>Das Blut sammelt sich um deine Füße herum. Du blickst auf und siehst die Elfin ein Stück weiter die Straße hinab auf dich warten.</DefaultText>
+      <DefaultText>Das Blut sammelt sich um deine Füße herum. Du blickst auf und siehst die Elfe ein Stück weiter die Straße hinab auf dich warten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -335,7 +335,7 @@ Die leere Hülle seines Leichnams fällt auf die Straße.</DefaultText>
     </Entry>
     <Entry>
       <ID>70</ID>
-      <DefaultText>Die siehst die zwei Gestalten, den Zwerg und die Elfin, noch immer auf beiden Seiten der Straße auf dich warten. Keiner von beiden hat sich dem jeweiligen Schädeltor hinter sich genähert.</DefaultText>
+      <DefaultText>Die siehst die zwei Gestalten, den Zwerg und die Elfe, noch immer auf beiden Seiten der Straße auf dich warten. Keiner von beiden hat sich dem jeweiligen Schädeltor hinter sich genähert.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -347,7 +347,7 @@ Du erkennst, dass du die Vision verlassen hast und nach Teir Evron zurückgekehr
     </Entry>
     <Entry>
       <ID>72</ID>
-      <DefaultText>Du drehst dich wieder zu der Straße vor dir um - und siehst dort die Elfin warten. Als du in ihre Richtung gehst, wird die Erde unter deinen Füßen hart und verwandelt sich in Steinplatten. Das fahle Sternenlicht schimmert und wird zu Kerzenflammen. 
+      <DefaultText>Du drehst dich wieder zu der Straße vor dir um - und siehst dort die Elfe warten. Als du in ihre Richtung gehst, wird die Erde unter deinen Füßen hart und verwandelt sich in Steinplatten. Das fahle Sternenlicht schimmert und wird zu Kerzenflammen. 
 
 Du erkennst, dass du die Vision verlassen hast und nach Teir Evron zurückgekehrt bist.</DefaultText>
       <FemaleText />

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_bledha.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_bledha.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Die Elfin hält eine alte, abgewetzte Holzpfeife in der Hand. Der süßliche Rauch, der aus der Rauchkammer steigt, macht dich schwindlig.
+      <DefaultText>Die Elfe hält eine alte, abgewetzte Holzpfeife in der Hand. Der süßliche Rauch, der aus der Rauchkammer steigt, macht dich schwindlig.
 
 "Willkommen, Estramor. Ich verkaufe Kräuter und Tränke. Suchst du etwas, um deine Reisen weniger beschwerlich zu machen? Oder etwas, um sie interessanter zu gestalten?" Als sie grinst, siehst du, dass ihre Zähne und ihr Zahnfleisch braun gefärbt sind.</DefaultText>
       <FemaleText />

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_high_ovate_erona.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_high_ovate_erona.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Eine Elfin steht auf einem Podest in der Mitte einer Lichtung. Der Boden ist mit Blättern in verschiedenen Rotbraun- und Goldtönen bedeckt. Ihre Augen sind geschlossen, ihre Arme vor ihr verschränkt. Ein Vorhang aus herbstgelben Haaren hängt vor ihrem Gesicht. Als du dich näherst, hebt sie das Kinn und blickt dich mit wachen braunen Augen an.</DefaultText>
+      <DefaultText>Eine Elfe steht auf einem Podest in der Mitte einer Lichtung. Der Boden ist mit Blättern in verschiedenen Rotbraun- und Goldtönen bedeckt. Ihre Augen sind geschlossen, ihre Arme vor ihr verschränkt. Ein Vorhang aus herbstgelben Haaren hängt vor ihrem Gesicht. Als du dich näherst, hebt sie das Kinn und blickt dich mit wachen braunen Augen an.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -55,7 +55,7 @@ Ihre Augen pulsieren mit einem tiefen, sommerhaften Grün. "Ihre Wurzeln nähren
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>Die Elfin hebt die Arme über den Kopf. "Spüre das Leben in jedem Windstoß, in jedem Tautropfen. Flüsse fließen durch deine Adern. Dein Gewebe ist Lehm, fruchtbar und voller Energie."</DefaultText>
+      <DefaultText>Die Elfe hebt die Arme über den Kopf. "Spüre das Leben in jedem Windstoß, in jedem Tautropfen. Flüsse fließen durch deine Adern. Dein Gewebe ist Lehm, fruchtbar und voller Energie."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_iswld.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_iswld.stringtable
@@ -61,7 +61,7 @@ Als du endlich wieder zu Sinnen kommst, stehst du in einem dir unbekannten Wald.
       <ID>13</ID>
       <DefaultText>"Wir sind die Ovaten - Druiden, Philosophen und Schüler der Natur. Wir versammeln uns hier zum Feiern und um unser Wissen miteinander zu teilen."
 
-Sie gestikuliert auf eine andere Elfin, die am Eingang des Hains steht. "Viele Reisende kommen für Breiumschläge und Arzneien zu uns. Niemand versteht die Heilmittel und Gifte der Natur wie Bledha."</DefaultText>
+Sie gestikuliert in Richtung einer anderen Elfe, die am Eingang des Hains steht. "Viele Reisende kommen für Breiumschläge und Arzneien zu uns. Niemand versteht die Heilmittel und Gifte der Natur wie Bledha."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -90,8 +90,8 @@ Sie blickt auf die Gestandenen, die sich im Hain versammelt haben. "Die meisten 
     </Entry>
     <Entry>
       <ID>20</ID>
-      <DefaultText>Eine Elfin mit gelassenen grünen Augen nickt zum Gruß. "Willkommen im Goldenen Hain, Reisender."</DefaultText>
-      <FemaleText>Eine Elfin mit gelassenen grünen Augen nickt zum Gruß. "Willkommen im Goldenen Hain, Reisende."</FemaleText>
+      <DefaultText>Eine Elfe mit gelassenen grünen Augen nickt zum Gruß. "Willkommen im Goldenen Hain, Reisender."</DefaultText>
+      <FemaleText>Eine Elfe mit gelassenen grünen Augen nickt zum Gruß. "Willkommen im Goldenen Hain, Reisende."</FemaleText>
     </Entry>
     <Entry>
       <ID>21</ID>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_rymrgand_coalition.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_rymrgand_coalition.stringtable
@@ -96,10 +96,10 @@ Der Schnee reicht dir nun bis zu den Knien. Deine Beine fühlen sich in den Schn
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>Du packst die nächste Elfin bei den Schultern, schüttelst sie und schreist, um den heulenden Wind zu übertönen. Du zeigst in Richtung des dröhnenden Lärms, aber sie blickt dich nur zornig an. 
+      <DefaultText>Du packst die nächste Elfe bei den Schultern, schüttelst sie und schreist, um den heulenden Wind zu übertönen. Du zeigst in Richtung des dröhnenden Lärms, aber sie blickt dich nur zornig an. 
 
 "Lass uns in Frieden, Reisender. Wir müssen hindurch. Wir können nicht länger auf dieser Seite bleiben."</DefaultText>
-      <FemaleText>Du packst die nächste Elfin bei den Schultern, schüttelst sie und schreist, um den heulenden Wind zu übertönen. Du zeigst in Richtung des dröhnenden Lärms, aber sie blickt dich nur zornig an. 
+      <FemaleText>Du packst die nächste Elfe bei den Schultern, schüttelst sie und schreist, um den heulenden Wind zu übertönen. Du zeigst in Richtung des dröhnenden Lärms, aber sie blickt dich nur zornig an. 
 
 "Lass uns in Frieden, Reisende. Wir müssen hindurch. Wir können nicht länger auf dieser Seite bleiben."</FemaleText>
     </Entry>
@@ -120,7 +120,7 @@ Der Schnee reicht dir nun bis zu den Knien. Deine Beine fühlen sich in den Schn
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>Du schlägst nach dem nächsten Elf, der zu einem Schneehaufen zerfällt. Du greifst eine weitere Elfin an, die ebenso leicht fällt. Während du die Elfen um dich herum niederstreckst, hauen ihre Kameraden unbeirrt weiter auf das Eis ein, immer schneller. Doch ihre Bemühungen scheinen weiter vergebens zu sein.
+      <DefaultText>Du schlägst nach dem nächsten Elf, der zu einem Schneehaufen zerfällt. Du greifst eine weitere Elfe an, die ebenso leicht fällt. Während du die Elfen um dich herum niederstreckst, hauen ihre Kameraden unbeirrt weiter auf das Eis ein, immer schneller. Doch ihre Bemühungen scheinen weiter vergebens zu sein.
 
 Als die letzten Elfen fallen, verstummt das Gebrüll endlich und der Wind lässt nach.</DefaultText>
       <FemaleText />
@@ -160,7 +160,7 @@ Du berührst den Elf neben dir und er zerfällt zu einem Schneehaufen.</DefaultT
     </Entry>
     <Entry>
       <ID>39</ID>
-      <DefaultText>Die Elfin lauscht angestrengt. Als sie ihre Picke in dem immer tieferen Schnee absetzt, halten einige ihrer Kameraden in ihrer Arbeit inne.
+      <DefaultText>Die Elfe lauscht angestrengt. Als sie ihre Picke in dem immer tieferen Schnee absetzt, halten einige ihrer Kameraden in ihrer Arbeit inne.
 
 Ein Mann mit einem verkümmerten, abgefrorenen Finger dreht sich um. Er hebt seine verstümmelte Hand und die anderen hören auch mit der Arbeit auf. 
 

--- a/text/quests/03_defiance_bay_ondras_gift/03_tsk_lighthouse.stringtable
+++ b/text/quests/03_defiance_bay_ondras_gift/03_tsk_lighthouse.stringtable
@@ -68,7 +68,7 @@ Das muss die Kreatur sein, die seit über einem Jahrhundert in dem Leuchtturm sp
     </Entry>
     <Entry>
       <ID>20002</ID>
-      <DefaultText>Niah hat mir berichtet, dass die Roter Traum ein Piratenschiff ist, deren Kapitän eine Elfin namens Maerwith ist. Wenn sie in der Stadt anlegt, hält sie sich meistens im Verkohlten Fass in Farnheim auf - so auch jetzt.</DefaultText>
+      <DefaultText>Niah hat mir berichtet, dass die Roter Traum ein Piratenschiff ist, deren Kapitän eine Elfe namens Maerwith ist. Wenn sie in der Stadt anlegt, hält sie sich meistens im Verkohlten Fass in Farnheim auf - so auch jetzt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/11_twin_elms_hearthsong/11_qst_downwind_dyrwood.stringtable
+++ b/text/quests/11_twin_elms_hearthsong/11_qst_downwind_dyrwood.stringtable
@@ -93,7 +93,7 @@ Unzählige glanfathanische Reißzähne haben die Dyrwäldler umzingelt und warte
     </Entry>
     <Entry>
       <ID>20001</ID>
-      <DefaultText>Ich bin einer Elfin begegnet, einer Jägerin der Reißzähne, Anführerin der Glanfathaner, die Cwineths Expedition verfolgen. Sie will, dass ich mich um die Dyrwäldler kümmere - als Beweis, dass ich ein Freund Eir Glanfaths bin, nicht einfach nur ein weiterer Plünderer aus dem Dyrwald.</DefaultText>
+      <DefaultText>Ich bin einer Elfe begegnet, einer Jägerin der Reißzähne, Anführerin der Glanfathaner, die Cwineths Expedition verfolgen. Sie will, dass ich mich um die Dyrwäldler kümmere - als Beweis, dass ich ein Freund Eir Glanfaths bin, nicht einfach nur ein weiterer Plünderer aus dem Dyrwald.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/12_twin_elms_oldsong/12_qst_nest_above_the_clouds.stringtable
+++ b/text/quests/12_twin_elms_oldsong/12_qst_nest_above_the_clouds.stringtable
@@ -65,7 +65,7 @@ Hoffentlich versteht die Göttin meine Sichtweise. Ich kann in Teir Evron zu ihr
     </Entry>
     <Entry>
       <ID>20001</ID>
-      <DefaultText>Die Vision hat mir einen Elfen und eine Elfin gezeigt, die von dem Berggipfel flohen. Als ich sie zuletzt sah, versteckten sie sich in einem Steinkreis, in der Ruine eines älteren Tempels in Zwillingsulmen. Wenn es in der Stadt einen Bezirk mit anderen Tempeln gibt, finde ich sie vielleicht dort. Sie könnten mir den Weg zu Hyleas Tempel zeigen.</DefaultText>
+      <DefaultText>Die Vision hat mir einen Elfen und eine Elfe gezeigt, die von dem Berggipfel flohen. Als ich sie zuletzt sah, versteckten sie sich in einem Steinkreis, in der Ruine eines älteren Tempels in Zwillingsulmen. Wenn es in der Stadt einen Bezirk mit anderen Tempeln gibt, finde ich sie vielleicht dort. Sie könnten mir den Weg zu Hyleas Tempel zeigen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/13_twin_elms_elms_reach/13_qst_servant_of_death.stringtable
+++ b/text/quests/13_twin_elms_elms_reach/13_qst_servant_of_death.stringtable
@@ -21,12 +21,12 @@
     </Entry>
     <Entry>
       <ID>10000</ID>
-      <DefaultText>Berath ist es leid, dass Sterbliche den natürlichen Kreislauf von Tod und Wiedergeburt stören. Er hat mir zwei Personen gezeigt, die ihre Leben seit Jahrhunderten auf unnatürliche Weise verlängern - einen Zwerg und eine Elfin.</DefaultText>
+      <DefaultText>Berath ist es leid, dass Sterbliche den natürlichen Kreislauf von Tod und Wiedergeburt stören. Er hat mir zwei Personen gezeigt, die ihre Leben seit Jahrhunderten auf unnatürliche Weise verlängern - einen Zwerg und eine Elfe.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>10001</ID>
-      <DefaultText>Berath, der Gott des Todes und der Wiedergeburt, hat mir eine Vision einer Elfin und eines Zwergs gezeigt, die auf einer Straße angehalten haben. Durch meine Berührung starben sie - erst dann konnte ich den Weg weitergehen.
+      <DefaultText>Berath, der Gott des Todes und der Wiedergeburt, hat mir eine Vision einer Elfe und eines Zwergs gezeigt, die auf einer Straße angehalten haben. Durch meine Berührung starben sie - erst dann konnte ich den Weg weitergehen.
 
 Ich glaube, der Gott will mir sagen, dass diese zwei Personen dem Tod schon zu lange ein Schnippchen schlagen. Wenn ich ihre Leben beende, ist Berath gewiss erfreut.</DefaultText>
       <FemaleText />
@@ -43,7 +43,7 @@ Ich glaube, der Gott will mir sagen, dass diese zwei Personen dem Tod schon zu l
     </Entry>
     <Entry>
       <ID>20002</ID>
-      <DefaultText>Die Elfin war in der Vision auf seltsame Weise einem Baum ähnlich. Sie erwähnte einen Ort namens "Goldener Hain".</DefaultText>
+      <DefaultText>Die Elfe war in der Vision auf seltsame Weise einem Baum ähnlich. Sie erwähnte einen Ort namens "Goldener Hain".</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -53,12 +53,12 @@ Ich glaube, der Gott will mir sagen, dass diese zwei Personen dem Tod schon zu l
     </Entry>
     <Entry>
       <ID>20004</ID>
-      <DefaultText>Die Elfin, Hoheovatin Erona, ist jetzt tot.</DefaultText>
+      <DefaultText>Die Elfe, Hoheovatin Erona, ist jetzt tot.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>20005</ID>
-      <DefaultText>Die Druiden des Goldenen Hains haben mir berichtet, dass Hoheovatin Erona oft nach Ulmenküste geht, auf der Suche nach Heilmitteln zur Verlängerung ihres Lebens. Ich nehme an, dass Erona die Elfin aus der Vision ist.</DefaultText>
+      <DefaultText>Die Druiden des Goldenen Hains haben mir berichtet, dass Hoheovatin Erona oft nach Ulmenküste geht, auf der Suche nach Heilmitteln zur Verlängerung ihres Lebens. Ich nehme an, dass Erona die Elfe aus der Vision ist.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/critical_path/act_4/cp_qst_earn_gods_favor.stringtable
+++ b/text/quests/critical_path/act_4/cp_qst_earn_gods_favor.stringtable
@@ -52,7 +52,7 @@ Allerdings scheinen die Götter bereit zu sein, große Macht anzubieten, im Aust
     </Entry>
     <Entry>
       <ID>20000</ID>
-      <DefaultText>Berath sandte mir eine Vision eines Zwerges und einer Elfin auf einer unheimlichen Straße. Beide starben, als ich sie berührte.</DefaultText>
+      <DefaultText>Berath sandte mir eine Vision eines Zwerges und einer Elfe auf einer unheimlichen Straße. Beide starben, als ich sie berührte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Im Spiel wird an einigen Stellen "Elfe", an anderen das doch massiv komisch aussehende "Elfin" verwendet. Konvertiere die Stellen auf "Elfe".
