### PR TITLE
unified spelling of names and regions

### DIFF
--- a/text/conversations/00_dyrwood/00_cv_beodmar.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_beodmar.stringtable
@@ -60,7 +60,7 @@ Er hält sich eine Hand aufs Herz. "Wo auch immer sie sein mag, in diesem Leben 
     </Entry>
     <Entry>
       <ID>89</ID>
-      <DefaultText>Der alte Priester zupft an seinem Bart und runzelt die Stirn. "Der Glanfathan-Stamm, der die Ruinen bewacht, tötet alle Eindringlinge augenblicklich, und die Geschichte hat bereits einmal gezeigt, dass sie dann auch an uns Vergeltung üben."
+      <DefaultText>Der alte Priester zupft an seinem Bart und runzelt die Stirn. "Der glanfathanische Stamm, der die Ruinen bewacht, tötet alle Eindringlinge augenblicklich, und die Geschichte hat bereits einmal gezeigt, dass sie dann auch an uns Vergeltung üben."
 
 "In letzter Zeit haben hier einfach zu viele Glücksritter für Probleme gesorgt. Wenn ich es dir sagen soll, dann muss ich den Grund wissen, warum du dorthin willst."</DefaultText>
       <FemaleText />
@@ -201,7 +201,7 @@ Er zieht eine verblichene Karte hervor und deutet auf einen Ort im Wald. "Hier w
       <ID>142</ID>
       <DefaultText>Er verschränkt seine Arme und schaut dich mit einem Auge mürrisch an. "Und jetzt kommt der Punkt, an dem ich sage 'Wenn du zu den Ruinen gehst, werde ich dich töten' und du antwortest 'Hiravias, ich bin ein Wächter und du könntest es niemals mit allen von uns auf einmal aufnehmen und außerdem haben wir einen guten Grund für all das'. Und dann geb ich es auf, mit dir zu streiten und lass dich losziehen, um dir dein eigenes Eindringlingsgrab zu schaufeln."
 
-"Und damit bin ich gar nicht mal so metaphorisch: Manchmal lassen wir Dyrwäldler nämlich ihr eigenes Grab ausheben, bevor wir sie töten - eine fabelhafte Abschreckung für Kinder, die davon hören."</DefaultText>
+"Und damit bin ich gar nicht mal so metaphorisch: Manchmal lassen wir Dyrwälder nämlich ihr eigenes Grab ausheben, bevor wir sie töten - eine fabelhafte Abschreckung für Kinder, die davon hören."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -223,7 +223,7 @@ Er zieht eine verblichene Karte hervor und deutet auf einen Ort im Wald. "Hier w
       <ID>146</ID>
       <DefaultText>"Berath ist der Universellste aller Götter. Er überwacht Portale und Zyklen aller Art, auch das Leben und den Tod selbst. Unter Berath ist ein Ende lediglich ein Übergang zu einem neuen Beginn." 
 
-"Berath hat zeit- und kulturenübergreifend viele Repräsentationen. Im Dyrwald siehst du ihn üblicherweise als die Bleiche Ritterin oder den Totengräber. Die Glanfathans kennen ihn aber als Bewnen i Ankew und Ankew i Bewnen."</DefaultText>
+"Berath hat zeit- und kulturenübergreifend viele Repräsentationen. Im Dyrwald siehst du ihn üblicherweise als die Bleiche Ritterin oder den Totengräber. Die Glanfathaner kennen ihn aber als Bewnen i Ankew und Ankew i Bewnen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/00_dyrwood/00_cv_korgrak.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_korgrak.stringtable
@@ -244,7 +244,7 @@ Hiravias zuckt mit den Achseln und lächelt Korgrak an. "Den Druiden wird es woh
       <ID>64</ID>
       <DefaultText>"Ich habe einmal von einem Reisenden gehört, dass in Zwillingsulmen Oger friedlich neben Gestandenen leben sollen."
 
-"Wahrscheinlich haben sie lieber diesen Oger in der Stadt als noch einen Dyrwäldler."</DefaultText>
+"Wahrscheinlich haben sie lieber diesen Oger in der Stadt als noch einen Dyrwälder."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/00_dyrwood/00_cv_lord_harond.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_lord_harond.stringtable
@@ -130,7 +130,7 @@
     </Entry>
     <Entry>
       <ID>138</ID>
-      <DefaultText>Der Mann trägt Ornat im aedyranischen Stil - einfach, aber doch elegant. Seine edlen Lederschuhe sehen eher wie Hausschuhe aus, aber sie sind trotzdem schlammverkrustet.
+      <DefaultText>Der Mann trägt Ornat im aedyrischen Stil - einfach, aber doch elegant. Seine edlen Lederschuhe sehen eher wie Hausschuhe aus, aber sie sind trotzdem schlammverkrustet.
 
 Er zerrt an einer Haarlocke, die um seinen seidenbehandschuhten Finger gewickelt ist. Über seine noblen Züge hat sich der Schatten der Angst gelegt.</DefaultText>
       <FemaleText />

--- a/text/conversations/00_dyrwood/00_cv_nyfre_new.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_nyfre_new.stringtable
@@ -236,14 +236,14 @@ Sie und der Rest ihrer Gefährten eilen die Treppe hinunter.</DefaultText>
     </Entry>
     <Entry>
       <ID>44</ID>
-      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreht?" Sie zieht ihr Stilett. "Es ist eine Lüge, ganz einfach. Ich habe es mir mit seinen Arbeitgebern verscherzt und jetzt ist er hinter mir her."
+      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreth?" Sie zieht ihr Stilett. "Es ist eine Lüge, ganz einfach. Ich habe es mir mit seinen Arbeitgebern verscherzt und jetzt ist er hinter mir her."
 
 "Aber wenn du hier bist, um seine Drecksarbeit zu erledigen ... ich werde es dir nicht leicht machen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>45</ID>
-      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreht?" Sie zieht ihr Stilett. "Du bist ein hohes Tier in Trutzbucht. Wenn ich irgendeinen Amoklauf unternommen hätte, hättest du dann nicht davon gehört?" 
+      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreth?" Sie zieht ihr Stilett. "Du bist ein hohes Tier in Trutzbucht. Wenn ich irgendeinen Amoklauf unternommen hätte, hättest du dann nicht davon gehört?" 
 
 Sie schüttelt den Kopf. "Ich habe es mir mit seinen Arbeitgebern verscherzt und jetzt ist er hinter mir her."
 
@@ -252,7 +252,7 @@ Sie schüttelt den Kopf. "Ich habe es mir mit seinen Arbeitgebern verscherzt und
     </Entry>
     <Entry>
       <ID>46</ID>
-      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreht?" Sie zieht ihr Stilett. "Du bist ein hohes Tier bei den Schmelztiegelrittern. Wenn ich irgendeinen Amoklauf unternommen hätte, hättest du dann nicht davon gehört?" 
+      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreth?" Sie zieht ihr Stilett. "Du bist ein hohes Tier bei den Schmelztiegelrittern. Wenn ich irgendeinen Amoklauf unternommen hätte, hättest du dann nicht davon gehört?" 
 
 Sie schüttelt den Kopf. "Ich habe es mir mit seinen Arbeitgebern verscherzt und jetzt ist er hinter mir her."
 
@@ -261,7 +261,7 @@ Sie schüttelt den Kopf. "Ich habe es mir mit seinen Arbeitgebern verscherzt und
     </Entry>
     <Entry>
       <ID>47</ID>
-      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreht?" Sie zieht ihr Stilett. "Du bist ein hohes Tier in der Dunrydstraße. Wenn ich irgendeinen Amoklauf unternommen hätte, hättest du dann nicht davon gehört?" 
+      <DefaultText>"Lass mich raten. Hieß dieser Jemand Medreth?" Sie zieht ihr Stilett. "Du bist ein hohes Tier in der Dunrydstraße. Wenn ich irgendeinen Amoklauf unternommen hätte, hättest du dann nicht davon gehört?" 
 
 Sie schüttelt den Kopf. "Ich habe es mir mit seinen Arbeitgebern verscherzt und jetzt ist er hinter mir her."
 

--- a/text/conversations/00_dyrwood/00_cv_sid.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_sid.stringtable
@@ -30,7 +30,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>"Sie wurde zur Zeit von Hadrets Rebellion gebaut. Einst unterhielt hier eine aedyranische Lady-Thaynu eine Burg - einer der Türme steht immer noch, aber der Rest soll unter dem Dorf begraben liegen. Wie auch immer, sie hielt zum Kaiserreich und ein Kontingent von Duc Hadrets Schmelztiegelrittern half den Bauern und Kolonisten in der Gegend, ihre Burg in Schutt zu verwandeln."</DefaultText>
+      <DefaultText>"Sie wurde zur Zeit von Hadrets Rebellion gebaut. Einst unterhielt hier eine aedyrische Lady-Thaynu eine Burg - einer der Türme steht immer noch, aber der Rest soll unter dem Dorf begraben liegen. Wie auch immer, sie hielt zum Kaiserreich und ein Kontingent von Duc Hadrets Schmelztiegelrittern half den Bauern und Kolonisten in der Gegend, ihre Burg in Schutt zu verwandeln."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -62,7 +62,7 @@
     </Entry>
     <Entry>
       <ID>44</ID>
-      <DefaultText>"Dyrwäldler sind ein störrischer Haufen, und je öfter sich diese neuen Nachbarn trafen, desto mehr Streit gab es. Ihnen wurde klar, dass sie nicht viel gemeinsam hatten, außer den alten Fürst hinauswerfen zu wollen. Die größte Meinungsverschiedenheit bestand über die Glanfathaner und ihre nahegelegenen Ruinen. Hadrets Ritter und ihre Unterstützer wollten sie in Frieden lassen, aber eine Außenseitergruppe mit stärkeren anarchischen Tendenzen, die sich im Dorf gebildet hatte, wollte den Stämmen ebenso auf den Pelz rücken wie ihren Fürsten. Schon bald kämpften die Dörfler untereinander genau so heftig wie gegen die Aedryaner."</DefaultText>
+      <DefaultText>"Dyrwälder sind ein störrischer Haufen, und je öfter sich diese neuen Nachbarn trafen, desto mehr Streit gab es. Ihnen wurde klar, dass sie nicht viel gemeinsam hatten, außer den alten Fürst hinauswerfen zu wollen. Die größte Meinungsverschiedenheit bestand über die Glanfathaner und ihre nahegelegenen Ruinen. Hadrets Ritter und ihre Unterstützer wollten sie in Frieden lassen, aber eine Außenseitergruppe mit stärkeren anarchischen Tendenzen, die sich im Dorf gebildet hatte, wollte den Stämmen ebenso auf den Pelz rücken wie ihren Fürsten. Schon bald kämpften die Dörfler untereinander genau so heftig wie gegen die Aedyrer."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -109,7 +109,7 @@
     </Entry>
     <Entry>
       <ID>54</ID>
-      <DefaultText>"Das war der erste große Konflikt der ursprünglichen aedyranischen Siedler und den Glanfathanern. Er begann drei Jahre nach der Kolonisierung, als ein paar Bauern einen Adra Menhir umstießen, der zu einer Engwithan-Ruine gehörte."
+      <DefaultText>"Das war der erste große Konflikt der ursprünglichen aedyrischen Siedler und den Glanfathanern. Er begann drei Jahre nach der Kolonisierung, als ein paar Bauern einen Adra Menhir umstießen, der zu einer engwithanischen Ruine gehörte."
 
 "Der Krieg dauert zwar nicht lange, aber er weitete sich schnell aus und kostete Tausende das Leben. Während der ersten paar Wochen wussten die meisten Kolonisten nicht einmal, dass sie sich im Krieg befanden, bis die Glanfathaner-Plünderer ihre Dörfer überfielen."</DefaultText>
       <FemaleText />
@@ -123,7 +123,7 @@
       <ID>56</ID>
       <DefaultText>"Er begann zur Zeit der Kolonisierung, fast dreißig Jahre nach dem Krieg des Zerbrochenen Steins. Obwohl es immer noch hier und da zu isolierten Konflikten zwischen den Siedlern und den Glanfathanern kam, hatten beide Seiten offiziell ein Friedensabkommen geschlossen."
 
-"Admeths Vater, Edrang Hadret war zu jener Zeit der Gréf. Als Teil der Friedensverhandlungen hatte er Verträge unterzeichnet, die aedyranischen Kolonisten das Plündern engwithanischer Ruinen verbot. Die Versklavung gefangener Glanfathaner allerdings hatte er nicht ächten können."</DefaultText>
+"Admeths Vater, Edrang Hadret war zu jener Zeit der Gréf. Als Teil der Friedensverhandlungen hatte er Verträge unterzeichnet, die aedyrischen Kolonisten das Plündern engwithanischer Ruinen verbot. Die Versklavung gefangener Glanfathaner allerdings hatte er nicht ächten können."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -138,7 +138,7 @@
     </Entry>
     <Entry>
       <ID>59</ID>
-      <DefaultText>"Ein Gréf ist der Gouverneur einer Kolonie und dient in dieser Funktion dem aedyranischen Kaiser. Alle frühen Anführer der Aedyr-Kolonie im Dyrwald, einschließlich Edrang und Admeth Hadret, waren Gréfs."
+      <DefaultText>"Ein Gréf ist der Gouverneur einer Kolonie und dient in dieser Funktion dem aedyrischen Kaiser. Alle frühen Anführer der Aedyr-Kolonie im Dyrwald, einschließlich Edrang und Admeth Hadret, waren Gréfs."
 
 "Zu Beginn des Widerstandskriegs erklärte sich Admeth Hadret selbst zum Duc eines unabhängigen Dyrwalds, anstatt weiter Gréf einer Kolonie des Kaisers zu sein. Dieselbe Bezeichnung wurde für die Anführer der erst kürzlich unabhängig gewordenen Vailianischen Republiken benutzt. Wie auch immer, seit dieser Zeit haben wir keinen Gréf mehr gehabt."</DefaultText>
       <FemaleText />

--- a/text/conversations/00_dyrwood/00_cv_wymund.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_wymund.stringtable
@@ -67,7 +67,7 @@ Er nimmt eine Haarlocke der jungen Frau in seine große, blutverschmierte Hand. 
     </Entry>
     <Entry>
       <ID>42</ID>
-      <DefaultText>"Gut. Wenn du die Harrond-Familie zerstören willst, werde ich dich nicht aufhalten."</DefaultText>
+      <DefaultText>"Gut. Wenn du die Harond-Familie zerstören willst, werde ich dich nicht aufhalten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/01_defiance_bay_copperlane/01_bs_master_dozens.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_bs_master_dozens.stringtable
@@ -156,12 +156,12 @@
     </Entry>
     <Entry>
       <ID>31</ID>
-      <DefaultText>"Deine Freunde, die Doemenels, könnten selbst auch gut Aedyraner sein."</DefaultText>
+      <DefaultText>"Deine Freunde, die Doemenels, könnten selbst auch gut Aedyrer sein."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>32</ID>
-      <DefaultText>"Du bist gar nicht so übel. Für einen Aedyraner."</DefaultText>
+      <DefaultText>"Du bist gar nicht so übel. Für einen Aedyrer."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/01_defiance_bay_copperlane/01_cv_bishop.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_bishop.stringtable
@@ -80,7 +80,7 @@ Vor ihm steht ein winziger Zinnkelch. Er dreht ihn in einer Hand, trinkt aber ni
     </Entry>
     <Entry>
       <ID>27</ID>
-      <DefaultText>Er legt seine Ellbogen auf das polierte Holz des Tresens. "Es dauerte nicht lange und es war hier gerammelt voll. Adlige aus Farnheim diskutierten mit Dockarbeitern aus dem Geschenk, während Soldaten mit Politikern zankten. Die Dyrwäldler sind nicht dafür bekannt, Konflikten aus dem Weg zu gehen." Er trinkt aus dem winzigen Kelch.</DefaultText>
+      <DefaultText>Er legt seine Ellbogen auf das polierte Holz des Tresens. "Es dauerte nicht lange und es war hier gerammelt voll. Adlige aus Farnheim diskutierten mit Dockarbeitern aus dem Geschenk, während Soldaten mit Politikern zankten. Die Dyrwälder sind nicht dafür bekannt, Konflikten aus dem Weg zu gehen." Er trinkt aus dem winzigen Kelch.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/01_defiance_bay_copperlane/01_cv_osric.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_osric.stringtable
@@ -218,7 +218,7 @@
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>Er versucht, dir in die Augen zu blicken, aber als er das tut, überlegt er es sich offenbar anders. Er seufzt. "Sie wurde vom Magran-Orden verliehen. Die höchste Tapferkeitsauszeichnung. Sie wird nur den Toten verliehen, niemals jemandem Lebenden. Wir Dyrwäldler - ECHTE Dyrwäldler - wir haben keinen Adel, keine Geburtsrechte ... wenn man kein reicher Kupferficker aus Aedyr ist. Wir haben nur die Ehre, die wir dem Namen unserer Familie einbringen."</DefaultText>
+      <DefaultText>Er versucht, dir in die Augen zu blicken, aber als er das tut, überlegt er es sich offenbar anders. Er seufzt. "Sie wurde vom Magran-Orden verliehen. Die höchste Tapferkeitsauszeichnung. Sie wird nur den Toten verliehen, niemals jemandem Lebenden. Wir Dyrwälder - ECHTE Dyrwälder - wir haben keinen Adel, keine Geburtsrechte ... wenn man kein reicher Kupferficker aus Aedyr ist. Wir haben nur die Ehre, die wir dem Namen unserer Familie einbringen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/01_defiance_bay_copperlane/01_cv_roedric.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_roedric.stringtable
@@ -347,7 +347,7 @@ Er blickt wieder hinauf zu dir. "Du hast nicht zufällig herausgefunden, was sie
     </Entry>
     <Entry>
       <ID>86</ID>
-      <DefaultText>Er legt die Waffen ab. "Zumindest muss ich keine weiteren Expeditionen wegen dieser Sache vergeuden. Wenn die Ritter tatsächlich etwas unternehmen, müssen wir sie eben mit guter alter dyrwäldlerischer Sturheit besiegen." </DefaultText>
+      <DefaultText>Er legt die Waffen ab. "Zumindest muss ich keine weiteren Expeditionen wegen dieser Sache vergeuden. Wenn die Ritter tatsächlich etwas unternehmen, müssen wir sie eben mit guter alter dyrwälderischer Sturheit besiegen." </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -367,7 +367,7 @@ Er blickt wieder hinauf zu dir. "Du hast nicht zufällig herausgefunden, was sie
     </Entry>
     <Entry>
       <ID>90</ID>
-      <DefaultText>"So lobe ich mir das! Nichts kann einen entschlossenen Dyrwäldler aufhalten."</DefaultText>
+      <DefaultText>"So lobe ich mir das! Nichts kann einen entschlossenen Dyrwälder aufhalten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -382,7 +382,7 @@ Er blickt wieder hinauf zu dir. "Du hast nicht zufällig herausgefunden, was sie
     </Entry>
     <Entry>
       <ID>93</ID>
-      <DefaultText>"Das hatte noch nie etwas zu bedeuten. Unser Ahnen haben das aedyranische Militär vertrieben. Unsere Gründerväter haben die Armee eines so genannten Gottes besiegt."
+      <DefaultText>"Das hatte noch nie etwas zu bedeuten. Unser Ahnen haben das aedyrische Militär vertrieben. Unsere Gründerväter haben die Armee eines so genannten Gottes besiegt."
 
 Er nickt in Richtung der Männer und Frauen in der Halle. "Wir haben das Zeug dazu, sie zu besiegen. Wenn es nötig werden sollte."</DefaultText>
       <FemaleText />

--- a/text/conversations/01_defiance_bay_copperlane/01_cv_rowan.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_rowan.stringtable
@@ -52,7 +52,7 @@ Er mustert dich. "Neu in der Stadt, was? Du kommst zu spannenden Zeiten nach Tru
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>"Sie beschäftigt sich mit dem Studium und der Manipulation von Essenz, was wie jeder mit einem Funken Verstand weiß den Göttern vorbehalten ist. Die Aedyraner waren zumindest so klug, sie zu verbieten ... was aber auch das einzige Gute ist, was sich über sie sagen lässt."
+      <DefaultText>"Sie beschäftigt sich mit dem Studium und der Manipulation von Essenz, was wie jeder mit einem Funken Verstand weiß den Göttern vorbehalten ist. Die Aedyrer waren zumindest so klug, sie zu verbieten ... was aber auch das einzige Gute ist, was sich über sie sagen lässt."
 
 "Sie ist nicht wie die Magie, das Zaubern oder das Seelenlesen, das ein Medium betreibt. Es gibt die Beseelung seit antiken engwithanischen Zeiten, weshalb diese Beseeler auch oft mit alten engwithanischen Artefakten herumhantieren."</DefaultText>
       <FemaleText />
@@ -180,12 +180,12 @@ Er blickt auf die Menge und senkt seine Stimme. "Du hast es vermutlich noch nich
       <ID>35</ID>
       <DefaultText>Seine Augen funkeln schelmisch. "Ja, im guten alten Aedyr sagen sie einem bestimmt nichts von der Kolonie, die Hadrets Dienstmädchen vermöbelt hat, was?"
 
-"Das hier ist die Hauptstadt des Freien Palatinats des Dyrwalds. Zunächst waren wir die Hauptstadt einer aedyranischen Kolonie, aber wir haben das schlaffe Zepter vor einhundertfünfzig Jahren hinausgeworfen."</DefaultText>
+"Das hier ist die Hauptstadt des Freien Palatinats des Dyrwalds. Zunächst waren wir die Hauptstadt einer aedyrischen Kolonie, aber wir haben das schlaffe Zepter vor einhundertfünfzig Jahren hinausgeworfen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>36</ID>
-      <DefaultText>"Das hier ist die Hauptstadt des Freien Palatinats des Dyrwalds. Zunächst waren wir die Hauptstadt einer aedyranischen Kolonie, aber wir haben das schlaffe Zepter vor einhundertfünfzig Jahren hinausgeworfen."</DefaultText>
+      <DefaultText>"Das hier ist die Hauptstadt des Freien Palatinats des Dyrwalds. Zunächst waren wir die Hauptstadt einer aedyrischen Kolonie, aber wir haben das schlaffe Zepter vor einhundertfünfzig Jahren hinausgeworfen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_bs_armory_guard.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_bs_armory_guard.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>"Ich hörte, dass Penhelm die Reinkarnation eines Aedyrianers war. Ist das wahr?"</DefaultText>
+      <DefaultText>"Ich hörte, dass Penhelm die Reinkarnation eines Aedyrers war. Ist das wahr?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_bs_master_knight.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_bs_master_knight.stringtable
@@ -56,7 +56,7 @@
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>"Gerüchten zufolge hatte einer der Novizen die Seele eines aedyranischen Generals."</DefaultText>
+      <DefaultText>"Gerüchten zufolge hatte einer der Novizen die Seele eines aedyrischen Generals."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_bs_vailian_soldier.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_bs_vailian_soldier.stringtable
@@ -16,8 +16,8 @@
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>"Oh Amico, diese Aufstände! Wir können von Glück sagen, dass die Meute ihre Wut woanders ausgelassen hat."</DefaultText>
-      <FemaleText />
+      <DefaultText>"Oh aimico, diese Aufstände! Wir können von Glück sagen, dass die Meute ihre Wut woanders ausgelassen hat."</DefaultText>
+      <FemaleText>"Oh aimica, diese Aufstände! Wir können von Glück sagen, dass die Meute ihre Wut woanders ausgelassen hat."</FemaleText>
     </Entry>
   </Entries>
 </StringTableFile>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_captain_aldmar.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_captain_aldmar.stringtable
@@ -111,7 +111,7 @@
     </Entry>
     <Entry>
       <ID>49</ID>
-      <DefaultText>"Wir sind die Verteidiger von Trutzbucht. Wir sind nicht wirklich eine offizielle Ritterschaft. Verrate Kommandant&#160;Clyver aber nicht, dass ich das gerade gesagt habe." Er grinst. "Wir waren die erste organisierte Miliz, die sich der aedyrianischen Herrschaft stellte, und heute sind wir die größte Macht in der Stadt. Unsere Soldaten werden einer jahrelangen Kampfausbildung unterzogen, und unsere Offiziere müssen ihre Seelen von diesem Kriechtier draußen in der Dunrydstraße lesen lassen."</DefaultText>
+      <DefaultText>"Wir sind die Verteidiger von Trutzbucht. Wir sind nicht wirklich eine offizielle Ritterschaft. Verrate Kommandant&#160;Clyver aber nicht, dass ich das gerade gesagt habe." Er grinst. "Wir waren die erste organisierte Miliz, die sich der aedyrischen Herrschaft stellte, und heute sind wir die größte Macht in der Stadt. Unsere Soldaten werden einer jahrelangen Kampfausbildung unterzogen, und unsere Offiziere müssen ihre Seelen von diesem Kriechtier draußen in der Dunrydstraße lesen lassen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_clyver_rimgund.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_clyver_rimgund.stringtable
@@ -80,7 +80,7 @@ Er öffnet den Mund, um einem seiner Männer etwas zu sagen, folgt jedoch dem Bl
     </Entry>
     <Entry>
       <ID>20</ID>
-      <DefaultText>Er verschränkt die Arme hinter dem Rücken. "Wir sind die einzige Berufsarmee in Trutzbucht, oder im Dyrwald, die sich darum kümmert. Wir verteidigten die Stadt zur Zeit von Hadret. Seitdem haben wir unsere Ausbildung verbessert, doch die Dunrydstraße kann bestätigen, dass viele unserer Offiziere aus guter Dyrwalder Kampfschule stammen."</DefaultText>
+      <DefaultText>Er verschränkt die Arme hinter dem Rücken. "Wir sind die einzige Berufsarmee in Trutzbucht, oder im Dyrwald, die sich darum kümmert. Wir verteidigten die Stadt zur Zeit von Hadret. Seitdem haben wir unsere Ausbildung verbessert, doch die Dunrydstraße kann bestätigen, dass viele unserer Offiziere aus guter Dyrwälder Kampfschule stammen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_duc_assassination.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_duc_assassination.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>"Ramir di Barrasc, Repräsentant der Interessen der dyrwäldlerischen Beseeler, bitte tritt vor."</DefaultText>
+      <DefaultText>"Ramir di Barrasc, Repräsentant der Interessen der dyrwälderischen Beseeler, bitte tritt vor."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_duc_meeting.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_duc_meeting.stringtable
@@ -765,7 +765,7 @@ Thaos ist fort.</DefaultText>
       <ID>171</ID>
       <DefaultText>Edér beugt sich zu dir hinunter. Du siehst seinen Kopf verkehrt herum. "He, du lebst!"
 
-Er mustert dich und runzelt die Stirn. "Kannst du dich bewegen? Wir sollten lieber verschwinden. Wenn Dyrwäldler wütend werden, fangen sie gerne an, Sachen in Brand zu stecken."</DefaultText>
+Er mustert dich und runzelt die Stirn. "Kannst du dich bewegen? Wir sollten lieber verschwinden. Wenn Dyrwälder wütend werden, fangen sie gerne an, Sachen in Brand zu stecken."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_dunstan.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_dunstan.stringtable
@@ -78,7 +78,7 @@
     </Entry>
     <Entry>
       <ID>18</ID>
-      <DefaultText>Dunstan lässt einen leisen Pfiff. "Das ist eine schöne Klinge, in der Tat." Er hält ein Fragment in seinen rauen Händen. "Sieht aedyranisch aus. Sonderanfertigung. Muss ein Auftrag für irgendeinen Champion gewesen sein."</DefaultText>
+      <DefaultText>Dunstan lässt einen leisen Pfiff. "Das ist eine schöne Klinge, in der Tat." Er hält ein Fragment in seinen rauen Händen. "Sieht aedyrisch aus. Sonderanfertigung. Muss ein Auftrag für irgendeinen Champion gewesen sein."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_fyrga.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_fyrga.stringtable
@@ -187,7 +187,7 @@ Sie hebt die Hände, als würde sie ein Bild ihrer Vision einrahmen. "Und hinter
     </Entry>
     <Entry>
       <ID>43</ID>
-      <DefaultText>"Magran ist die am meisten verehrte Göttin der Dyrwaldaner. Deswegen ist es nicht überraschend, dass ihr Tempel gleichzeitig Teil des Palast des Ducs ist. Ihre Feuer symbolisieren Prüfungen, Revolutionen und das Lodern neuer Pfade. All dies ist für uns von Bedeutung."
+      <DefaultText>"Magran ist die am meisten verehrte Göttin der Dyrwälder. Deswegen ist es nicht überraschend, dass ihr Tempel gleichzeitig Teil des Palast des Ducs ist. Ihre Feuer symbolisieren Prüfungen, Revolutionen und das Lodern neuer Pfade. All dies ist für uns von Bedeutung."
 
 Sie deutet auf die Statue. "Dies ist der erste der heiligen Scheiterhaufen. Wenn dieser entzündet ist, dann brennen auch die anderen in der Stadt."</DefaultText>
       <FemaleText />
@@ -387,7 +387,7 @@ Sie faltet die Hände vor sich zusammen. "Es wird noch Wochen dauern, bis ein an
     </Entry>
     <Entry>
       <ID>79</ID>
-      <DefaultText>"In Rautai haben wir Kanonen, Sprengstoff, Bomben ... aber das hier ist andere Arbeit." Kana betrachtet den Stein nachdenklich. "Ein Stück Geschichte. Ist das nicht das Zeichen, nach dem du gesucht hast?"</DefaultText>
+      <DefaultText>"In Rauatai haben wir Kanonen, Sprengstoff, Bomben ... aber das hier ist andere Arbeit." Kana betrachtet den Stein nachdenklich. "Ein Stück Geschichte. Ist das nicht das Zeichen, nach dem du gesucht hast?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_penhelm.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_penhelm.stringtable
@@ -183,7 +183,7 @@ Alle Augen richten sich auf ihn, er hebt die Hände. "Was? Kümmert euch nicht u
     </Entry>
     <Entry>
       <ID>105</ID>
-      <DefaultText>"Diesmal ist er zu weit gegangen. Er war dreist genug, zu behaupten, dass wir uns so weit von unseren Wurzeln entfernt hätten, dass einige unserer Offiziere begannen, dem aedyranischen Adel zu ähneln." Er reibt mit einem seidenen Taschentuch eine Stelle auf seiner Armschiene.
+      <DefaultText>"Diesmal ist er zu weit gegangen. Er war dreist genug, zu behaupten, dass wir uns so weit von unseren Wurzeln entfernt hätten, dass einige unserer Offiziere begannen, dem aedyrischen Adel zu ähneln." Er reibt mit einem seidenen Taschentuch eine Stelle auf seiner Armschiene.
 
 "Er wollte, dass wir alle grob gewebtes Garn tragen und mit Schmiedehämmern kämpfen. Ich habe lediglich seine Aussagen gemeldet."</DefaultText>
       <FemaleText />
@@ -249,7 +249,7 @@ Er blinzelt dich an. "Das ist natürlich eine Lüge."</DefaultText>
     </Entry>
     <Entry>
       <ID>119</ID>
-      <DefaultText>"Welche Wahrheit? Dass ich vor über einem Jahrhundert irgendein Aedyraner war, der jetzt Staub und Asche ist?"
+      <DefaultText>"Welche Wahrheit? Dass ich vor über einem Jahrhundert irgendein Aedyrer war, der jetzt Staub und Asche ist?"
 
 Seine Hand greift nach dem Schwertknauf. "Ich sage es dir nur noch einmal. Gib das zurück."</DefaultText>
       <FemaleText />
@@ -378,14 +378,14 @@ Er blinzelt dich an. "Das ist natürlich eine Lüge. Was jemandem mit deinen log
       <ID>143</ID>
       <DefaultText>"Meinst du das ernst? Wir sprechen von meiner Karriere! Ich habe jahrelang dafür geschuftet. Und alles hängt von irgendeinem Zufall in einem früheren Leben ab."
 
-"Jeder Dyrwäldler - reich oder arm - kann eine Position bei den Schmelztiegelrittern anstreben. Jeder kann in den Rang des Hochrichters aufsteigen. Außer jenen, die mit der falschen Seele geboren wurden. Erklär mir, was daran vernünftig ist."</DefaultText>
+"Jeder Dyrwälder - reich oder arm - kann eine Position bei den Schmelztiegelrittern anstreben. Jeder kann in den Rang des Hochrichters aufsteigen. Außer jenen, die mit der falschen Seele geboren wurden. Erklär mir, was daran vernünftig ist."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>144</ID>
       <DefaultText>"Meinst du das ernst? Wie würde es dir gefallen, wenn jemand drohen würde, dich aus deinem Orden zu werfen - nur wegen irgendeines Zufalls in einem früheren Leben, an das du dich nicht einmal erinnerst?"
 
-"Jeder Dyrwäldler - reich oder arm - kann eine Position bei den Schmelztiegelrittern anstreben. Jeder kann in den Rang des Hochrichters aufsteigen. Außer jenen, die mit der falschen Seele geboren wurden. Sieh mir in die Augen und sag mir, dass das vernünftig ist."</DefaultText>
+"Jeder Dyrwälder - reich oder arm - kann eine Position bei den Schmelztiegelrittern anstreben. Jeder kann in den Rang des Hochrichters aufsteigen. Außer jenen, die mit der falschen Seele geboren wurden. Sieh mir in die Augen und sag mir, dass das vernünftig ist."</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_records_keeper.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_records_keeper.stringtable
@@ -50,7 +50,7 @@
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>"Die dyrwäldlerische Behandlung readceranischer Kriegsgefangener und Flüchtlinge war beklagenswert."</DefaultText>
+      <DefaultText>"Die dyrwälderische Behandlung readceranischer Kriegsgefangener und Flüchtlinge war beklagenswert."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -70,7 +70,7 @@
     </Entry>
     <Entry>
       <ID>14</ID>
-      <DefaultText>Der Tonfall des Archivars hat etwas Eigenartiges. Die Unterschiede sind nur ganz fein, aber er klingt wie keiner der Muttersprachler des Dyrwäldlerischen, die du bislang gehört hast.</DefaultText>
+      <DefaultText>Der Tonfall des Archivars hat etwas Eigenartiges. Die Unterschiede sind nur ganz fein, aber er klingt wie keiner der Muttersprachler des Dyrwälderischen, die du bislang gehört hast.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -171,7 +171,7 @@ Dann, endlich, stoppt seine Hand und seine Finger kommen unter einem Namen zur R
     </Entry>
     <Entry>
       <ID>32</ID>
-      <DefaultText>"Woden Teylecg, Gefallen am 18 Majiverno, 2808. Dritte Schlacht von ... Clee- Clee-ah- Clîaban Rilag."
+      <DefaultText>"Woden Teylecg, Gefallen am 18 Majivèrno, 2808. Dritte Schlacht von ... Clee- Clee-ah- Clîaban Rilag."
 
 "Verdammte glanfathanische Namen, ich schwöre, ich-"</DefaultText>
       <FemaleText />

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_sidly.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_sidly.stringtable
@@ -33,7 +33,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>"Es ist der Regierungssitz hier in Trutzbucht. Hier erklärte Duc&#160;Admeth vor etwa 150&#160;Jahren die Freiheit von der aedyranischen Herrschaft." 
+      <DefaultText>"Es ist der Regierungssitz hier in Trutzbucht. Hier erklärte Duc&#160;Admeth vor etwa 150&#160;Jahren die Freiheit von der aedyrischen Herrschaft." 
 
 Sie senkt ihre Stimme und grinst. "Es ist auch eine Brutstätte regionaler Politik. Vertrau mir, der Klatsch hier schlägt alles, was du in Schänken oder Freudenhäusern in der Stadt zu hören bekommst."</DefaultText>
       <FemaleText />

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_vicent.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_vicent.stringtable
@@ -11,8 +11,8 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Amico! So schön, dich wiederzusehen! Was kann ich für dich tun?"</DefaultText>
-      <FemaleText />
+      <DefaultText>"Aimico! So schön, dich wiederzusehen! Was kann ich für dich tun?"</DefaultText>
+      <FemaleText>"Aimica! So schön, dich wiederzusehen! Was kann ich für dich tun?"</FemaleText>
     </Entry>
     <Entry>
       <ID>3</ID>
@@ -21,8 +21,8 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>"Es ist schön, dich zu sehen, Amico."</DefaultText>
-      <FemaleText />
+      <DefaultText>"Es ist schön, dich zu sehen, aimico."</DefaultText>
+     <FemaleText>"Es ist schön, dich zu sehen, aimica."</FemaleText>
     </Entry>
     <Entry>
       <ID>6</ID>
@@ -299,7 +299,7 @@
     </Entry>
     <Entry>
       <ID>87</ID>
-      <DefaultText>"Diese Dyrwäldler sind wahnsinnig. Ihr Duc wird ermordet, also brennen sie fast die Stadt nieder?"
+      <DefaultText>"Diese Dyrwälder sind wahnsinnig. Ihr Duc wird ermordet, also brennen sie fast die Stadt nieder?"
 
 Er hebt die Hände und blickt an die Decke. "Diese Sciòderie. Wie ich mich freue, wieder nach Ozia zurückzukehren."</DefaultText>
       <FemaleText />

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_aefre.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_aefre.stringtable
@@ -35,14 +35,14 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>"Ich bin Aefre, Leutnant der Dutzenden." Sie klopft auf ihren eingedellten Brustharnisch. "Wir sind die letzte Streitkraft in Trutzbucht, die sich noch daran erinnert, was es heißt, ein Dyrwäldler zu sein."
+      <DefaultText>"Ich bin Aefre, Leutnant der Dutzenden." Sie klopft auf ihren eingedellten Brustharnisch. "Wir sind die letzte Streitkraft in Trutzbucht, die sich noch daran erinnert, was es heißt, ein Dyrwälder zu sein."
 
 "Außerdem scheine ich unglücklicherweise die Einzige zu sein, die sich daran stört, dass Maea die Einheimischen nach Strich und Faden ausnimmt."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>"Die gewöhnlichen Gestandenen sind wütend. Und das sollten sie über diese betrügerische Aumaua auch sein, die den Edelleuten hinten rein kriecht." Sie grinst spöttisch. "Sie nutzt die Tragödie von Waidwens Vermächtnis aus, um sich die Taschen zu füllen. Sie ist keinen Deut besser als die aedyranischen Lehensherren, die wir vor zweihundert Jahren hinausgeworfen haben."</DefaultText>
+      <DefaultText>"Die gewöhnlichen Gestandenen sind wütend. Und das sollten sie über diese betrügerische Aumaua auch sein, die den Edelleuten hinten rein kriecht." Sie grinst spöttisch. "Sie nutzt die Tragödie von Waidwens Vermächtnis aus, um sich die Taschen zu füllen. Sie ist keinen Deut besser als die aedyrischen Lehensherren, die wir vor zweihundert Jahren hinausgeworfen haben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_lyrinia.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_lyrinia.stringtable
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>Lyriana schätzt dich ab. "Dass diese Schläger aufgehalten wurden, haben wir anscheinend dir zu verdanken. Dich kostet eine Nacht nur dreihundert Pand, und diese Nacht wird dich ordentlich aus den Schuhen ledern."</DefaultText>
+      <DefaultText>Lyrinia schätzt dich ab. "Dass diese Schläger aufgehalten wurden, haben wir anscheinend dir zu verdanken. Dich kostet eine Nacht nur dreihundert Pand, und diese Nacht wird dich ordentlich aus den Schuhen ledern."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_maea.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_maea.stringtable
@@ -503,7 +503,7 @@ Sie überblickt die plaudernde, lachende, trinkende Menge. "Diese Gemächer wurd
     </Entry>
     <Entry>
       <ID>117</ID>
-      <DefaultText>"Trutzbucht hat seit dem Abzug der Aedyraner keine solche Schlacht mehr gesehen. Zumindest hat diese nicht das Geschenk eingenommen."
+      <DefaultText>"Trutzbucht hat seit dem Abzug der Aedyrer keine solche Schlacht mehr gesehen. Zumindest hat diese nicht das Geschenk eingenommen."
 
 Sie überblickt die Kunden und Huren. "Wann kann wohl noch nicht sagen, was das für uns bedeutet."</DefaultText>
       <FemaleText />

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_maerwith.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_maerwith.stringtable
@@ -125,7 +125,7 @@ Ihre dunklen Augen sind voller Zorn. "Ich wusste nicht, wohin ich sonst gehen so
     </Entry>
     <Entry>
       <ID>58</ID>
-      <DefaultText>"Sie hat den Vormarsch der Aedyraner ignoriert und ist geblieben. Ich glaube, sie hat auf dich gewartet."</DefaultText>
+      <DefaultText>"Sie hat den Vormarsch der Aedyrer ignoriert und ist geblieben. Ich glaube, sie hat auf dich gewartet."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_niah.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_niah.stringtable
@@ -235,9 +235,9 @@ Sie schüttelt den Kopf. "Genau das meine ich. Wenn nicht einmal eine Piratin ei
     </Entry>
     <Entry>
       <ID>89</ID>
-      <DefaultText>"Am Ende des Widerstandskriegs. Das war einer der entscheidenden letzten Schläge gegen das aedyranische Militär."
+      <DefaultText>"Am Ende des Widerstandskriegs. Das war einer der entscheidenden letzten Schläge gegen das aedyrische Militär."
 
-"Hat uns aber viel gekostet. Eigentlich sollte der ganze Bezirk evakuiert werden, aber es sind nicht alle rechtzeitig fort. Die Aedyraner haben jeden, den sie gefunden haben, mit dem Schwert gerichtet. Wer Glück hatte, ist dem Gemetzel entkommen und wenige Stunden später ertrunken, als Hadrets Truppen die Dämme zerstört haben."</DefaultText>
+"Hat uns aber viel gekostet. Eigentlich sollte der ganze Bezirk evakuiert werden, aber es sind nicht alle rechtzeitig fort. Die Aedyrer haben jeden, den sie gefunden haben, mit dem Schwert gerichtet. Wer Glück hatte, ist dem Gemetzel entkommen und wenige Stunden später ertrunken, als Hadrets Truppen die Dämme zerstört haben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -254,9 +254,9 @@ Sie zuckt mit den Achseln. "Ich weiß nicht, warum es im Leuchtturm deswegen meh
     </Entry>
     <Entry>
       <ID>92</ID>
-      <DefaultText>"Hadret hat sie am Ende des Widerstandskriegs angeordnet. Das war einer der entscheidenden letzten Schläge gegen das aedyranische Militär."
+      <DefaultText>"Hadret hat sie am Ende des Widerstandskriegs angeordnet. Das war einer der entscheidenden letzten Schläge gegen das aedyrische Militär."
 
-"Hat uns aber viel gekostet. Eigentlich sollte der ganze Bezirk evakuiert werden, aber es sind nicht alle rechtzeitig fort. Die Aedyraner haben jeden, den sie gefunden haben, mit dem Schwert gerichtet. Wer Glück hatte, ist dem Gemetzel entkommen und wenige Stunden später ertrunken, als Hadrets Truppen die Dämme zerstört haben."</DefaultText>
+"Hat uns aber viel gekostet. Eigentlich sollte der ganze Bezirk evakuiert werden, aber es sind nicht alle rechtzeitig fort. Die Aedyrer haben jeden, den sie gefunden haben, mit dem Schwert gerichtet. Wer Glück hatte, ist dem Gemetzel entkommen und wenige Stunden später ertrunken, als Hadrets Truppen die Dämme zerstört haben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_og_brothel_female_01.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_og_brothel_female_01.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>"Maea hätte die Aedyraner ganz alleine aus Trutzbucht hinauswerfen können. In der Tat ein schlaffes Zepter."</DefaultText>
+      <DefaultText>"Maea hätte die Aedyrer ganz alleine aus Trutzbucht hinauswerfen können. In der Tat ein schlaffes Zepter."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_og_vailian_female_01.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_og_vailian_female_01.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Egal, was diese Dyrwäldler denken mögen: Hier stinkt es nach verfaultem Fisch."</DefaultText>
+      <DefaultText>"Egal, was diese Dyrwälder denken mögen: Hier stinkt es nach verfaultem Fisch."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_og_warehouse_male_01.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_og_warehouse_male_01.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Dyrwäldler mögen ja zäh sein, aber mit unseren Ambitionen können sie es nicht aufnehmen."</DefaultText>
+      <DefaultText>"Dyrwälder mögen ja zäh sein, aber mit unseren Ambitionen können sie es nicht aufnehmen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_vailian_merchant.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_vailian_merchant.stringtable
@@ -21,8 +21,8 @@
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>"Was kann ich dir heute anbieten, Amico?"</DefaultText>
-      <FemaleText />
+      <DefaultText>"Was kann ich dir heute anbieten, aimico?"</DefaultText>
+      <FemaleText>"Was kann ich dir heute anbieten, aimica?"</FemaleText>
     </Entry>
   </Entries>
 </StringTableFile>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_verzano.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_verzano.stringtable
@@ -26,7 +26,9 @@ Seine Seidenkleidung ist zwar fein bestickt, aber keineswegs neu - du bemerkst e
       <DefaultText>Er wischt sich den Schweiß von der Stirn und sieht sich mit den weit aufgerissenen, ängstlichen Augen eines gejagten Tiers im Lagerhaus um. "Aimico, ich kann dir gar nicht genug danken, aber das wird die Doemenels nicht lange aufhalten. Ich muss von hier verschwinden, und dasselbe würde ich auch dir empfehlen."
 
 Mit zitternden Händen übergibt er dir seine Pistole und einen Münzbeutel. "Das ist alles, was ich nach dieser unglückseligen Unternehmung noch übrig habe. Vielen Dank, und bitte pass auf dich auf."</DefaultText>
-      <FemaleText />
+      <FemaleText>Er wischt sich den Schweiß von der Stirn und sieht sich mit den weit aufgerissenen, ängstlichen Augen eines gejagten Tiers im Lagerhaus um. "Aimica, ich kann dir gar nicht genug danken, aber das wird die Doemenels nicht lange aufhalten. Ich muss von hier verschwinden, und dasselbe würde ich auch dir empfehlen."
+
+Mit zitternden Händen übergibt er dir seine Pistole und einen Münzbeutel. "Das ist alles, was ich nach dieser unglückseligen Unternehmung noch übrig habe. Vielen Dank, und bitte pass auf dich auf."</FemaleText>
     </Entry>
     <Entry>
       <ID>6</ID>
@@ -242,7 +244,9 @@ Er deutet auf die gestapelten Kisten. "Wir transportieren Fracht in die Republik
       <DefaultText>"Sie ist tot? Aimico, ich kann dir gar nicht genug danken, aber das wird die Doemenels nicht lange aufhalten. Ich muss von hier verschwinden, und dasselbe würde ich auch dir empfehlen."
 
 Mit zitternden Händen übergibt er einen Münzbeutel. "Das ist alles, was ich nach dieser unglückseligen Unternehmung noch übrig habe. Vielen Dank, und bitte pass auf dich auf."</DefaultText>
-      <FemaleText />
+      <FemaleText>"Sie ist tot? Aimica, ich kann dir gar nicht genug danken, aber das wird die Doemenels nicht lange aufhalten. Ich muss von hier verschwinden, und dasselbe würde ich auch dir empfehlen."
+
+Mit zitternden Händen übergibt er einen Münzbeutel. "Das ist alles, was ich nach dieser unglückseligen Unternehmung noch übrig habe. Vielen Dank, und bitte pass auf dich auf."</FemaleText>
     </Entry>
     <Entry>
       <ID>86</ID>

--- a/text/conversations/04_defiance_bay_brackenbury/04_bs_animancer_female_01.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_bs_animancer_female_01.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>"Es heißt, die Seelen von Glanfathan-Ältesten würden nach ihrem Tod in Adra konserviert. Wenn sie es Außenstehenden doch nur erlauben würden, sie zu untersuchen."</DefaultText>
+      <DefaultText>"Es heißt, die Seelen der Glanfathaner-Ältesten würden nach ihrem Tod in Adra konserviert. Wenn sie es Außenstehenden doch nur erlauben würden, sie zu untersuchen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/04_defiance_bay_brackenbury/04_bs_mafia_capo.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_bs_mafia_capo.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>"Die Dutzenden halten nicht viel von Rafinesse, was?"</DefaultText>
+      <DefaultText>"Die Dutzenden halten nicht viel von Raffinesse, was?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_audmer.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_audmer.stringtable
@@ -38,7 +38,7 @@
     </Entry>
     <Entry>
       <ID>8</ID>
-      <DefaultText>"Wir sind so nah an der Glanfathan-Wildnis, dass wir jedes Jahr mehrere Opfer von Bîaŵac haben. Überlebende, die mit Komplikationen zu kämpfen haben. Dieser Mann hier ist ein schwerer Fall. Seine Essenz ist nur noch ein seidener Faden."</DefaultText>
+      <DefaultText>"Wir sind so nah an der Wildnis Glanfaths, dass wir jedes Jahr mehrere Opfer durch Bîaŵacs haben. Überlebende, die mit Komplikationen zu kämpfen haben. Dieser Mann hier ist ein schwerer Fall. Seine Essenz ist nur noch ein seidener Faden."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_bellasege.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_bellasege.stringtable
@@ -67,7 +67,7 @@ Sie läuft fast in dich hinein. "Eccosi! Nun suche ich so angestrengt in meiner 
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>"Ich scherze! Ihr Aedyraner seid so verspannt. Ich weiß nicht einmal, wofür das Ding verwendet wird. Es gehört wohl dem letzten Nutzer dieses Büros. Sie haben ihn hochgestuft, er hat jetzt seine eigene Zelle."
+      <DefaultText>"Ich scherze! Ihr Aedyrer seid so verspannt. Ich weiß nicht einmal, wofür das Ding verwendet wird. Es gehört wohl dem letzten Nutzer dieses Büros. Sie haben ihn hochgestuft, er hat jetzt seine eigene Zelle."
 
 "Und wieder. Ich scherze."</DefaultText>
       <FemaleText />
@@ -201,7 +201,7 @@ Sie lächelt dich breit an, wenn auch etwas bemüht. "Aber danke für das Angebo
     </Entry>
     <Entry>
       <ID>39</ID>
-      <DefaultText>"Tja, das ist das Wesen des Dyrwalds. Die Leute hier sind mächtig stolz auf ihre Souveränität. Dabei sind sie längst nicht so unabhängig von ihren aedyranischen Brüdern und ihren glanfathanischen Nachbarn, wie sie sich einreden. Sie verlassen sich zu sehr auf die unergründlichen Wege der Götter und fürchten genau jenen Fortschritt, den sie so nötig hätten."</DefaultText>
+      <DefaultText>"Tja, das ist das Wesen des Dyrwalds. Die Leute hier sind mächtig stolz auf ihre Souveränität. Dabei sind sie längst nicht so unabhängig von ihren aedyrischen Brüdern und ihren glanfathanischen Nachbarn, wie sie sich einreden. Sie verlassen sich zu sehr auf die unergründlichen Wege der Götter und fürchten genau jenen Fortschritt, den sie so nötig hätten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -554,7 +554,7 @@ Er hält einen Finger an seine Lippen, seine Augen weit und flehend. "Bitte. Ich
     <Entry>
       <ID>108</ID>
       <DefaultText>"Mir fallen selten Dinge auf, die nichts mit meiner Arbeit zu tun haben. Selbst, wenn sie direkt vor mir liegen. Sientere aimico, aber ich bin wahrlich nicht die beste Wahl, um dir dabei zu helfen."</DefaultText>
-      <FemaleText />
+      <FemaleText>"Mir fallen selten Dinge auf, die nichts mit meiner Arbeit zu tun haben. Selbst, wenn sie direkt vor mir liegen. Sientere aimica, aber ich bin wahrlich nicht die beste Wahl, um dir dabei zu helfen."</FemaleText>
     </Entry>
     <Entry>
       <ID>109</ID>

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_caedman_azo.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_caedman_azo.stringtable
@@ -213,7 +213,7 @@ Er nickt Azo zu und berührt zum Gruß seine Augenklappe. "Würden wir nur die e
     </Entry>
     <Entry>
       <ID>94</ID>
-      <DefaultText>"Was, wenn es für immer Hohlgeburten geben wird? Was, wenn Generation um Generation mit diesem Grauen konfrontiert ist? Wenn sich all das aufhalten ließe, indem man ein paar Dyrwäldler auf dem Altar der Wissenschaft opfert ... " Sein Gesicht verzieht sich zu einem gequälten Lächeln. "Dann kann ich an seiner Ethik nichts aussetzen."</DefaultText>
+      <DefaultText>"Was, wenn es für immer Hohlgeburten geben wird? Was, wenn Generation um Generation mit diesem Grauen konfrontiert ist? Wenn sich all das aufhalten ließe, indem man ein paar Dyrwälder auf dem Altar der Wissenschaft opfert ... " Sein Gesicht verzieht sich zu einem gequälten Lächeln. "Dann kann ich an seiner Ethik nichts aussetzen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_edmar_doemenel.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_edmar_doemenel.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Fürst Gedmar Doemenel ist ein Mann mit Ausstrahlung. Er trägt edle Kleider im Stil des aedyranischen Adels, doch die Narben auf seinen Handknöcheln und die Brandwunden auf seinem Hals sieht man bei Hochgeborenen eher selten.</DefaultText>
+      <DefaultText>Fürst Gedmar Doemenel ist ein Mann mit Ausstrahlung. Er trägt edle Kleider im Stil des aedyrischen Adels, doch die Narben auf seinen Handknöcheln und die Brandwunden auf seinem Hals sieht man bei Hochgeborenen eher selten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -303,7 +303,7 @@
     </Entry>
     <Entry>
       <ID>94</ID>
-      <DefaultText>Fürst Gedmar Doemenel ist ein Mann mit Ausstrahlung. Er trägt edle Kleider im Stil des aedyranischen Adels, doch die Narben auf seinen Handknöcheln und die Brandwunden auf seinem Hals sieht man bei Hochgeborenen eher selten.</DefaultText>
+      <DefaultText>Fürst Gedmar Doemenel ist ein Mann mit Ausstrahlung. Er trägt edle Kleider im Stil des aedyrischen Adels, doch die Narben auf seinen Handknöcheln und die Brandwunden auf seinem Hals sieht man bei Hochgeborenen eher selten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -454,7 +454,7 @@ Er nickt dir langsam zu. "Du wirst dich noch freuen, die siegreiche Seite gewäh
     </Entry>
     <Entry>
       <ID>123</ID>
-      <DefaultText>"Für ein Volk mit einer so kurzen Geschichte haben wir Dyrwäldler ein langes Gedächtnis. Meine Ahnen waren nicht mehr in denselben Kreisen willkommen, also mussten sie sich anpassen." Er reibt die Fingerkuppen seiner Seidenhandschuhe aneinander.
+      <DefaultText>"Für ein Volk mit einer so kurzen Geschichte haben wir Dyrwälder ein langes Gedächtnis. Meine Ahnen waren nicht mehr in denselben Kreisen willkommen, also mussten sie sich anpassen." Er reibt die Fingerkuppen seiner Seidenhandschuhe aneinander.
 
 "Letztlich hat es ein gutes Ende für uns genommen. Wir sind in eine einzigartige Stellung als Meister des Schwarzhandels in Trutzbucht aufgestiegen. Und damit ging eine etwas andere Art der Macht einher."</DefaultText>
       <FemaleText />

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_ethelmoer.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_ethelmoer.stringtable
@@ -118,7 +118,7 @@ Sie strahlt eine starke Wärme aus, die du auch am anderen Ende des Raumes spür
       <ID>36</ID>
       <DefaultText>"Eine Geschichtsstunde? Welch seltenes Vergnügen. Die meisten, die herkommen, möchten nur dem Tod ein Schnippchen schlagen."
 
-"Wir sind eine alte Institution, für dyrwaldsche Verhältnisse. Wir befinden uns in unserem 94. Jahr. Wie es in so vielen Städten der Fall ist, brachte das Wachstum von Trutzbucht eine ganze Reihe von Problemen mit sich. Eines der schlimmsten war, dass jene, die mit ... sagen wir ... unglücklichen Seelen geboren wurden, in Scharen die Straßen bevölkerten. Daher das Sanatorium."</DefaultText>
+"Wir sind eine alte Institution, für dyrwälderische Verhältnisse. Wir befinden uns in unserem 94. Jahr. Wie es in so vielen Städten der Fall ist, brachte das Wachstum von Trutzbucht eine ganze Reihe von Problemen mit sich. Eines der schlimmsten war, dass jene, die mit ... sagen wir ... unglücklichen Seelen geboren wurden, in Scharen die Straßen bevölkerten. Daher das Sanatorium."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_kurren.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_kurren.stringtable
@@ -304,7 +304,7 @@
       <ID>77</ID>
       <DefaultText>Er hält die Seite, scheint jedoch durch die Worte hindurchzustarren, als wäre etwas in das Papier eingewebt. 
 
-Kurren lässt seine spitzen Zähne aufblitzen. "Ich erinnere mich an Penhelm. Ein eitler Pfau von einem Mann, sein Mund trocken und seine Hände feucht, als ich ihm sagte, er sei ein Seelennachkomme eines aedyranischen Generals. Eines Generals, der gegen Hadrets Rebellion kämpfte."</DefaultText>
+Kurren lässt seine spitzen Zähne aufblitzen. "Ich erinnere mich an Penhelm. Ein eitler Pfau von einem Mann, sein Mund trocken und seine Hände feucht, als ich ihm sagte, er sei ein Seelennachkomme eines aedyrischen Generals. Eines Generals, der gegen Hadrets Rebellion kämpfte."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_lady_webb.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_lady_webb.stringtable
@@ -44,7 +44,7 @@ Sie blickt zum ersten Mal auf und mustert dich. "Das ist also die Wächterin, di
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>"Ich weiß auch von deinem kleinen Ausflug in eine engwithanische Ruine nahe Dyrfurt, deren Betreten allen Dyrwäldlern strengstens verboten ist. Nur das Warum ist mir ein Rätsel."</DefaultText>
+      <DefaultText>"Ich weiß auch von deinem kleinen Ausflug in eine engwithanische Ruine nahe Dyrfurt, deren Betreten allen Dyrwäldern strengstens verboten ist. Nur das Warum ist mir ein Rätsel."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -505,7 +505,7 @@ Ihre Mundwinkel zucken. "Er muss rasend sein vor Zorn."</DefaultText>
     </Entry>
     <Entry>
       <ID>116</ID>
-      <DefaultText>"Und wir versuchen, erleuchtet zu sein, um ihretwillen. Das Wissen, das wir hier sammeln, ist das stehende Heer des Dyrwalds, in vielerlei Hinsicht. Wir erfahren die wesentlichen Dinge und handeln entsprechend, während die Dyrwäldler schlafen, in seliger Unkenntnis der furchterregenden Wahrheiten um sie herum."
+      <DefaultText>"Und wir versuchen, erleuchtet zu sein, um ihretwillen. Das Wissen, das wir hier sammeln, ist das stehende Heer des Dyrwalds, in vielerlei Hinsicht. Wir erfahren die wesentlichen Dinge und handeln entsprechend, während die Dyrwälder schlafen, in seliger Unkenntnis der furchterregenden Wahrheiten um sie herum."
 
 "Manchmal wünsche ich mir, ich könnte den Leuten sagen, was ich weiß. Aber nicht viele wären in der Lage, es zu ertragen."</DefaultText>
       <FemaleText />

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_lord_reymont.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_lord_reymont.stringtable
@@ -135,7 +135,7 @@ Er reibt sich das Kinn. "In letzter Zeit versuchen sie, sich eine eigene Nische 
     </Entry>
     <Entry>
       <ID>41</ID>
-      <DefaultText>"Das Herz der Weißmark ist ein nahezu makelloser Diamant. Außerdem ist es das Erbvermögen der Zwerge der Weißmark. Es wurde in der Frühzeit der Kolonialisierung von einem aedyranischen Fürst gestohlen, und die Zwerge haben es nicht vergessen. Nun wollen die Ritter und die Dutzenden es beide kaufen, um es den Zwergen als Zeichen des Friedens zu überreichen."
+      <DefaultText>"Das Herz der Weißmark ist ein nahezu makelloser Diamant. Außerdem ist es das Erbvermögen der Zwerge der Weißmark. Es wurde in der Frühzeit der Kolonialisierung von einem aedyrischen Fürst gestohlen, und die Zwerge haben es nicht vergessen. Nun wollen die Ritter und die Dutzenden es beide kaufen, um es den Zwergen als Zeichen des Friedens zu überreichen."
 
 Er zuckt mit den Achseln. "Wer es letztlich auch kauft, die Zwerge werden nützliche Verbündete für Trutzbucht darstellen. Besonders in den heutigen Zeiten."</DefaultText>
       <FemaleText />

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_nedyn.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_nedyn.stringtable
@@ -400,7 +400,7 @@ Sie nimmt das alte Buch und hält es schützend vor ihre Brust. Sie blickt auf d
     </Entry>
     <Entry>
       <ID>124</ID>
-      <DefaultText>"Ich glaube nicht, dass die Dyrwäldler das als großen Spaß ansehen würden."</DefaultText>
+      <DefaultText>"Ich glaube nicht, dass die Dyrwälder das als großen Spaß ansehen würden."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_bs_aefre_prisoner.stringtable
+++ b/text/conversations/06_stronghold/06_bs_aefre_prisoner.stringtable
@@ -16,7 +16,7 @@
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>"Dann bist du also ein echter Fürst, genau so tyrannisch wie die aedyranischen Bastarde."</DefaultText>
+      <DefaultText>"Dann bist du also ein echter Fürst, genau so tyrannisch wie die aedyrischen Bastarde."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_cv_jailer.stringtable
+++ b/text/conversations/06_stronghold/06_cv_jailer.stringtable
@@ -51,7 +51,7 @@
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>"Ich möchte Lücen freilassen."</DefaultText>
+      <DefaultText>"Ich möchte Lucen freilassen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_cv_maerwald.stringtable
+++ b/text/conversations/06_stronghold/06_cv_maerwald.stringtable
@@ -278,7 +278,7 @@ Er sieht dich verloren und mit hängenden Augenlidern an. "Kein Schlaf. Kein Sch
     </Entry>
     <Entry>
       <ID>52</ID>
-      <DefaultText>"Krieg des Baums ... Ach, natürlich - der Krieg des Zerbrochenen Steins und der Krieg der Schwarzen Bäume. Das war in der Frühzeit der aedyranischen Kolonialisierung. Kämpfe zwischen den dyrwäldischen Kolonisten und den eingeborenen Glanfathanern. Aber ... das war vor langer Zeit ..."</DefaultText>
+      <DefaultText>"Krieg des Baums ... Ach, natürlich - der Krieg des Zerbrochenen Steins und der Krieg der Schwarzen Bäume. Das war in der Frühzeit der aedyrischen Kolonialisierung. Kämpfe zwischen den dyrwälderischen Kolonisten und den eingeborenen Glanfathanern. Aber ... das war vor langer Zeit ..."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_cv_steward.stringtable
+++ b/text/conversations/06_stronghold/06_cv_steward.stringtable
@@ -35,7 +35,7 @@
     </Entry>
     <Entry>
       <ID>25</ID>
-      <DefaultText>"Jeder Versuch, hier eine Siedlung zu etablieren, ist fehlgeschlagen - seit der Zeit unserer aedryanischen Kolonisten. Von den Endlosen Pfaden erheben sich Biester, bis der neue Herr oder die neue Herrin nicht mehr ist. Der in der Tiefe lebt, dieser ... 'Meister' scheint keine Rivalen zu tolerieren. Von Zeit zu Zeit habe ich furchtlose Entdecker gesehen, die für Antworten in die Tiefe gestiegen sind ... und niemals wiedergekehrt sind." 
+      <DefaultText>"Jeder Versuch, hier eine Siedlung zu etablieren, ist fehlgeschlagen - seit der Zeit unserer aedyrischen Kolonisten. Von den Endlosen Pfaden erheben sich Biester, bis der neue Herr oder die neue Herrin nicht mehr ist. Der in der Tiefe lebt, dieser ... 'Meister' scheint keine Rivalen zu tolerieren. Von Zeit zu Zeit habe ich furchtlose Entdecker gesehen, die für Antworten in die Tiefe gestiegen sind ... und niemals wiedergekehrt sind." 
 
 "Das ist die Macht, die verhindert, dass aus Caed Nua mehr als eine nutzlose Ruine wird ... und die mich all meiner Hoffnungen beraubt hat."</DefaultText>
       <FemaleText />
@@ -62,7 +62,7 @@
     </Entry>
     <Entry>
       <ID>30</ID>
-      <DefaultText>"Kein Lebender weiß, wie tief nach unten sich die Tunnel erstrecken, und nur wenige, die dorthin gegangen sind, kehrten wieder. Es gibt viel Gerede über Reichtümer und Schätze ... allein die Aussicht auf Engwithan-Reliquien hat viele Glücksritter angelockt. Und in ihren Tod, fürchte ich."</DefaultText>
+      <DefaultText>"Kein Lebender weiß, wie tief nach unten sich die Tunnel erstrecken, und nur wenige, die dorthin gegangen sind, kehrten wieder. Es gibt viel Gerede über Reichtümer und Schätze ... allein die Aussicht auf engwithanische Reliquien hat viele Glücksritter angelockt. Und in ihren Tod, fürchte ich."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -863,7 +863,7 @@ Als du dich näherst, spürst du, wie die Wärme fluktuiert, als ob sie in Beweg
     </Entry>
     <Entry>
       <ID>189</ID>
-      <DefaultText>"Die Endlosen Pfade! Dorthin muss ich - dorthin müssen wir, wenn du mich begleitest. Welche Teufel auch dort laufen ... bedenke auch, welches Wissen wir finden werden! ... Vielleicht spricht dieser Meister Aedyranisch?"</DefaultText>
+      <DefaultText>"Die Endlosen Pfade! Dorthin muss ich - dorthin müssen wir, wenn du mich begleitest. Welche Teufel auch dort laufen ... bedenke auch, welches Wissen wir finden werden! ... Vielleicht spricht dieser Meister Aedyrisch?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_cv_warden.stringtable
+++ b/text/conversations/06_stronghold/06_cv_warden.stringtable
@@ -145,7 +145,7 @@
     </Entry>
     <Entry>
       <ID>28</ID>
-      <DefaultText>"Ich weiß nicht recht, was ich hiermit anfangen soll. Ein mörderischer Druidenkult, angeführt von einer Menpwgra. Die Kreatur wird Devŵen genannt - und offenbar hat sie sich mit ihren Anhängern in einer Höhle in der Nordlandschaft niedergelassen."</DefaultText>
+      <DefaultText>"Ich weiß nicht recht, was ich hiermit anfangen soll. Ein mörderischer Druidenkult, angeführt von einer Mênpŵgra. Die Kreatur wird Devŵen genannt - und offenbar hat sie sich mit ihren Anhängern in einer Höhle in der Nordlandschaft niedergelassen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_cv_warden.stringtable
+++ b/text/conversations/06_stronghold/06_cv_warden.stringtable
@@ -140,7 +140,7 @@
     </Entry>
     <Entry>
       <ID>27</ID>
-      <DefaultText>"Das hier wird nicht leicht. Galen Dalgard, der Sklaventreiber. Er wurde mit seinen Freunden bei der Madhamr-Brücke gesehen. Die örtlichen Behörden weigern sich, gegen ihn vorzugehen, weil er mächtige Freunde in Aedyr hat. Aber irgendeine namenlose Seele, ist bereit, Geld dafür zu bezahlen, dass Galen seinen letzten Atemzug tut. Es ist offenbar etwas Persönliches."</DefaultText>
+      <DefaultText>"Das hier wird nicht leicht. Galen Dalgard, der Sklaventreiber. Er wurde mit seinen Freunden bei der Madhmr-Brücke gesehen. Die örtlichen Behörden weigern sich, gegen ihn vorzugehen, weil er mächtige Freunde in Aedyr hat. Aber irgendeine namenlose Seele, ist bereit, Geld dafür zu bezahlen, dass Galen seinen letzten Atemzug tut. Es ist offenbar etwas Persönliches."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_bs_gv_ambients_raedric.stringtable
+++ b/text/conversations/07_gilded_vale/07_bs_gv_ambients_raedric.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>"Diese Wachen haben Glück, dass wir sie ihrem aedyranischen Tyrannen nicht gleich hinterhergeschickt haben."</DefaultText>
+      <DefaultText>"Diese Wachen haben Glück, dass wir sie ihrem aedyrischen Tyrannen nicht gleich hinterhergeschickt haben."</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/07_gilded_vale/07_cv_berath_paladin_generic.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_berath_paladin_generic.stringtable
@@ -101,7 +101,7 @@
     </Entry>
     <Entry>
       <ID>21</ID>
-      <DefaultText>"Ich war bei Osyra. Sie brauchte jemanden, um mehr Vorräte zu holen."</DefaultText>
+      <DefaultText>"Ich war bei Osrya. Sie brauchte jemanden, um mehr Vorräte zu holen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_berath_priest_generic.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_berath_priest_generic.stringtable
@@ -101,7 +101,7 @@
     </Entry>
     <Entry>
       <ID>21</ID>
-      <DefaultText>"Ich war bei Osyra. Sie brauchte jemanden, um mehr Vorräte zu holen."</DefaultText>
+      <DefaultText>"Ich war bei Osrya. Sie brauchte jemanden, um mehr Vorräte zu holen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_berath_priestess_generic.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_berath_priestess_generic.stringtable
@@ -101,7 +101,7 @@
     </Entry>
     <Entry>
       <ID>21</ID>
-      <DefaultText>"Ich war bei Osyra. Sie brauchte jemanden, um mehr Vorräte zu holen."</DefaultText>
+      <DefaultText>"Ich war bei Osrya. Sie brauchte jemanden, um mehr Vorräte zu holen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_giacco.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_giacco.stringtable
@@ -86,7 +86,7 @@
     </Entry>
     <Entry>
       <ID>18</ID>
-      <DefaultText>"Erzähl mir von Osyra."</DefaultText>
+      <DefaultText>"Erzähl mir von Osrya."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_kolsc.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_kolsc.stringtable
@@ -446,7 +446,7 @@
     </Entry>
     <Entry>
       <ID>129</ID>
-      <DefaultText>"Er ist Raedric VII., ein Abkömmling des großen aedyranischen Hauses, das sich während der Revolution mit dem Dyrwald verbündet hat. Seit dieser Zeit sind die Raedrics die Verwalter von Goldtal gewesen. Früher waren sie ihrer Verantwortung würdig."</DefaultText>
+      <DefaultText>"Er ist Raedric VII., ein Abkömmling des großen aedyrischen Hauses, das sich während der Revolution mit dem Dyrwald verbündet hat. Seit dieser Zeit sind die Raedrics die Verwalter von Goldtal gewesen. Früher waren sie ihrer Verantwortung würdig."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -556,7 +556,7 @@
     </Entry>
     <Entry>
       <ID>151</ID>
-      <DefaultText>"Fürst Raedric ist eindeutig verrückt, aber ich glaube nicht, dass die Ducs meine Beteiligung an einem dyrwäldlerischen Putsch schätzen würden ... "</DefaultText>
+      <DefaultText>"Fürst Raedric ist eindeutig verrückt, aber ich glaube nicht, dass die Ducs meine Beteiligung an einem dyrwälderischen Putsch schätzen würden ... "</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_magistrate_urgeat.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_magistrate_urgeat.stringtable
@@ -165,7 +165,7 @@ Er schätzt dich über halbmondförmige Augengläser ab und kratzt sich am Kinn.
     </Entry>
     <Entry>
       <ID>37</ID>
-      <DefaultText>"Er stammt aus einer Adelsfamilie, die diese Lande seit Aedyr-Zeiten verteidigt haben. Raedric II. war während der Revolution ein früher Unterstützer der dyrwäldlerischen Unabhängigkeit, und der Vater der derzeitigen Fürsten fiel im Krieg des Heiligen."
+      <DefaultText>"Er stammt aus einer Adelsfamilie, die diese Lande seit Aedyr-Zeiten verteidigt haben. Raedric II. war während der Revolution ein früher Unterstützer der dyrwälderischen Unabhängigkeit, und der Vater der derzeitigen Fürsten fiel im Krieg des Heiligen."
 
 "Kurz nach dem Ende des Kriegs setzten die Hohlgeburten im Dyrwald ein."</DefaultText>
       <FemaleText />
@@ -194,7 +194,7 @@ Er schätzt dich über halbmondförmige Augengläser ab und kratzt sich am Kinn.
     </Entry>
     <Entry>
       <ID>42</ID>
-      <DefaultText>"Der Krieg dauerte ungefähr ein Jahr, aber du kannst dir vorstellen, was dieses Jahr mit der Verehrung von Eothas im Dyrwald anstellte. Alle von Fürst Raedrics Vorfahren sind Eothasianer gewesen, aber nachdem sein Vater bei unserer Verteidigung gegen diese Fanatiker gefallen war, kümmerte er sich persönlich darum, dass der Eothas-Tempel hier im Dorf stillgelegt wurde." Er deutet auf ein paar Mauerruinen neben dem Baum.</DefaultText>
+      <DefaultText>"Der Krieg dauerte ungefähr ein Jahr, aber du kannst dir vorstellen, was dieses Jahr mit der Verehrung von Eothas im Dyrwald anstellte. Alle von Fürst Raedrics Vorfahren sind Eothasier gewesen, aber nachdem sein Vater bei unserer Verteidigung gegen diese Fanatiker gefallen war, kümmerte er sich persönlich darum, dass der Eothas-Tempel hier im Dorf stillgelegt wurde." Er deutet auf ein paar Mauerruinen neben dem Baum.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -437,7 +437,7 @@ Eine merkwürdige Zuckung zieht sich über sein Gesicht, und seine Mundwinkel ve
       <ID>93</ID>
       <DefaultText>"Mir wurde bestätigt, dass Fürst Raedrics Erbe nicht ... gesund geboren wurde."
 
-"Mein Fürst hat einen Unterlassungsbefehl auf alle neuen Heimstätten erteilt, bis er sicher sein kann, dass das Dorf von Eothasianern und allen sonstigen Unerwünschten gesäubert wurde, die diesen Fluch über seine Lande gebracht haben."</DefaultText>
+"Mein Fürst hat einen Unterlassungsbefehl auf alle neuen Heimstätten erteilt, bis er sicher sein kann, dass das Dorf von Eothasiern und allen sonstigen Unerwünschten gesäubert wurde, die diesen Fluch über seine Lande gebracht haben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_nedmar.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_nedmar.stringtable
@@ -76,12 +76,12 @@
     </Entry>
     <Entry>
       <ID>18</ID>
-      <DefaultText>"Selbst der arme Giacco ... Ich dachte, dass wenigstens er gerettet werden könnte. Jetzt aber gehört er Osyra. Nachschub ist er, für ihre Experimente." Er beugt seinen Kopf und stützt sich mit seinen zitternden Händen auf dem Tisch ab. "Ich bin nur knapp der Verdächtigung entgangen."</DefaultText>
+      <DefaultText>"Selbst der arme Giacco ... Ich dachte, dass wenigstens er gerettet werden könnte. Jetzt aber gehört er Osrya. Nachschub ist er, für ihre Experimente." Er beugt seinen Kopf und stützt sich mit seinen zitternden Händen auf dem Tisch ab. "Ich bin nur knapp der Verdächtigung entgangen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>19</ID>
-      <DefaultText>"Du erwähntest Osyras Experimente?"</DefaultText>
+      <DefaultText>"Du erwähntest Osryas Experimente?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -151,7 +151,7 @@
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>"Ich ... flehte Fürst Raedric für meinen Akolythen um Vergebung an, aber ich glaube, dass ich Giaccos Schicksal auf diese Weise nur hinausgezögert habe." Er schüttelt seinen Kopf. "Jetzt ist er Osyra schutzlos ausgeliefert."</DefaultText>
+      <DefaultText>"Ich ... flehte Fürst Raedric für meinen Akolythen um Vergebung an, aber ich glaube, dass ich Giaccos Schicksal auf diese Weise nur hinausgezögert habe." Er schüttelt seinen Kopf. "Jetzt ist er Osrya schutzlos ausgeliefert."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -161,7 +161,7 @@
     </Entry>
     <Entry>
       <ID>35</ID>
-      <DefaultText>"Wenn du ihn aber sicher außer Reichweite von Osyra bringt, so verspreche ich dir, dass ich mein Bestes geben werde, um dir zu helfen." Er sieht sich vorsichtig im Zimmer um.</DefaultText>
+      <DefaultText>"Wenn du ihn aber sicher außer Reichweite von Osrya bringt, so verspreche ich dir, dass ich mein Bestes geben werde, um dir zu helfen." Er sieht sich vorsichtig im Zimmer um.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -191,7 +191,7 @@
     </Entry>
     <Entry>
       <ID>41</ID>
-      <DefaultText>"Sei vorsichtig. Osyra beherrscht mächtige Magie, außerdem hat sie eine Vorliebe für grausame Fallen. Wenn du sie verärgerst, wirst sie dir sicherlich zu einer schrecklichen Feindin gereichen." Nedmar presst seine Hände zusammen. "Mögen dich die Götter leiten."</DefaultText>
+      <DefaultText>"Sei vorsichtig. Osrya beherrscht mächtige Magie, außerdem hat sie eine Vorliebe für grausame Fallen. Wenn du sie verärgerst, wirst sie dir sicherlich zu einer schrecklichen Feindin gereichen." Nedmar presst seine Hände zusammen. "Mögen dich die Götter leiten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -356,7 +356,7 @@
     </Entry>
     <Entry>
       <ID>76</ID>
-      <DefaultText>[Angreifen.] "Osyra bestellt dir ihre Grüße."</DefaultText>
+      <DefaultText>[Angreifen.] "Osrya bestellt dir ihre Grüße."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_osrya.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_osrya.stringtable
@@ -91,12 +91,12 @@
     </Entry>
     <Entry>
       <ID>24</ID>
-      <DefaultText>Osyra kneift ihre Augen zusammen, aber ihr Lächeln wird breiter. "Na, wir sind aber ganz schon dreist, was?"</DefaultText>
+      <DefaultText>Osrya kneift ihre Augen zusammen, aber ihr Lächeln wird breiter. "Na, wir sind aber ganz schon dreist, was?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>25</ID>
-      <DefaultText>"Du musst noch einer von Kolscs kleinen Rebellen sein.", sagt Osyra kichernd. "Rekrutiert er euch denn alle im Schwarzen Hund? Überzeugt er euch mit Met? Bittet er euch, die Konsequenzen eurer Taten zu ignorieren?"</DefaultText>
+      <DefaultText>"Du musst noch einer von Kolscs kleinen Rebellen sein.", sagt Osrya kichernd. "Rekrutiert er euch denn alle im Schwarzen Hund? Überzeugt er euch mit Met? Bittet er euch, die Konsequenzen eurer Taten zu ignorieren?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -121,8 +121,8 @@
     </Entry>
     <Entry>
       <ID>30</ID>
-      <DefaultText>"Du ... " Osyras Gesicht wird dunkel vor Wut. "Dieser wichtigtuerische alte Narr. Er wagt es, einen Botenjungen hier herunter in mein Labor zu schicken? Für was? Um seinen kleinen Schützling zu retten?"</DefaultText>
-      <FemaleText>"Du ... " Osyras Gesicht wird dunkel vor Wut. "Dieser wichtigtuerische alte Narr. Er wagt es, ein Botenmädchen hier herunter in mein Labor zu schicken? Für was? Um seinen kleinen Schützling zu retten?"</FemaleText>
+      <DefaultText>"Du ... " Osryas Gesicht wird dunkel vor Wut. "Dieser wichtigtuerische alte Narr. Er wagt es, einen Botenjungen hier herunter in mein Labor zu schicken? Für was? Um seinen kleinen Schützling zu retten?"</DefaultText>
+      <FemaleText>"Du ... " Osryas Gesicht wird dunkel vor Wut. "Dieser wichtigtuerische alte Narr. Er wagt es, ein Botenmädchen hier herunter in mein Labor zu schicken? Für was? Um seinen kleinen Schützling zu retten?"</FemaleText>
     </Entry>
     <Entry>
       <ID>31</ID>

--- a/text/conversations/07_gilded_vale/07_cv_sweynur.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_sweynur.stringtable
@@ -286,7 +286,7 @@
     </Entry>
     <Entry>
       <ID>63</ID>
-      <DefaultText>"Ha! Glaubst du etwa, zu ihm durchzukommen, wo wir es auch nicht geschafft haben? Der Mann ist so dumm wie ein Torfmoor. Ich habe gehört, dass er sich die Seele lesen ließ und herausgefunden hat, dass seine Verwandten Sonnread-Bäume für ihre aedyranischen Fürsten anbauen, bis sie herausfanden, dass ihre Seite am Verlieren war. Das erklärt auch, warum seine Knie immer noch schmerzen, wenn ein Fürst oder eine Lady über die Straße geht und er sich verbeugen soll."</DefaultText>
+      <DefaultText>"Ha! Glaubst du etwa, zu ihm durchzukommen, wo wir es auch nicht geschafft haben? Der Mann ist so dumm wie ein Torfmoor. Ich habe gehört, dass er sich die Seele lesen ließ und herausgefunden hat, dass seine Verwandten Sonnread-Bäume für ihre aedyrischen Fürsten anbauen, bis sie herausfanden, dass ihre Seite am Verlieren war. Das erklärt auch, warum seine Knie immer noch schmerzen, wenn ein Fürst oder eine Lady über die Straße geht und er sich verbeugen soll."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_wirtan.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_wirtan.stringtable
@@ -106,7 +106,7 @@
     </Entry>
     <Entry>
       <ID>35</ID>
-      <DefaultText>"Wie du meinst. Als das Vermächtnis anfing, beschloss Fürst Raedric, dass er den Eothasianern gegenüber zu milde gestimmt war. Er hat sie von seinen Leuten allesamt im Tempel niedermachen, und sie da unten unter einem Haufen Felsen begraben liegen lassen."</DefaultText>
+      <DefaultText>"Wie du meinst. Als das Vermächtnis anfing, beschloss Fürst Raedric, dass er den Eothasiern gegenüber zu milde gestimmt war. Er hat sie von seinen Leuten allesamt im Tempel niedermachen, und sie da unten unter einem Haufen Felsen begraben liegen lassen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -523,7 +523,7 @@
     </Entry>
     <Entry>
       <ID>140</ID>
-      <DefaultText>"E-etwas Wertvolles, meinst du? Du kannst behalten, was du gefunden hast, ich ... ich will damit nichts zu tun haben. Niemand ist mehr dort unten gewesen, seit ... Raedrics Leute haben kein Interesse an eothasianischen Gütern, das meine ich. Was auch immer du nimmst, sie werden es nicht vermissen."</DefaultText>
+      <DefaultText>"E-etwas Wertvolles, meinst du? Du kannst behalten, was du gefunden hast, ich ... ich will damit nichts zu tun haben. Niemand ist mehr dort unten gewesen, seit ... Raedrics Leute haben kein Interesse an eothasischen Gütern, das meine ich. Was auch immer du nimmst, sie werden es nicht vermissen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -835,7 +835,7 @@
     </Entry>
     <Entry>
       <ID>205</ID>
-      <DefaultText>Er schaut Edér von unten an. "Zollst du deinen Respekt, Eothasianer?" Er bringt ein schmerzverzerrtes Grinsen zustande. "Ist das nicht ein bisschen riskant? Überlege dir nur, was die Dörfler sagen würden."</DefaultText>
+      <DefaultText>Er schaut Edér von unten an. "Zollst du deinen Respekt, Eothasier?" Er bringt ein schmerzverzerrtes Grinsen zustande. "Ist das nicht ein bisschen riskant? Überlege dir nur, was die Dörfler sagen würden."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -865,7 +865,7 @@
     </Entry>
     <Entry>
       <ID>213</ID>
-      <DefaultText>"Als das Vermächtnis anfing, beschloss Fürst Raedric, dass er den Eothasianern gegenüber zu milde gestimmt war. Er hat sie von seinen Leuten allesamt im Tempel niedermachen, und sie da unten unter einem Haufen Felsen begraben liegen lassen."</DefaultText>
+      <DefaultText>"Als das Vermächtnis anfing, beschloss Fürst Raedric, dass er den Eothasiern gegenüber zu milde gestimmt war. Er hat sie von seinen Leuten allesamt im Tempel niedermachen, und sie da unten unter einem Haufen Felsen begraben liegen lassen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/08_wilderness/08_cv_downwind_fang_leader.stringtable
+++ b/text/conversations/08_wilderness/08_cv_downwind_fang_leader.stringtable
@@ -25,7 +25,7 @@
       <ID>4</ID>
       <DefaultText>"Du solltest nicht hier sein, Estramor". Ihre Hand gleitet zu einer von mehreren Klingen, die sie um die Hüfte geschlungen hat. "Wenn du in unseren Landen bist, dann um uns zu bestehlen oder jenen zu helfen, die das vorhaben."
 
-Sie deutet nach Norden, auf die Ruinen engwithanischer Gebäude, die aus dem Unterholz aufragen. "Dyrwäldlerische Söldner. Plünderer. Hörst du ihr panisches Wispern? Verschwinde von hier, sofort. Oder wir werden dich töten, wenn wir mit diesen Estramorwn fertig sind."</DefaultText>
+Sie deutet nach Norden, auf die Ruinen engwithanischer Gebäude, die aus dem Unterholz aufragen. "Dyrwälderische Söldner. Plünderer. Hörst du ihr panisches Wispern? Verschwinde von hier, sofort. Oder wir werden dich töten, wenn wir mit diesen Estramorwn fertig sind."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -50,9 +50,9 @@ Sie deutet nach Norden, auf die Ruinen engwithanischer Gebäude, die aus dem Unt
     </Entry>
     <Entry>
       <ID>9</ID>
-      <DefaultText>"Räuber. Plünderer. Genau wie alle anderen dyrwäldischen Diebe, die unsere Lande bestehlen." Die Frau berührt den Stummel, der von ihrem Ohr übrig ist. 
+      <DefaultText>"Räuber. Plünderer. Genau wie alle anderen dyrwälderischen Diebe, die unsere Lande bestehlen." Die Frau berührt den Stummel, der von ihrem Ohr übrig ist. 
 
-"Wir haben die Dyrwäldler verfolgt, seit sie den großen Fluss überquert haben. Haben gewartet, bis sie fehlgehen. Das tun sie immer. Wir haben ihr halbes Rudel beim ersten Angriff besiegt. Die Feiglinge, die geflohen sind, verbergen sich jetzt im Norden - wenn der Wind sich dreht, kannst du ihre Angst riechen."</DefaultText>
+"Wir haben die Dyrwälder verfolgt, seit sie den großen Fluss überquert haben. Haben gewartet, bis sie fehlgehen. Das tun sie immer. Wir haben ihr halbes Rudel beim ersten Angriff besiegt. Die Feiglinge, die geflohen sind, verbergen sich jetzt im Norden - wenn der Wind sich dreht, kannst du ihre Angst riechen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -107,7 +107,7 @@ Sie tritt näher und legt ihre Hände auf deinen Nabel. Sie drückt gegen deinen
     </Entry>
     <Entry>
       <ID>18</ID>
-      <DefaultText>[Lügen] "Ich gehöre nicht zu irgendwelchen dyrwäldischen Söldnern. Ich weiß, wir sehen alle gleich aus, doch du täuschst dich."</DefaultText>
+      <DefaultText>[Lügen] "Ich gehöre nicht zu irgendwelchen dyrwälderischen Söldnern. Ich weiß, wir sehen alle gleich aus, doch du täuschst dich."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -129,12 +129,12 @@ Sie zieht eines ihrer Schwerter und deutet durch eine schnelle Bogenbewegung mit
     </Entry>
     <Entry>
       <ID>22</ID>
-      <DefaultText>"Dyrwäldische Plünderer teilen sich oft auf, um eine größere Fläche abzudecken, um unseren Patrouillen auszuweichen oder um von allen Seiten anzugreifen. Ich soll wirklich glauben, du wärest just in diesem Augenblick aus purem Zufall hier?" Sie presst den Kiefer zusammen, die Muskeln zittern.</DefaultText>
+      <DefaultText>"Dyrwälderische Plünderer teilen sich oft auf, um eine größere Fläche abzudecken, um unseren Patrouillen auszuweichen oder um von allen Seiten anzugreifen. Ich soll wirklich glauben, du wärest just in diesem Augenblick aus purem Zufall hier?" Sie presst den Kiefer zusammen, die Muskeln zittern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>23</ID>
-      <DefaultText>"Ich habe mich bereits um die Dyrwäldler gekümmert."</DefaultText>
+      <DefaultText>"Ich habe mich bereits um die Dyrwälder gekümmert."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/08_wilderness/08_cv_foelmar.stringtable
+++ b/text/conversations/08_wilderness/08_cv_foelmar.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>"Du brauchst nicht zufällig Vorräte? Ich wollte eigentlich zur Madhamr-Brücke, aber vielleicht ist es besser, ich gehe zurück in die Stadt und versammle noch einige Leute."</DefaultText>
+      <DefaultText>"Du brauchst nicht zufällig Vorräte? Ich wollte eigentlich zur Madhmr-Brücke, aber vielleicht ist es besser, ich gehe zurück in die Stadt und versammle noch einige Leute."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/08_wilderness/08_cv_gramrfel.stringtable
+++ b/text/conversations/08_wilderness/08_cv_gramrfel.stringtable
@@ -94,8 +94,8 @@ Vom Hals abwärts aber ist die Gestalt allem Anschein nach ein menschlicher Mann
     </Entry>
     <Entry>
       <ID>18</ID>
-      <DefaultText>"Ich bin Gramrfel, zuletzt wohnhaft auf aedyranischem Boden. Und dies", er deutet mit einer ausladenden Geste auf seine Kameraden, "sind meine fröhlichen Gefährten. Grins nicht so, Frysca, du machst ihm Angst."</DefaultText>
-      <FemaleText>"Ich bin Gramrfel, zuletzt wohnhaft auf aedyranischem Boden. Und dies", er deutet mit einer ausladenden Geste auf seine Kameraden, "sind meine fröhlichen Gefährten. Grins nicht so, Frysca, du machst ihr Angst."</FemaleText>
+      <DefaultText>"Ich bin Gramrfel, zuletzt wohnhaft auf aedyrischem Boden. Und dies", er deutet mit einer ausladenden Geste auf seine Kameraden, "sind meine fröhlichen Gefährten. Grins nicht so, Frysca, du machst ihm Angst."</DefaultText>
+      <FemaleText>"Ich bin Gramrfel, zuletzt wohnhaft auf aedyrischem Boden. Und dies", er deutet mit einer ausladenden Geste auf seine Kameraden, "sind meine fröhlichen Gefährten. Grins nicht so, Frysca, du machst ihr Angst."</FemaleText>
     </Entry>
     <Entry>
       <ID>19</ID>

--- a/text/conversations/10_od_nua/1003_si_aedyran_statue.stringtable
+++ b/text/conversations/10_od_nua/1003_si_aedyran_statue.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>Die Statue ist zwar alt, scheint aber nicht so verfallen wie die anderen Objekte an diesem Ort zu sein. Die Steinfigur trägt Kleidung im aedyranischen Stil, was nahelegt, dass sie ein Überbleibsel aus der Zeit der aedyranischen Kolonisierung ist. </DefaultText>
+      <DefaultText>Die Statue ist zwar alt, scheint aber nicht so verfallen wie die anderen Objekte an diesem Ort zu sein. Die Steinfigur trägt Kleidung im aedyrischen Stil, was nahelegt, dass sie ein Überbleibsel aus der Zeit der aedyrischen Kolonisierung ist. </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/10_od_nua/1012_cv_scouts.stringtable
+++ b/text/conversations/10_od_nua/1012_cv_scouts.stringtable
@@ -216,7 +216,7 @@
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>"Wie kann es sein, dass du Aedyranisch sprichst?"</DefaultText>
+      <DefaultText>"Wie kann es sein, dass du Aedyrisch sprichst?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/10_od_nua/1012_cv_vithrack_leader.stringtable
+++ b/text/conversations/10_od_nua/1012_cv_vithrack_leader.stringtable
@@ -226,7 +226,7 @@
     </Entry>
     <Entry>
       <ID>57</ID>
-      <DefaultText>"Sprichst du auch Aedyranisch?"</DefaultText>
+      <DefaultText>"Sprichst du auch Aedyrisch?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -286,7 +286,7 @@
     </Entry>
     <Entry>
       <ID>71</ID>
-      <DefaultText>"Ich glaube, du musst ein bisschen an deinem Aedyranisch arbeiten."</DefaultText>
+      <DefaultText>"Ich glaube, du musst ein bisschen an deinem Aedyrisch arbeiten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -366,7 +366,7 @@
     </Entry>
     <Entry>
       <ID>91</ID>
-      <DefaultText>"Das ist ein sehr alter Dialekt. Sprichst du auch Aedyranisch?"</DefaultText>
+      <DefaultText>"Das ist ein sehr alter Dialekt. Sprichst du auch Aedyrisch?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/10_od_nua/1015_cv_adra_dragon.stringtable
+++ b/text/conversations/10_od_nua/1015_cv_adra_dragon.stringtable
@@ -470,7 +470,7 @@ Der Drache harkt mit seinen Klauen über die Erde. "Natürlich liegen hier mehr 
     </Entry>
     <Entry>
       <ID>136</ID>
-      <DefaultText>"Ich war schon hier, bevor die Aedyraner noch den ersten Stein aufgehoben hatten. Ich bin älter als die Stufen, die dich hierher geführt haben. Ich bin an dieses ... lächerliche Denkmal gebunden, und du kannst es ebenso wenig beherrschen wie mich."</DefaultText>
+      <DefaultText>"Ich war schon hier, bevor die Aedyrer noch den ersten Stein aufgehoben hatten. Ich bin älter als die Stufen, die dich hierher geführt haben. Ich bin an dieses ... lächerliche Denkmal gebunden, und du kannst es ebenso wenig beherrschen wie mich."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/11_hearthsong/11_bs_glanfathan_reactives.stringtable
+++ b/text/conversations/11_hearthsong/11_bs_glanfathan_reactives.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>"Die Dyrwäldler können unsere heiligen Stätten nicht respektieren, wenn ihre eigenen Städte unter ihren Füßen zerfallen."</DefaultText>
+      <DefaultText>"Die Dyrwälder können unsere heiligen Stätten nicht respektieren, wenn ihre eigenen Städte unter ihren Füßen zerfallen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/11_hearthsong/11_bs_sapling_glanfathan.stringtable
+++ b/text/conversations/11_hearthsong/11_bs_sapling_glanfathan.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>"Die Dyrwäldler neigen doch zum recht ... großzügigen Trinken."</DefaultText>
+      <DefaultText>"Die Dyrwälder neigen doch zum recht ... großzügigen Trinken."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/11_hearthsong/11_bs_sapling_orlan.stringtable
+++ b/text/conversations/11_hearthsong/11_bs_sapling_orlan.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>"Ich hasse es, wie die Dyrwäldler immer über mich hinweg reden. Meine Augen sind hier unten, Estramor."</DefaultText>
+      <DefaultText>"Ich hasse es, wie die Dyrwälder immer über mich hinweg reden. Meine Augen sind hier unten, Estramor."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/11_hearthsong/11_cv_alarhi.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_alarhi.stringtable
@@ -134,7 +134,7 @@ Aus den Falten ihrer Robe zieht sie eine kleine Wurzel hervor und hält sie sich
     </Entry>
     <Entry>
       <ID>53</ID>
-      <DefaultText>"Wir sind keine barbarischen Dyrwäldler. Hier herrscht die Gastfreundschaft!" Alarhî nickt dir zu. Sie hält eine offene Hand hoch, ihre Handfläche und ihre Finger voller blauer und grüner Farbe.
+      <DefaultText>"Wir sind keine barbarischen Dyrwälder. Hier herrscht die Gastfreundschaft!" Alarhî nickt dir zu. Sie hält eine offene Hand hoch, ihre Handfläche und ihre Finger voller blauer und grüner Farbe.
 
 "Gesandter des Vailianers, sprich die Botschaft, die du überbringen sollst."</DefaultText>
       <FemaleText />

--- a/text/conversations/11_hearthsong/11_cv_anamfath_leader.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_anamfath_leader.stringtable
@@ -154,7 +154,7 @@ Die wütende Anamenfath zuckt zusammen.
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>"Ferwlts Warnung kam vor dem Krieg des Zerbrochenen Steins. Ferwlt - mein Vorfahre mütterlicherseits - war damals Anamfath unseres Stammes. Als die Estramorek-Bauern die Monumente der Erbauer schändeten, drängte Ferwlt die anderen Anamfatha zur Geduld."
+      <DefaultText>"Ferwlts Warnung kam vor dem Krieg des Zerbrochenen Steins. Ferwlt - mein Vorfahre mütterlicherseits - war damals Anamfath unseres Stammes. Als die Estramor-Bauern die Monumente der Erbauer schändeten, drängte Ferwlt die anderen Anamfatha zur Geduld."
 
 Sie faltet ihre, mit Klauen versehenen, Hände vor sich und schaut auf sie hinab. "Letztendlich setzten sich aber lautere, wütendere Stimmen durch."</DefaultText>
       <FemaleText />

--- a/text/conversations/11_hearthsong/11_cv_sapling_vailian.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_sapling_vailian.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>"Die Dyrwäldler servieren bessere Getränke, aber die Glanfathaner bauen Tavernen, die ich auch tatsächlich besuchen möchte."</DefaultText>
+      <DefaultText>"Die Dyrwälder servieren bessere Getränke, aber die Glanfathaner bauen Tavernen, die ich auch tatsächlich besuchen möchte."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/12_oldsong/12_cv_irensi.stringtable
+++ b/text/conversations/12_oldsong/12_cv_irensi.stringtable
@@ -100,7 +100,7 @@ Sie blickt die elegante Löwin an. "Danke, dass du diese Angelegenheit gelöst h
     </Entry>
     <Entry>
       <ID>26</ID>
-      <DefaultText>"Danke, dass du unseren Fehler erkannt hast. Wir haben Galwains Grundsätze vergessen, weil wir so begierig darauf waren, seine Schöpfung zu ehren."</DefaultText>
+      <DefaultText>"Danke, dass du unseren Fehler erkannt hast. Wir haben Galawains Grundsätze vergessen, weil wir so begierig darauf waren, seine Schöpfung zu ehren."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_galawain_coalition.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_galawain_coalition.stringtable
@@ -411,7 +411,7 @@ Ein vernarbter Stelgaer knurrt und zuckt mit dem Schwanz.
     </Entry>
     <Entry>
       <ID>87</ID>
-      <DefaultText>"Warum sollte ich die Essenz der verlorenen Seelen an den Rest des Drywalds weitergeben?"</DefaultText>
+      <DefaultText>"Warum sollte ich die Essenz der verlorenen Seelen an den Rest des Dyrwalds weitergeben?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_glanfathan_elms_locals_01.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_glanfathan_elms_locals_01.stringtable
@@ -61,7 +61,7 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>Ein Elf bewegt seine Hand in einem Bogen über den Boden. "Es ist geschehen." Am Ende der Bewegung verschließen sich seine Finger zu einer Faust. "Wir hätten es nicht vorhersehen können. Auch die Delemengan nicht."</DefaultText>
+      <DefaultText>Ein Elf bewegt seine Hand in einem Bogen über den Boden. "Es ist geschehen." Am Ende der Bewegung verschließen sich seine Finger zu einer Faust. "Wir hätten es nicht vorhersehen können. Auch die Delemgan nicht."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_simoc.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_simoc.stringtable
@@ -177,7 +177,7 @@ Ein Stelgaer reckt sich und lässt seine Krallen spielen.</DefaultText>
     </Entry>
     <Entry>
       <ID>40</ID>
-      <DefaultText>Er richtet seine zusammengesunkenen Schultern auf. "Ich habe im Krieg des Zerbrochenen Steins und im Krieg der Schwarzen Bäume gekämpft. Ich habe gesehen, wie meine Brüder niedergestreckt wurden, als sie die Stätten der Erbauer verteidigten, und ich habe neben Galven Rêgd selbst Blut vergossen."</DefaultText>
+      <DefaultText>Er richtet seine zusammengesunkenen Schultern auf. "Ich habe im Krieg des Zerbrochenen Steins und im Krieg der Schwarzen Bäume gekämpft. Ich habe gesehen, wie meine Brüder niedergestreckt wurden, als sie die Stätten der Erbauer verteidigten, und ich habe neben Galven Regd selbst Blut vergossen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -565,7 +565,7 @@ Hiravias verschränkt die Arme und zuckt mit den Schultern. "Er hat allen Grund,
     </Entry>
     <Entry>
       <ID>117</ID>
-      <DefaultText>"Eine zu harte Zusammenfassung, nach allem, was ich gelesen habe. Man muss zwischen den Zeilen lesen, die Berichte all der frustrierten aedryanischen Kommandanten über den unsichtbaren Feind, der ihre Truppen heimsucht. Ein wenig Sabotage und einige kluge Hinterhalte können in jedem Konflikt das Blatt wenden."</DefaultText>
+      <DefaultText>"Eine zu harte Zusammenfassung, nach allem, was ich gelesen habe. Man muss zwischen den Zeilen lesen, die Berichte all der frustrierten aedyrischen Kommandanten über den unsichtbaren Feind, der ihre Truppen heimsucht. Ein wenig Sabotage und einige kluge Hinterhalte können in jedem Konflikt das Blatt wenden."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/14_burial_isle/14_cv_iovara_2.stringtable
+++ b/text/conversations/14_burial_isle/14_cv_iovara_2.stringtable
@@ -278,7 +278,7 @@ Zum ersten Mal sind in ihrem ruhigen Antlitz Anzeichen von Zweifeln zu sehen.</D
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>"Wie kann es sein, dass du Aedyranisch sprichst?"</DefaultText>
+      <DefaultText>"Wie kann es sein, dass du Aedyrisch sprichst?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/14_burial_isle/14_cv_scathden.stringtable
+++ b/text/conversations/14_burial_isle/14_cv_scathden.stringtable
@@ -8,7 +8,7 @@
       <ID>1</ID>
       <DefaultText>Der Aumaua vor dir steht stolz und reglos dar. Er lächelt breit und zeigt dabei mehrere schiefe sowie fehlende Zähne. Sein Körper ist der eines jungen Mannes, doch sein erschöpftes und faltiges Gesicht scheint älter zu sein.
 
-Er ist in ein Sammelsurium aus zusammengeflickten Fellen und Pelzen von den unterschiedlichsten Tieren gekleidet. Von seinem Gürtel hängen mehrere blutige Skalps: Um Fingerknochen geflochtene Haarsträhnen von Menschen, Aedyranern, Zwergen und Orlanern.</DefaultText>
+Er ist in ein Sammelsurium aus zusammengeflickten Fellen und Pelzen von den unterschiedlichsten Tieren gekleidet. Von seinem Gürtel hängen mehrere blutige Skalps: Um Fingerknochen geflochtene Haarsträhnen von Menschen, Aedyrern, Zwergen und Orlanern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/14_burial_isle/voice_set_iovara.stringtable
+++ b/text/conversations/14_burial_isle/voice_set_iovara.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Moeth ixi anath."</DefaultText>
+      <DefaultText>"Moeith ixi anath."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/14_burial_isle/voice_set_thaos.stringtable
+++ b/text/conversations/14_burial_isle/voice_set_thaos.stringtable
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>"Moeth ixi anath."</DefaultText>
+      <DefaultText>"Moeith ixi anath."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_bs_aloth_banter.stringtable
+++ b/text/conversations/companions/companion_bs_aloth_banter.stringtable
@@ -106,7 +106,7 @@
     </Entry>
     <Entry>
       <ID>21</ID>
-      <DefaultText>"Könntest du das bitte nochmal auf Aedyranisch wiederholen? Und komm bitte noch ein bisschen näher, damit ich dich am Genick packen kann, wenn du das gesagt hast, was ich denke."</DefaultText>
+      <DefaultText>"Könntest du das bitte nochmal auf Aedyrisch wiederholen? Und komm bitte noch ein bisschen näher, damit ich dich am Genick packen kann, wenn du das gesagt hast, was ich denke."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_bs_hiravias_banter.stringtable
+++ b/text/conversations/companions/companion_bs_hiravias_banter.stringtable
@@ -56,7 +56,7 @@
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>"Hab ich schon mal getan. In meinem Fall war es ein Unfall. Machmal wache ich nachts noch auf und habe ein schlechtes Gewissen deswegen."</DefaultText>
+      <DefaultText>"Hab ich schon mal getan. In meinem Fall war es ein Unfall. Manchmal wache ich nachts noch auf und habe ein schlechtes Gewissen deswegen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_bs_kana_banter.stringtable
+++ b/text/conversations/companions/companion_bs_kana_banter.stringtable
@@ -126,7 +126,7 @@
     </Entry>
     <Entry>
       <ID>25</ID>
-      <DefaultText>"Das Komische an den Dyrwäldlern: Angesichts all des Feuers und Lichts behandelten sie ihn nur wie eine weitere Autoritätsperson."</DefaultText>
+      <DefaultText>"Das Komische an den Dyrwäldern: Angesichts all des Feuers und Lichts behandelten sie ihn nur wie eine weitere Autoritätsperson."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_bs_pallegina_banter.stringtable
+++ b/text/conversations/companions/companion_bs_pallegina_banter.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>"Edér, wie könnt ihr Eothasianer immer so optimistisch bleiben? Die Welt hat euereins nicht viel Grund zur Hoffnung gegeben."</DefaultText>
+      <DefaultText>"Edér, wie könnt ihr Eothasier immer so optimistisch bleiben? Die Welt hat euereins nicht viel Grund zur Hoffnung gegeben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -16,12 +16,12 @@
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>"Edér, wie hast du es geschafft, im Krieg des Heiligen zu kämpfen? Mir ist zu Ohren gekommen, dass die Einheimischen ihren eothasianischen Landsleuten nicht über den Weg trauten."</DefaultText>
+      <DefaultText>"Edér, wie hast du es geschafft, im Krieg des Heiligen zu kämpfen? Mir ist zu Ohren gekommen, dass die Einheimischen ihren eothasischen Landsleuten nicht über den Weg trauten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>"Aloth, ich habe noch nie einen aedyranischen Mann getroffen, der so damit zögerte, seine Meinung zu sagen."</DefaultText>
+      <DefaultText>"Aloth, ich habe noch nie einen aedyrischen Mann getroffen, der so damit zögerte, seine Meinung zu sagen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -31,7 +31,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>"Aloth, du bist doch ein Aedyraner, oder? Du spricht mit dem Akzent eines Einheimischen des Cythwalds."</DefaultText>
+      <DefaultText>"Aloth, du bist doch ein Aedyrer, oder? Du spricht mit dem Akzent eines Einheimischen des Cythwalds."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -216,7 +216,7 @@
     </Entry>
     <Entry>
       <ID>44</ID>
-      <DefaultText>"Was für eine Schande, dass du und deine Familie noch immer litten, als der Krieg des Heiligen schon vorbei war. Ihr Dyrwäldler habt in der Tat eine Gabe dafür, vergangene Zwistigkeiten nicht zu vergessen."</DefaultText>
+      <DefaultText>"Was für eine Schande, dass du und deine Familie noch immer litten, als der Krieg des Heiligen schon vorbei war. Ihr Dyrwälder habt in der Tat eine Gabe dafür, vergangene Zwistigkeiten nicht zu vergessen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_bs_sagani_banter.stringtable
+++ b/text/conversations/companions/companion_bs_sagani_banter.stringtable
@@ -141,7 +141,7 @@
     </Entry>
     <Entry>
       <ID>28</ID>
-      <DefaultText>"Ich stimme zu. Dyrwäldler versalzen alles und ertränken es dann in Soße."</DefaultText>
+      <DefaultText>"Ich stimme zu. Dyrwälder versalzen alles und ertränken es dann in Soße."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_aloth.stringtable
+++ b/text/conversations/companions/companion_cv_aloth.stringtable
@@ -15,7 +15,7 @@ Die erste Gestalt erhebt ihre Hände, um die Situation zu beruhigen. Sein Gesich
       <ID>2</ID>
       <DefaultText>Die anderen Gestalten, Männer aus dem Volk und eine Elfe, sehen nicht gerade überzeugt aus. 
 
-Die Frau verschränkt ihre Arme. "Aha, willst unseren Stolz wohl mit ein paar aedyranischen Kupferstücken beschwichtigen, was?" Sie spuckt auf seine Füße. "Wir brauchen dein Geld nicht."</DefaultText>
+Die Frau verschränkt ihre Arme. "Aha, willst unseren Stolz wohl mit ein paar aedyrischen Kupferstücken beschwichtigen, was?" Sie spuckt auf seine Füße. "Wir brauchen dein Geld nicht."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -40,9 +40,9 @@ Die Frau verschränkt ihre Arme. "Aha, willst unseren Stolz wohl mit ein paar ae
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>Einer der anderen Männer deutet auf den Elf mit der Kapuze. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. "Verspottet uns sogar noch, während er in unserem Dorf wohnt. Soviel zum Thema, was diese feinen aedyranischen Manieren wirklich wert sind."
+      <DefaultText>Einer der anderen Männer deutet auf den Elf mit der Kapuze. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. "Verspottet uns sogar noch, während er in unserem Dorf wohnt. Soviel zum Thema, was diese feinen aedyrischen Manieren wirklich wert sind."
 
-"So eine Behandlung lassen wir uns nicht gefallen. Nicht von Ausländern, und von Aedyranern erst recht nicht."</DefaultText>
+"So eine Behandlung lassen wir uns nicht gefallen. Nicht von Ausländern, und von Aedyrern erst recht nicht."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -57,12 +57,12 @@ Die Frau verschränkt ihre Arme. "Aha, willst unseren Stolz wohl mit ein paar ae
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. "Du bist ganz schön frech, uns in unserem eigenen Dorf zu verspotten. Von Ausländern lassen wir uns nicht schlecht behandeln. Von Aedyranern erst recht nicht."</DefaultText>
+      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. "Du bist ganz schön frech, uns in unserem eigenen Dorf zu verspotten. Von Ausländern lassen wir uns nicht schlecht behandeln. Von Aedyrern erst recht nicht."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. "Wir sind einfache Leute, aber dumm sind wir nicht. Das scheint er aber anders zu sehen, da er uns verspottet, während er in unserem Dorf wohnt. So lassen wir uns von Ausländern nicht anreden, und von Aedyranern erst recht nicht."</DefaultText>
+      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. "Wir sind einfache Leute, aber dumm sind wir nicht. Das scheint er aber anders zu sehen, da er uns verspottet, während er in unserem Dorf wohnt. So lassen wir uns von Ausländern nicht anreden, und von Aedyrern erst recht nicht."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -139,7 +139,7 @@ Er stellt sich fest hin. In seinen Augen flackert etwas Mürrisches und Rohes au
     </Entry>
     <Entry>
       <ID>26</ID>
-      <DefaultText>"Niemand gibt uns Befehle, Aedyraner."</DefaultText>
+      <DefaultText>"Niemand gibt uns Befehle, Aedyrer."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -149,7 +149,7 @@ Er stellt sich fest hin. In seinen Augen flackert etwas Mürrisches und Rohes au
     </Entry>
     <Entry>
       <ID>28</ID>
-      <DefaultText>Sie greifen dich mit hasserfüllten Augen an. "Oh nein, das wirst du nicht, Aedyraner."</DefaultText>
+      <DefaultText>Sie greifen dich mit hasserfüllten Augen an. "Oh nein, das wirst du nicht, Aedyrer."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -164,7 +164,7 @@ Er stellt sich fest hin. In seinen Augen flackert etwas Mürrisches und Rohes au
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>"Wir lassen uns von irgendwelchen dahergelaufenen Aedyranern nichts befehlen. Und von Mildtätigkeit halten wir auch nichts."</DefaultText>
+      <DefaultText>"Wir lassen uns von irgendwelchen dahergelaufenen Aedyrern nichts befehlen. Und von Mildtätigkeit halten wir auch nichts."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_aloth_act_3.stringtable
+++ b/text/conversations/companions/companion_cv_aloth_act_3.stringtable
@@ -108,7 +108,7 @@ Er verschränkt die Arme. "Ich hatte immer geglaubt, Iselmyr sei eine Krankheit,
     </Entry>
     <Entry>
       <ID>21</ID>
-      <DefaultText>"Und wir latschen durch die Wildnis, obwohl es besser wäre, unsere Füße an einem Lagerfeuer auszuruhen und es uns mit aedyranischen Pflaumenwein gemütlich zu machen. Wahrlich ungerecht."</DefaultText>
+      <DefaultText>"Und wir latschen durch die Wildnis, obwohl es besser wäre, unsere Füße an einem Lagerfeuer auszuruhen und es uns mit aedyrischen Pflaumenwein gemütlich zu machen. Wahrlich ungerecht."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_durance_hub_magran_v2.stringtable
+++ b/text/conversations/companions/companion_cv_durance_hub_magran_v2.stringtable
@@ -246,7 +246,7 @@
     </Entry>
     <Entry>
       <ID>67</ID>
-      <DefaultText>"Sie und ihre Klerus bieten den Eothasianern seit seinem Tod, seiner Erniedrigung, Unterschlupf. Sie nehme ich mir als nächstes vor."</DefaultText>
+      <DefaultText>"Sie und ihre Klerus bieten den Eothasiern seit seinem Tod, seiner Erniedrigung, Unterschlupf. Sie nehme ich mir als nächstes vor."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -306,7 +306,7 @@ Er runzelt die Stirn. "Sollte ich meine Göttin angreifen, dann diene ich ihr en
       <ID>78</ID>
       <DefaultText>Er grunzt. "Meine ist nur eine von vielen." Durance runzelt die Stirn und hält inne, dann werden seine Augen von einem begierigen Glänzen erfüllt. "Eins aber könnte ich dir sagen ..."
 
-"Ich könnte dir erzählen, was die unterliegende Seite von ihr hält, und das sollte dir eigentlich genug sagen. Lass mich darüber sprechen, was ein Aedyraner sieht."</DefaultText>
+"Ich könnte dir erzählen, was die unterliegende Seite von ihr hält, und das sollte dir eigentlich genug sagen. Lass mich darüber sprechen, was ein Aedyrer sieht."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -316,19 +316,19 @@ Er runzelt die Stirn. "Sollte ich meine Göttin angreifen, dann diene ich ihr en
     </Entry>
     <Entry>
       <ID>80</ID>
-      <DefaultText>"Und was sieht ein Aedyraner denn?"</DefaultText>
+      <DefaultText>"Und was sieht ein Aedyrer denn?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>81</ID>
-      <DefaultText>"Die Aedyraner haben eine ... korrekte, höfliche Übersetzung ihres Namens. 'Herausragend im Krieg. Taktische Disziplin'." Er schnaubt. 
+      <DefaultText>"Die Aedyrer haben eine ... korrekte, höfliche Übersetzung ihres Namens. 'Herausragend im Krieg. Taktische Disziplin'." Er schnaubt. 
 
 "Das ist natürlich auch der Grund, warum sie die verdammte Kolonie verloren haben. Wahrscheinlich zitierten sie das immer noch, als wir sie schon über die Decks beugen ließen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>82</ID>
-      <DefaultText>"All ihre Feuerwaffen und Kanonen sind ja schön und gut, aber trotzdem ziemlich nutzlos, wenn dein Stab ihnen Licht in den Schädel treibt und links wie rechts rote Geschenke verteilt." Durance ballt die Fäuste und lacht. "Aedyraner nennen das 'Erhabenheit', 'göttliches Bewusstsein'."
+      <DefaultText>"All ihre Feuerwaffen und Kanonen sind ja schön und gut, aber trotzdem ziemlich nutzlos, wenn dein Stab ihnen Licht in den Schädel treibt und links wie rechts rote Geschenke verteilt." Durance ballt die Fäuste und lacht. "Aedyrer nennen das 'Erhabenheit', 'göttliches Bewusstsein'."
 
 "Diese Worte sind so willkommen wie Scheiße am Stiefel, und mehr als das nahmen sie auch nicht mit, als sie davonliefen ..." Er schüttelt den Kopf. "Eine gelernte Lektion, aber zu falschen Zeit. Mir sind sie fast ein wenig sympathisch ... fast."</DefaultText>
       <FemaleText />
@@ -345,7 +345,7 @@ Er runzelt die Stirn. "Sollte ich meine Göttin angreifen, dann diene ich ihr en
     </Entry>
     <Entry>
       <ID>86</ID>
-      <DefaultText>"Diese ... aedyranische 'Höflichkeit', diese verspielte Festklammern am geschriebenen Wort, so wie sie es verstanden ... DAS verbrannte während des ganzen Dyrwald-Feldzugs ihre Schiffe, vernarbte sie und ließ sie ständig fliehen."
+      <DefaultText>"Diese ... aedyrische 'Höflichkeit', diese verspielte Festklammern am geschriebenen Wort, so wie sie es verstanden ... DAS verbrannte während des ganzen Dyrwald-Feldzugs ihre Schiffe, vernarbte sie und ließ sie ständig fliehen."
 
 Er schnaubt. "'Göttliches Bewusstsein'. Im Warten darauf, geprüft zu werden, steckt kein echter Glauben. Die Besten im Kampf haben sich bereits ordentlich eingeschissen, und zwar bis sie trocken waren und sich auf das Töten konzentrieren konnten."</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_durance_hub_v2.stringtable
+++ b/text/conversations/companions/companion_cv_durance_hub_v2.stringtable
@@ -482,7 +482,7 @@ Durance runzelt die Stirn. "Eothas war der Gott der Wiedergeburt und sein Licht 
     </Entry>
     <Entry>
       <ID>165</ID>
-      <DefaultText>"Eothas marschiert weiter. Die Dyrwäldler ziehen sich in die Wälder zurück und attackieren seine Flanken, seine Späher, seine Truppen. Es schien fast hoffnungslos zu sein." Durance' Gesicht wird düster, dann lächelt er leicht. "Bis zur Zitadelle von Halgot, bis zum Götterhammer."</DefaultText>
+      <DefaultText>"Eothas marschiert weiter. Die Dyrwälder ziehen sich in die Wälder zurück und attackieren seine Flanken, seine Späher, seine Truppen. Es schien fast hoffnungslos zu sein." Durance' Gesicht wird düster, dann lächelt er leicht. "Bis zur Zitadelle von Halgot, bis zum Götterhammer."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -594,7 +594,7 @@ Er lächelt höhnisch. "Er ließ sich nur von Sterblichen verspotten ... und das
     </Entry>
     <Entry>
       <ID>184</ID>
-      <DefaultText>Durance wird grimmiger und sein Gesicht erstarrt. "Wir begannen damit, die Eothasianer vor sich selbst zu retten. Wir verbrannten alle, die nicht mit ihrem Gott starben."
+      <DefaultText>Durance wird grimmiger und sein Gesicht erstarrt. "Wir begannen damit, die Eothasier vor sich selbst zu retten. Wir verbrannten alle, die nicht mit ihrem Gott starben."
 
 "Die Ketzerei in Readceras ist das Eine ... Hier im Dyrwald ist sie aber mit einer ... persönlicheren Note verbunden."</DefaultText>
       <FemaleText />
@@ -621,7 +621,7 @@ Er lächelt höhnisch. "Er ließ sich nur von Sterblichen verspotten ... und das
     </Entry>
     <Entry>
       <ID>189</ID>
-      <DefaultText>"So wie ich es sehe, gefährdet jeder noch im Dyrwald lebende Eothasianer die Nation und ist wie ein Dolch, der unserem Glauben an den Hals gehalten wird."
+      <DefaultText>"So wie ich es sehe, gefährdet jeder noch im Dyrwald lebende Eothasier die Nation und ist wie ein Dolch, der unserem Glauben an den Hals gehalten wird."
 
 "Entwurzelt sie, verbrennt sie oder schickt sie nach Readceras zurück, um sich dort im Blute ihres Scheiterns zu suhlen."</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_durance_voice_set.stringtable
+++ b/text/conversations/companions/companion_cv_durance_voice_set.stringtable
@@ -166,12 +166,12 @@
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>"Sieht einem Aedyraner ähnlich, so schnell zu fallen."</DefaultText>
+      <DefaultText>"Sieht einem Aedyrer ähnlich, so schnell zu fallen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>"Wäre ein Geschenk, sollte der Eothasianer nicht mehr aufwachen."</DefaultText>
+      <DefaultText>"Wäre ein Geschenk, sollte der Eothasier nicht mehr aufwachen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_eder_arc.stringtable
+++ b/text/conversations/companions/companion_cv_eder_arc.stringtable
@@ -30,7 +30,7 @@
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>"Es waren zwölf Dyrwäldler, die außerhalb der Zitadelle von Halgot darauf warteten, dass Waidwen die dortige Brücke überquert. Sie mussten ihn dort lange genug bis zur Detonation des Götterhammers aufhalten, also taten sie genau das."</DefaultText>
+      <DefaultText>"Es waren zwölf Dyrwälder, die außerhalb der Zitadelle von Halgot darauf warteten, dass Waidwen die dortige Brücke überquert. Sie mussten ihn dort lange genug bis zur Detonation des Götterhammers aufhalten, also taten sie genau das."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -90,7 +90,7 @@
       <ID>17</ID>
       <DefaultText>"Bestimmt, aber jetzt aus dem Stegreif fallen mir keine ein."
 
-"Obwohl, das sollte ich wohl nicht sagen: Es gibt da eine Gruppe Eothasianer, die sich der Nachtmarkt nennt. Sie werden ihren Gott immer noch gerecht. Während der Säuberungen brachten sie viele Leute in Sicherheit."</DefaultText>
+"Obwohl, das sollte ich wohl nicht sagen: Es gibt da eine Gruppe Eothasier, die sich der Nachtmarkt nennt. Sie werden ihren Gott immer noch gerecht. Während der Säuberungen brachten sie viele Leute in Sicherheit."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -198,7 +198,7 @@
     </Entry>
     <Entry>
       <ID>36</ID>
-      <DefaultText>"Man kann ja über die Dyrwäldler sagen, was man will, aber Probleme, die man nicht durch die Tötung einiger Sündenböcke aus der Welt schaffen könnte, haben sie noch nicht erlebt." Er grinst nichtssagend.</DefaultText>
+      <DefaultText>"Man kann ja über die Dyrwälder sagen, was man will, aber Probleme, die man nicht durch die Tötung einiger Sündenböcke aus der Welt schaffen könnte, haben sie noch nicht erlebt." Er grinst nichtssagend.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -234,14 +234,14 @@
       <ID>43</ID>
       <DefaultText>"Hah. Also die hier mit Sicherheit nicht. Hier gehen sie damit sehr genau um."
 
-"Vor fünfzehn Jahren versuchten sie, sämtliche Eothasianer umzubringen. Dann begann das Vermächtnis und sie machten sich Sorgen, dass diese Säuberungen damit zu tun haben könnten. Wie also versuchen sie, das zu beheben? Noch mehr Säuberungen."</DefaultText>
+"Vor fünfzehn Jahren versuchten sie, sämtliche Eothasier umzubringen. Dann begann das Vermächtnis und sie machten sich Sorgen, dass diese Säuberungen damit zu tun haben könnten. Wie also versuchen sie, das zu beheben? Noch mehr Säuberungen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>44</ID>
       <DefaultText>"Es ist ja schön, dass sie es gut meinen, aber wie kann es denn sein, dass organisierter Massenmord ihr bester Lösungsansatz ist?"
 
-"Obwohl, wenn man genauer darüber nachdenkt, so folgen sie doch eigentlich nur Waidwens Beispiel. Lange bevor der Dyrwald auf diese Idee kam, führte er schon Säuberungen gegen die eigenen Leute durch, wenn auch deshalb, weil sie ihm als Eothasianer nicht gut genug waren."</DefaultText>
+"Obwohl, wenn man genauer darüber nachdenkt, so folgen sie doch eigentlich nur Waidwens Beispiel. Lange bevor der Dyrwald auf diese Idee kam, führte er schon Säuberungen gegen die eigenen Leute durch, wenn auch deshalb, weil sie ihm als Eothasier nicht gut genug waren."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_eder_hub2.stringtable
+++ b/text/conversations/companions/companion_cv_eder_hub2.stringtable
@@ -57,7 +57,7 @@
       <ID>11</ID>
       <DefaultText>"Meine Eltern stellen sich bestimmt noch dieselbe Frage."
 
-"Der Wahnsinn der Eothasianer-Säuberungen legt sich wie eine Krankheit über das Dorf."
+"Der Wahnsinn der Eothasier-Säuberungen legt sich wie eine Krankheit über das Dorf."
 
 "Anscheinend sagt einem der Instinkt, dass man es aussitzen sollte, wenn man so etwas sieht, selbst wen man weiß, dass es wahrscheinlich nicht vorbeigehen wird."</DefaultText>
       <FemaleText />
@@ -123,7 +123,7 @@ Er lacht. "Er machte mir wirklich das Leben schwer, und ließ mich dumm aussehen
     </Entry>
     <Entry>
       <ID>23</ID>
-      <DefaultText>"Bin so aufgewachsen. Meine Familie sind schon lange Eothasianer. Ich glaube, eine andere Wahl hatte ich gar nicht."
+      <DefaultText>"Bin so aufgewachsen. Meine Familie sind schon lange Eothasier. Ich glaube, eine andere Wahl hatte ich gar nicht."
 
 "Ich bin mir nicht sicher, warum meine Familie begann, ihm zu huldigen. Wahrscheinlich, weil Gaun auf Leute wie uns aufpasste."</DefaultText>
       <FemaleText />
@@ -222,7 +222,7 @@ Er lacht. "Er machte mir wirklich das Leben schwer, und ließ mich dumm aussehen
     </Entry>
     <Entry>
       <ID>42</ID>
-      <DefaultText>"Dauerte eine Weile, bis uns die Nachrichten von den Säuberungen erreichten. Eothasianer wurden auf offener Straße ermordet. In Kaltmorg und solchen Orten, meine ich."
+      <DefaultText>"Dauerte eine Weile, bis uns die Nachrichten von den Säuberungen erreichten. Eothasier wurden auf offener Straße ermordet. In Kaltmorg und solchen Orten, meine ich."
 
 "Hier in Goldtal hätte man nicht zugelassen, dass so etwas passiert. Das jedenfalls sagten sie alle."</DefaultText>
       <FemaleText />
@@ -448,7 +448,7 @@ Er lächelt süffisant. "Sollte das der Fall sein, hat er all das Klagen verdien
       <ID>79</ID>
       <DefaultText>"Wenn man sieht, wie nackt man ist, wenn man keinen Gott hat, der einen schützt ... das öffnet einem ganz schön die Augen."
 
-"Im Krieg des Heiligen war es schwer, ein Dyrwäldler zu sein. Manche Leute sahen das vielleicht als Endzeit an. Sie schwangen große Reden darüber, wie wir einen Gott besiegen würden, aber ich glaube, von hier bis zur Weißmark gab es keinen einzigen Mann, der nicht damit rechnete, zu sterben."</DefaultText>
+"Im Krieg des Heiligen war es schwer, ein Dyrwälder zu sein. Manche Leute sahen das vielleicht als Endzeit an. Sie schwangen große Reden darüber, wie wir einen Gott besiegen würden, aber ich glaube, von hier bis zur Weißmark gab es keinen einzigen Mann, der nicht damit rechnete, zu sterben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -462,14 +462,14 @@ Er lächelt süffisant. "Sollte das der Fall sein, hat er all das Klagen verdien
       <ID>81</ID>
       <DefaultText>"Könnte gut sein, dass es in Kaltmorg angefangen hat, einem Grenzdorf. Sie ließen Waidwen einfach durchmarschieren. Der Rest des Dyrwalds verfluchte ihre Namen bis zum Ende des Kriegs."
 
-"Einige sagen, es wären die Eothasianer gewesen, die die Dörfler dazu überredet hatten, keinen Widerstand zu leisten. Andere sagten, dass es einfach nur Feigheit gewesen war."</DefaultText>
+"Einige sagen, es wären die Eothasier gewesen, die die Dörfler dazu überredet hatten, keinen Widerstand zu leisten. Andere sagten, dass es einfach nur Feigheit gewesen war."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>82</ID>
       <DefaultText>"Diesbezüglich verhielt es sich wie mit dem Vermächtnis - keiner kannte den tatsächlichen Grund, also reimten sie sich einfach etwas zusammen, was für sie den meisten Sinn ergab."
 
-"Wie auch immer, dieses Dorf brannte schon, bevor die ersten Ascheflocken von Eothas den Boden berührten, und nachdem sie so hilflos gewesen waren, fühlte es sich für die Leute dort gut an, die Kontrolle zu haben. Also verbreiteten sich die Feuer, und vielen von uns Eothasianern erging es so wie unserem Gott."</DefaultText>
+"Wie auch immer, dieses Dorf brannte schon, bevor die ersten Ascheflocken von Eothas den Boden berührten, und nachdem sie so hilflos gewesen waren, fühlte es sich für die Leute dort gut an, die Kontrolle zu haben. Also verbreiteten sich die Feuer, und vielen von uns Eothasiern erging es so wie unserem Gott."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_eder_intro.stringtable
+++ b/text/conversations/companions/companion_cv_eder_intro.stringtable
@@ -192,12 +192,12 @@ Er betrachtet dich von Kopf bis Fuß und zieht eine Grimasse. "Glaube nicht, das
     </Entry>
     <Entry>
       <ID>35</ID>
-      <DefaultText>"Krieg des Heiligen. Nur einer in meinem Leben. Dieser Kerl beschließt, die lebende Inkarnation von Eothas zu sein. Stürzt Readceras. Marschiert auf den Dyrwald. Also begrüßten wir ihn auf dyrwäldlerische Art."</DefaultText>
+      <DefaultText>"Krieg des Heiligen. Nur einer in meinem Leben. Dieser Kerl beschließt, die lebende Inkarnation von Eothas zu sein. Stürzt Readceras. Marschiert auf den Dyrwald. Also begrüßten wir ihn auf dyrwälderische Art."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>36</ID>
-      <DefaultText>"Was ist eine dyrwäldlerische Begrüßung?"</DefaultText>
+      <DefaultText>"Was ist eine dyrwälderische Begrüßung?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_eder_quest.stringtable
+++ b/text/conversations/companions/companion_cv_eder_quest.stringtable
@@ -267,7 +267,7 @@ Von Goldtal folgt er einer Straße zur Madhmrbrücke und erreicht die Tore von T
     </Entry>
     <Entry>
       <ID>54</ID>
-      <DefaultText>Der Weg führt zu einer readceranischen Stadt, die majestätisch und streng im aedyranisch-kaiserlichen Stil gehalten ist. Er windet sich durch die Straßen und erklimmt prachtvolle Treppenstufen, die in ein stattliches Gebäude führen, wobei er auf dem Weg in einen vermeintlichen Thronsaal spitz zulaufende Torbögen durchquert.
+      <DefaultText>Der Weg führt zu einer readceranischen Stadt, die majestätisch und streng im aedyrisch-kaiserlichen Stil gehalten ist. Er windet sich durch die Straßen und erklimmt prachtvolle Treppenstufen, die in ein stattliches Gebäude führen, wobei er auf dem Weg in einen vermeintlichen Thronsaal spitz zulaufende Torbögen durchquert.
 
 Auf dem Thron sitzt ein Mann, dessen Kopf aus reinem, blendenden Licht besteht, und als er dir seinen Blick zuwendet, überstrahlt das Licht alles andere. Der Stimme wohnt die Wucht des Donners inne, aber in dem Abdruck, der voller Echos ist, kannst du die Worte unmöglich verstehen.</DefaultText>
       <FemaleText />
@@ -434,7 +434,7 @@ Seine Stimme ist kaum mehr als ein Flüstern.
     </Entry>
     <Entry>
       <ID>85</ID>
-      <DefaultText>"Das war natürlich töricht. Warum sollte ich Antworten bekommen? Da draußen gibt es eine ganze Welt voller Eothasianer, die nicht wissen, ob man ihren Gott in die Luft gejagt hat."
+      <DefaultText>"Das war natürlich töricht. Warum sollte ich Antworten bekommen? Da draußen gibt es eine ganze Welt voller Eothasier, die nicht wissen, ob man ihren Gott in die Luft gejagt hat."
 
 "Trotzdem, man kann das Zurückblicken einfach nicht sein lassen."</DefaultText>
       <FemaleText />
@@ -484,7 +484,7 @@ Er zieht eine Augenbraue in die Höhe, der ein Mundwinkel folgt. "Natürlich wä
       <ID>93</ID>
       <DefaultText>"Viele Dinge wären wohl besser geworden, hätte er gewonnen, denke ich. Die Säuberungen hätten nie stattgefunden. Goldtal wäre heute ... anders. Die Bäume würden besser aussehen, so viel weiß ich zumindest. Selbst meine Familie würde vielleicht noch dort leben."
 
-"Vielleicht gäbe es gar kein Vermächtnis. Es hätte wohl eine lange Schlange kapitulationsbereiter Dyrwäldler gegeben, wenn sie gewusst hätten, was sie erwartet."</DefaultText>
+"Vielleicht gäbe es gar kein Vermächtnis. Es hätte wohl eine lange Schlange kapitulationsbereiter Dyrwälder gegeben, wenn sie gewusst hätten, was sie erwartet."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_hiravias.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias.stringtable
@@ -50,7 +50,7 @@
     </Entry>
     <Entry>
       <ID>108</ID>
-      <DefaultText>"Was an Delemgen ist es wohl, dass meinen Stamm zum Sprießen bringt? Meine Logik sagt mir eigentlich, dass sie keinen saftigen Löcher haben und einen wahrscheinlich nach der Kopulation umbringen. Trotzdem ... "</DefaultText>
+      <DefaultText>"Was an den Delemgan ist es wohl, dass meinen Stamm zum Sprießen bringt? Meine Logik sagt mir eigentlich, dass sie keine saftigen Löcher haben und einen wahrscheinlich nach der Kopulation umbringen. Trotzdem ... "</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -277,7 +277,7 @@ Er richtet seine Aufmerksamkeit auf seine Schulter und zupft sich ein kleines Sa
     </Entry>
     <Entry>
       <ID>232</ID>
-      <DefaultText>"Da ich mich jetzt aber in ihren Landen befinde, werde ich - im Sinne der akademischen Gerechtigkeit - zugeben, dass ich schon ein paar ... mehrere ... anständige ... kaum fanatische Dyrwäldler getroffen habe."
+      <DefaultText>"Da ich mich jetzt aber in ihren Landen befinde, werde ich - im Sinne der akademischen Gerechtigkeit - zugeben, dass ich schon ein paar ... mehrere ... anständige ... kaum fanatische Dyrwälder getroffen habe."
 
 Er schaut misstrauisch und verschränkt die Arme. "Aber mein Verdacht, dass sie alle Säufer sind, hat sich als durch und durch wahr herausgestellt. Ich frage mich, welchen großen Wunder sie wohl vollbringen könnten, wenn sie alle nüchtern würden."</DefaultText>
       <FemaleText />
@@ -286,7 +286,7 @@ Er schaut misstrauisch und verschränkt die Arme. "Aber mein Verdacht, dass sie 
       <ID>233</ID>
       <DefaultText>Hiravias spuckt aus. "Ausländische Plünderer, besessen mit Reichtümern und Wein. Mögen ihre Eingeweide von nässenden Geschwüren verstopft werden - und zwar alle!"
 
-Während er sich an seinem Ohrstummel kratzt, bleibt seine Stirn weiter in Falten. "Nicht dass du in mir einen neutralen Gesprächspartner hättest: Wenn ich, wie so häufig, ein unausstehliches Kind war, sagten mir meine Eltern, Dyrwäldler würden mich im jetzigen UND im nächsten Leben versklaven, wenn ich mich nicht benehme."</DefaultText>
+Während er sich an seinem Ohrstummel kratzt, bleibt seine Stirn weiter in Falten. "Nicht dass du in mir einen neutralen Gesprächspartner hättest: Wenn ich, wie so häufig, ein unausstehliches Kind war, sagten mir meine Eltern, Dyrwälder würden mich im jetzigen UND im nächsten Leben versklaven, wenn ich mich nicht benehme."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -413,7 +413,7 @@ Er errötet und schaut grinsend zu seinen Füßen hinab. "Danke, die Meinen konn
     </Entry>
     <Entry>
       <ID>268</ID>
-      <DefaultText>"Schon, was? Ich dachte, das Geisterwandeln zu erlernen, würde mir etwas Respekt einbringen - vielleicht würde mir sogar ein aedyranisches Mädchen mit einem Faible für kleine Männer ins Netz gehen. Ach, wäre ich ein Anfänger geblieben, es wäre mir womöglich besser ergangen."</DefaultText>
+      <DefaultText>"Schon, was? Ich dachte, das Geisterwandeln zu erlernen, würde mir etwas Respekt einbringen - vielleicht würde mir sogar ein aedyrisches Mädchen mit einem Faible für kleine Männer ins Netz gehen. Ach, wäre ich ein Anfänger geblieben, es wäre mir womöglich besser ergangen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -562,7 +562,7 @@ Er versucht mehrmals, seinen Gedanken zu Ende zu bringen, bis es ihm schließlic
     </Entry>
     <Entry>
       <ID>309</ID>
-      <DefaultText>"In meiner Jugend verfluchte ich die Dyrwäldler als ignorante Plünderer, die sich ungebremst vermehren. Aber seelenlose Babies? Welcher herzlose Gott würden denn eine SOLCHE Tragöde verursachen? Kein Elternteil oder Kind hat es verdient, Teil dieses Schreckens zu sein."</DefaultText>
+      <DefaultText>"In meiner Jugend verfluchte ich die Dyrwälder als ignorante Plünderer, die sich ungebremst vermehren. Aber seelenlose Babies? Welcher herzlose Gott würden denn eine SOLCHE Tragöde verursachen? Kein Elternteil oder Kind hat es verdient, Teil dieses Schreckens zu sein."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -748,7 +748,7 @@ Er spuckt auf den Boden. "Alles."</DefaultText>
     </Entry>
     <Entry>
       <ID>357</ID>
-      <DefaultText>"Ja, in der Tat", sagt er leise und langsam. "Einmal sah ich eine baden! Ich war so überrascht, dass ich meine Geisterwandlerform vergaß, deshalb wurden meine einladenden Gesten wohl von ein paar Krallen zu viel begleitet. Wahrscheinlich hatte ich Glück, dass es so gekommen ist - Delemgen sollte man besser nur anschauen, nicht anfassen!"</DefaultText>
+      <DefaultText>"Ja, in der Tat", sagt er leise und langsam. "Einmal sah ich eine baden! Ich war so überrascht, dass ich meine Geisterwandlerform vergaß, deshalb wurden meine einladenden Gesten wohl von ein paar Krallen zu viel begleitet. Wahrscheinlich hatte ich Glück, dass es so gekommen ist - Delemgan sollte man besser nur anschauen, nicht anfassen!"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_hiravias_quest.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias_quest.stringtable
@@ -307,7 +307,7 @@ Hiravias starrt dich mit aufgerissenen Augen mehrere Augenblicke lang an.
     </Entry>
     <Entry>
       <ID>52</ID>
-      <DefaultText>Er schaut dich an und kichert nervös. "Hübsches Geschichtchen - zwei Kerle 'treffen' sich im Bauch einer seelenfressenden Kreatur wieder. Vielleicht werde ich eines Tages zwei der dümmsten dyrwäldlerischen Holzfäller fressen, und dann werden mir im Dickdarm herumspuken, während sie auf ewig über Bier reden." </DefaultText>
+      <DefaultText>Er schaut dich an und kichert nervös. "Hübsches Geschichtchen - zwei Kerle 'treffen' sich im Bauch einer seelenfressenden Kreatur wieder. Vielleicht werde ich eines Tages zwei der dümmsten dyrwälderischen Holzfäller fressen, und dann werden mir im Dickdarm herumspuken, während sie auf ewig über Bier reden." </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -367,21 +367,21 @@ Er lächelt nervös und zuckt mit den Achseln. "Vielleicht werde ich die Beute t
     </Entry>
     <Entry>
       <ID>63</ID>
-      <DefaultText>Hiravias schnauft und keucht, sein eines gutes Auge blickt starr auf Scathdens Leichnam. Er wippt auf seinen Fußballen vor und zurück, während von seinem Fell Blut und Schweiß herabtropfen - vielleicht erwartet er, dass sich der Leichnam wieder erhebt.</DefaultText>
+      <DefaultText>Hiravias schnauft und keucht, sein eines gutes Auge blickt starr auf Scâthdens Leichnam. Er wippt auf seinen Fußballen vor und zurück, während von seinem Fell Blut und Schweiß herabtropfen - vielleicht erwartet er, dass sich der Leichnam wieder erhebt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>64</ID>
       <DefaultText>"Amüsiert, vermute ich. Wael zeigte mir, dass Galawain meine Gebete beantwortete - er machte mich zu dem großen Jäger, der ich immer werden wollte. Das Zerfleischen war keine Bestrafung, nur eine sehr, sehr schwere Prüfung."
 
-Hiravias schaut auf Scathdens Körper hinunter und grinst. "Und ich glaube, Wael hat mir jetzt gerade gezeigt, was aus mir werden wird, wenn ich dieser Facette meines Lebens freien Laufe lasse."</DefaultText>
+Hiravias schaut auf Scâthdens Körper hinunter und grinst. "Und ich glaube, Wael hat mir jetzt gerade gezeigt, was aus mir werden wird, wenn ich dieser Facette meines Lebens freien Laufe lasse."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>65</ID>
       <DefaultText>Hiravias nickt langsam und lächelt. "Hervorragend", sagt er nach einer langen Pause.
 
-Er umrundet Scathden mehrmals mit stolzen und entspannten Schritten. "Ich habe Galawains Prüfung erduldet und meinesgleichen besiegt. Ich bereue einzig und allein all die Jahre, die ich damit verschwendete, dies als Fluch anzusehen. Die Ächtung war zweifelsohne nur ein Weg Galawains, mich zum Stärkerwerden zu zwingen."</DefaultText>
+Er umrundet Scâthden mehrmals mit stolzen und entspannten Schritten. "Ich habe Galawains Prüfung erduldet und meinesgleichen besiegt. Ich bereue einzig und allein all die Jahre, die ich damit verschwendete, dies als Fluch anzusehen. Die Ächtung war zweifelsohne nur ein Weg Galawains, mich zum Stärkerwerden zu zwingen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -398,12 +398,12 @@ Er umrundet Scathden mehrmals mit stolzen und entspannten Schritten. "Ich habe G
       <ID>68</ID>
       <DefaultText>Hiravias nickt. "Ja, ich habe jetzt genug von Galawains Tests und Prüfungen. Selbst wenn ich jeden anderen Mann bezwingen könnte, der den Mantel des Herbst-Stelgaers trägt - was genau bringt mir das? Ich bin nicht mehr mit dem Herz bei der Jagd, wie ich es früher war."
 
-Er betrachtet Scathdens verstümmelte Leiche und schüttelt seinen Kopf. "Und das ist fast eine Schande, da ich ein ziemlich fantastischer und dennoch bescheidener Jäger bin. Aber um deine Frage zu beantworten: Ja, ich bin hier fertig."</DefaultText>
+Er betrachtet Scâthdens verstümmelte Leiche und schüttelt seinen Kopf. "Und das ist fast eine Schande, da ich ein ziemlich fantastischer und dennoch bescheidener Jäger bin. Aber um deine Frage zu beantworten: Ja, ich bin hier fertig."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>69</ID>
-      <DefaultText>"Fast zumindest", sagt er, während er sich vor Scathdens Körper hinkniet, den Kopf senkt und leise zu singen beginnt.
+      <DefaultText>"Fast zumindest", sagt er, während er sich vor Scâthdens Körper hinkniet, den Kopf senkt und leise zu singen beginnt.
 
 Du kannst die Worte seines leisen, feierlichen Gesangs kaum hören: "Galawain, wir danken dir für die Führung unserer Jagd, denn heute stärken wir uns am Fleisch der Schwächeren." 
 
@@ -412,21 +412,21 @@ Er steht auf, streicht seinen Waffenrock glatt und lächelt dich nickend an. "Ic
     </Entry>
     <Entry>
       <ID>70</ID>
-      <DefaultText>[Scathdens Leichnam untersuchen.]</DefaultText>
+      <DefaultText>[Scâthdens Leichnam untersuchen.]</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>71</ID>
       <DefaultText>Während sich deine Augen entspannen und deine Ohren sich an das Summen des Unsichtbaren gewöhnen, sieht du einen wirbelnden Haufen aus roten, orangenen und gelben Blättern. Der Blättersturm fliegt auseinander und die Blätter treiben ins Ungewisse davon.
 
-Als Scathdens Essenz verblasst, sieht du eine Handvoll Hiravias umkreisende Herbstblätter, während seine Seele in kühnerem Orange leuchtet.</DefaultText>
+Als Scâthdens Essenz verblasst, sieht du eine Handvoll Hiravias umkreisende Herbstblätter, während seine Seele in kühnerem Orange leuchtet.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>73</ID>
       <DefaultText>Während er fortzugehen beginnt, wirbelt er plötzlich herum und murmelt: "Bevor ihn die Geier erwischen ... "
 
-Er geht zu Scathdens Leichnam hinüber, fasst mit einer Hand in den Mund des toten Mannes und zieht mit aller Kraft an. Sehnen und Knorpel reißen begleitet von Blutfontänen, bis er schließlich den Unterkiefer in der Hand hält. 
+Er geht zu Scâthdens Leichnam hinüber, fasst mit einer Hand in den Mund des toten Mannes und zieht mit aller Kraft an. Sehnen und Knorpel reißen begleitet von Blutfontänen, bis er schließlich den Unterkiefer in der Hand hält. 
 
 "Ich dachte, ich sollte mir ein Erinnerungsstück mitnehmen". Als er seine blutüberströmte Trophäe betrachtet, errötet er lächelnd.</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_hiravias_quest.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias_quest.stringtable
@@ -307,7 +307,7 @@ Hiravias starrt dich mit aufgerissenen Augen mehrere Augenblicke lang an.
     </Entry>
     <Entry>
       <ID>52</ID>
-      <DefaultText>Er schaut dich an und kichert nervös. "Hübsches Geschichtchen - zwei Kerle 'treffen' sich im Bauch einer seelenfressenden Kreatur wieder. Vielleicht werde ich eines Tages zwei der dümmsten dyrwälderischen Holzfäller fressen, und dann werden mir im Dickdarm herumspuken, während sie auf ewig über Bier reden." </DefaultText>
+      <DefaultText>Er schaut dich an und kichert nervös. "Hübsches Geschichtchen - zwei Kerle 'treffen' sich im Bauch einer seelenfressenden Kreatur wieder. Vielleicht werde ich eines Tages zwei der dümmsten dyrwälderischen Holzfäller fressen, und dann werden die mir im Dickdarm herumspuken, während sie auf ewig über Bier reden." </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_kana_hub.stringtable
+++ b/text/conversations/companions/companion_cv_kana_hub.stringtable
@@ -213,7 +213,7 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>42</ID>
-      <DefaultText>"Dann kommt das Gespräch auf den Bann gegen aedyranische und vailianische Handelsschiffe, und ..." Kana seufzt. "Als ich ging, war die Lage ... schwierig. Die Älteren stritten viel untereinander. Ich vertraue darauf, dass der König den Frieden gesichert hat - aber manchmal sorge ich mich, dass sich alles zum Schlechten gewendet haben könnten."</DefaultText>
+      <DefaultText>"Dann kommt das Gespräch auf den Bann gegen aedyrische und vailianische Handelsschiffe, und ..." Kana seufzt. "Als ich ging, war die Lage ... schwierig. Die Älteren stritten viel untereinander. Ich vertraue darauf, dass der König den Frieden gesichert hat - aber manchmal sorge ich mich, dass sich alles zum Schlechten gewendet haben könnten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -243,7 +243,7 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>57</ID>
-      <DefaultText>"Caed Nua ist ein Wunder! Ein hässliches, zerbröckelndes zwar, aber dennoch ein Wunder. Die Burg wird zwar von dem überschattet, was unter ihr liegt, aber sie alleine kann einem schon viel über die aedyranische Siedlung verraten. Ein sehr unnachgiebiges Volk, wie ich finde."</DefaultText>
+      <DefaultText>"Caed Nua ist ein Wunder! Ein hässliches, zerbröckelndes zwar, aber dennoch ein Wunder. Die Burg wird zwar von dem überschattet, was unter ihr liegt, aber sie alleine kann einem schon viel über die aedyrische Siedlung verraten. Ein sehr unnachgiebiges Volk, wie ich finde."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -268,7 +268,7 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>62</ID>
-      <DefaultText>"Ich weiß nur, dass Od Nua ein großer König gewesen sein soll, der über viele Männer und Frauen herrschte, und dass er diesen Ort als Monument gebaut hat. Aber die Pfade sind schon seit zweitausend Jahren hier. Nach ihnen haben die Aedyraner sie für sich beansprucht, und auf diese folgen haufenweise Abenteurer und Entdecker. Ich würde was darauf wetten, dass da unten Knochen aus jeder Ära liegen."</DefaultText>
+      <DefaultText>"Ich weiß nur, dass Od Nua ein großer König gewesen sein soll, der über viele Männer und Frauen herrschte, und dass er diesen Ort als Monument gebaut hat. Aber die Pfade sind schon seit zweitausend Jahren hier. Nach ihnen haben die Aedyrer sie für sich beansprucht, und auf diese folgen haufenweise Abenteurer und Entdecker. Ich würde was darauf wetten, dass da unten Knochen aus jeder Ära liegen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -349,7 +349,7 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>77</ID>
-      <DefaultText>"Die Engwithaner haben trotzdem Großartiges vollbracht. Dieser Adra-Riese lässt alles, was die Dyrwäldler jemals gebaut haben, zwergenhaft erscheinen."</DefaultText>
+      <DefaultText>"Die Engwithaner haben trotzdem Großartiges vollbracht. Dieser Adra-Riese lässt alles, was die Dyrwälder jemals gebaut haben, zwergenhaft erscheinen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -422,8 +422,8 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>90</ID>
-      <DefaultText>"Ich stelle mir nur die Frage: Die Dyrwäldler werden sicherlich eine Weile brauchen, dich Thayn oder gar Fürst zu nennen. Damit meine ich nicht, dass du diese Titel nicht verdient hättest, aber solche Angelegenheiten sind immer recht kompliziert. Trotzdem bist du praktisch der König der Burg."</DefaultText>
-      <FemaleText>"Ich stelle mir nur die Frage: Die Dyrwäldler werden sicherlich eine Weile brauchen, dich Thaynu oder gar Fürstin zu nennen. Damit meine ich nicht, dass du diese Titel nicht verdient hättest, aber solche Angelegenheiten sind immer recht kompliziert. Trotzdem bist du praktisch der König der Burg ... oder heißt es hier Königin?"</FemaleText>
+      <DefaultText>"Ich stelle mir nur die Frage: Die Dyrwälder werden sicherlich eine Weile brauchen, dich Thayn oder gar Fürst zu nennen. Damit meine ich nicht, dass du diese Titel nicht verdient hättest, aber solche Angelegenheiten sind immer recht kompliziert. Trotzdem bist du praktisch der König der Burg."</DefaultText>
+      <FemaleText>"Ich stelle mir nur die Frage: Die Dyrwälder werden sicherlich eine Weile brauchen, dich Thaynu oder gar Fürstin zu nennen. Damit meine ich nicht, dass du diese Titel nicht verdient hättest, aber solche Angelegenheiten sind immer recht kompliziert. Trotzdem bist du praktisch der König der Burg ... oder heißt es hier Königin?"</FemaleText>
     </Entry>
     <Entry>
       <ID>91</ID>
@@ -799,7 +799,7 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>167</ID>
-      <DefaultText>"Während der letzten Schlachten strömten aedyranische Soldaten in das Viertel, worauf die kaiserliche Flotte die Stadt mit Kanonenfeuer aus der Bucht bombardierte. Die schlaue Galven Medhra aber hatte sie in eine Falle geführt."</DefaultText>
+      <DefaultText>"Während der letzten Schlachten strömten aedyrische Soldaten in das Viertel, worauf die kaiserliche Flotte die Stadt mit Kanonenfeuer aus der Bucht bombardierte. Die schlaue Galven Medhra aber hatte sie in eine Falle geführt."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1037,7 +1037,7 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>213</ID>
-      <DefaultText>"In vielen dieser Bücher und Aufzeichnungen fand ich Berichte über das uralte Engwith. Die Aedyraner sind ganz versessen auf engwithanische Reliquien - und wer könnte es ihnen verdenken? Schließlich war das die Zivilisation, von der die Glanfathaner das Lesen von Seelen erlernten."</DefaultText>
+      <DefaultText>"In vielen dieser Bücher und Aufzeichnungen fand ich Berichte über das uralte Engwith. Die Aedyrer sind ganz versessen auf engwithanische Reliquien - und wer könnte es ihnen verdenken? Schließlich war das die Zivilisation, von der die Glanfathaner das Lesen von Seelen erlernten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1054,7 +1054,7 @@ Kana kichert. "Tut mir leid."</DefaultText>
     </Entry>
     <Entry>
       <ID>225</ID>
-      <DefaultText>"Schon bald darauf fand ich es - einen Abschnitt des Tanvii ora Toha, in einer aedyranischen Übersetzung einer uralten engwithanischen Schrift. Da ... direkt vor mir. Ohne jegliche Erklärung."
+      <DefaultText>"Schon bald darauf fand ich es - einen Abschnitt des Tanvii ora Toha, in einer aedyrischen Übersetzung einer uralten engwithanischen Schrift. Da ... direkt vor mir. Ohne jegliche Erklärung."
 
 "Es erschien mir wie ein Geschenk der Götter."</DefaultText>
       <FemaleText />
@@ -1124,7 +1124,7 @@ Kana lächelt. "Er mag meinen Worten zwar keinen Glauben schenken, aber wenigste
     </Entry>
     <Entry>
       <ID>237</ID>
-      <DefaultText>"Was ein Eroberungsfeldzug über die Verantwortlichen aussagt, wirst du die Aedyraner fragen müssen." 
+      <DefaultText>"Was ein Eroberungsfeldzug über die Verantwortlichen aussagt, wirst du die Aedyrer fragen müssen." 
 
 "Der Ruf aber, ja, der hält sich. Ist recht hilfreich, wenn du für dein Geld kämpfen willst. Wenn du aber lieber in der Küche stehst, bringt er dir nicht so viel."</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_kana_od_nua.stringtable
+++ b/text/conversations/companions/companion_cv_kana_od_nua.stringtable
@@ -18,7 +18,7 @@
       <ID>3</ID>
       <DefaultText>"Hier wären wir also. Wenn man sich überlegt, wie nahe wie sind! Direkt unter unseren Füßen liegen die Endlosen Pfade, gebaut von Od Nua, dem großen engwithanischen König."
 
-Kana hält inne. "Naja, hier oben ist natürlich alles aedyranischer Bauart, aber sollten wir tief genug hinabsteigen, werden wir wahre Geschichte erleben!"</DefaultText>
+Kana hält inne. "Naja, hier oben ist natürlich alles aedyrischer Bauart, aber sollten wir tief genug hinabsteigen, werden wir wahre Geschichte erleben!"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_kana_rest.stringtable
+++ b/text/conversations/companions/companion_cv_kana_rest.stringtable
@@ -111,12 +111,12 @@
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>"Dann hat dich wohl noch niemand zu einer Rauferei hinter der Scheune herausgefordert." Kana grinst dich schief an. "Ich auch nicht. Um das Temperament der Dyrwäldler wird großes Aufheben gemacht, aber bislang haben sie es weitestgehend aneinander ausgelassen."</DefaultText>
+      <DefaultText>"Dann hat dich wohl noch niemand zu einer Rauferei hinter der Scheune herausgefordert." Kana grinst dich schief an. "Ich auch nicht. Um das Temperament der Dyrwälder wird großes Aufheben gemacht, aber bislang haben sie es weitestgehend aneinander ausgelassen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>49</ID>
-      <DefaultText>"Meinst du? Ich bin überrascht, dass dich wohl noch niemand zu einer Rauferei hinter der Scheune herausgefordert hat. Anscheinend lieben Dyrwäldler nichts mehr als Gelegenheiten, ihren Hass auf Aedyraner zu zeigen."</DefaultText>
+      <DefaultText>"Meinst du? Ich bin überrascht, dass dich wohl noch niemand zu einer Rauferei hinter der Scheune herausgefordert hat. Anscheinend lieben Dyrwälder nichts mehr als Gelegenheiten, ihren Hass auf Aedyrer zu zeigen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -126,12 +126,12 @@
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>"Also hast du dich schon mit den Einheimischen getroffen?" Kana lacht. "Ich weiß nicht, ob sie so schlimm sind. Um das Temperament der Dyrwäldler wird viel Aufhebens gemacht, aber sie scheinen es größtenteils füreinander aufzuheben."</DefaultText>
+      <DefaultText>"Also hast du dich schon mit den Einheimischen getroffen?" Kana lacht. "Ich weiß nicht, ob sie so schlimm sind. Um das Temperament der Dyrwälder wird viel Aufhebens gemacht, aber sie scheinen es größtenteils füreinander aufzuheben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>52</ID>
-      <DefaultText>"Hierzulande scheint das eine Konstante zu sein. Wenn die Dyrwäldler keine Probleme mit den Glanfathanern haben, dann miteinander. Ich finde es merkwürdig, dass ein Volk, das von Feinden umzingelt ist, derart aufeinander herumhackt."</DefaultText>
+      <DefaultText>"Hierzulande scheint das eine Konstante zu sein. Wenn die Dyrwälder keine Probleme mit den Glanfathanern haben, dann miteinander. Ich finde es merkwürdig, dass ein Volk, das von Feinden umzingelt ist, derart aufeinander herumhackt."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_pallegina.stringtable
+++ b/text/conversations/companions/companion_cv_pallegina.stringtable
@@ -275,7 +275,9 @@ Sie presst die Kiefer zusammen und fährt leise fort:</DefaultText>
       <DefaultText>"Sie ist tot? Aimico, ich kann dir gar nicht genug danken, aber das wird die Doemenels nicht lange aufhalten. Ich muss von hier verschwinden, und dasselbe würde ich auch dir empfehlen."
 
 Mit zitternden Händen übergibt er einen Münzbeutel. "Das ist alles, was ich nach dieser unglückseligen Unternehmung noch übrig habe. Vielen Dank, und bitte pass auf dich auf."</DefaultText>
-      <FemaleText />
+      <FemaleText>"Sie ist tot? Aimica, ich kann dir gar nicht genug danken, aber das wird die Doemenels nicht lange aufhalten. Ich muss von hier verschwinden, und dasselbe würde ich auch dir empfehlen."
+
+Mit zitternden Händen übergibt er einen Münzbeutel. "Das ist alles, was ich nach dieser unglückseligen Unternehmung noch übrig habe. Vielen Dank, und bitte pass auf dich auf."</FemaleText>
     </Entry>
     <Entry>
       <ID>84</ID>
@@ -524,7 +526,7 @@ Mit zitternden Händen übergibt er einen Münzbeutel. "Das ist alles, was ich n
     </Entry>
     <Entry>
       <ID>136</ID>
-      <DefaultText>"Die Wünsche der Ducs Bels haben sich seit unserem letzten Gespräch nicht geändert. Und falls du es noch nicht mitbekommen hast: Die Nachrichten über deinen Ungehorsam sind der Ducesa von Biageppe und dem Duc von Selona zu Ohren gekommen."</DefaultText>
+      <DefaultText>"Die Wünsche der Ducs Bels haben sich seit unserem letzten Gespräch nicht geändert. Und falls du es noch nicht mitbekommen hast: Die Nachrichten über deinen Ungehorsam sind der Ducessa von Biageppe und dem Duc von Selona zu Ohren gekommen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -581,7 +583,7 @@ Palleginas Gebaren schlägt schnell in Erschütterung und Angst um, aber sie sch
     </Entry>
     <Entry>
       <ID>151</ID>
-      <DefaultText>Palleginas Federn sträuben sich, aber dennoch spricht sie mit ungewöhnlich sanftmütiger Stimme. "Eccosi, Botschafter, aber wird das nicht die Dyrwäldler provozieren? Ihr Land ist im Zerfall begriffen und wir teilen schon ihre Handelsbündnisse unter uns auf."</DefaultText>
+      <DefaultText>Palleginas Federn sträuben sich, aber dennoch spricht sie mit ungewöhnlich sanftmütiger Stimme. "Eccosi, Botschafter, aber wird das nicht die Dyrwälder provozieren? Ihr Land ist im Zerfall begriffen und wir teilen schon ihre Handelsbündnisse unter uns auf."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_pallegina_act_3.stringtable
+++ b/text/conversations/companions/companion_cv_pallegina_act_3.stringtable
@@ -211,7 +211,7 @@
     </Entry>
     <Entry>
       <ID>45</ID>
-      <DefaultText>"Ich könnte der Anamenfath die Idee in den Kopf setzen, dass die Republiken kein Interesse an Exklusivrechten haben, sondern vielmehr am eingeschränkten Handel von Gütern, die sie nicht schon mit den Dyrwäldlern handeln." </DefaultText>
+      <DefaultText>"Ich könnte der Anamenfath die Idee in den Kopf setzen, dass die Republiken kein Interesse an Exklusivrechten haben, sondern vielmehr am eingeschränkten Handel von Gütern, die sie nicht schon mit den Dyrwäldern handeln." </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -226,7 +226,7 @@
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>"Das wäre nur gerecht. Die Dyrwäldler sind der Gnade der Republiken ausgeliefert, und das wissen sie nicht einmal. Deine heutigen Taten können zukünftiges Leid vermeiden."</DefaultText>
+      <DefaultText>"Das wäre nur gerecht. Die Dyrwälder sind der Gnade der Republiken ausgeliefert, und das wissen sie nicht einmal. Deine heutigen Taten können zukünftiges Leid vermeiden."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -326,7 +326,7 @@
     </Entry>
     <Entry>
       <ID>71</ID>
-      <DefaultText>"Die Dyrwäldler wissen immer noch nichts von euren Absichten, oder? Wenn sie das herausfinden ... "</DefaultText>
+      <DefaultText>"Die Dyrwälder wissen immer noch nichts von euren Absichten, oder? Wenn sie das herausfinden ... "</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_pallegina_hub.stringtable
+++ b/text/conversations/companions/companion_cv_pallegina_hub.stringtable
@@ -146,7 +146,7 @@
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>"Wie alle anderen Brüder auch wuchs ich unter den Bastionen von Ozian auf. Es war nicht einfach, aber ich zog es dem Ausnehmen von Fischen vor."</DefaultText>
+      <DefaultText>"Wie alle anderen Brüder auch wuchs ich unter den Bastionen von Ozia auf. Es war nicht einfach, aber ich zog es dem Ausnehmen von Fischen vor."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -306,7 +306,7 @@
     </Entry>
     <Entry>
       <ID>61</ID>
-      <DefaultText>Pallegina schüttelt leicht den Kopf. "Trotzdem kann ich die Besessenheit der Dyrwäldler mit Rache und Fehden ebenso wenig verstehen wie den allgegenwärtigen Hass auf Orlaner."</DefaultText>
+      <DefaultText>Pallegina schüttelt leicht den Kopf. "Trotzdem kann ich die Besessenheit der Dyrwälder mit Rache und Fehden ebenso wenig verstehen wie den allgegenwärtigen Hass auf Orlaner."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -331,7 +331,7 @@
     </Entry>
     <Entry>
       <ID>66</ID>
-      <DefaultText>"Du bist wie einer dieser Dyrwäldler, die immer mit einem Feuer im Magen darauf warten, es auf jemand zu speien, der ihnen in den Weg kommt. Manchmal kommt die Zeit zum Kämpfen, aber nicht alle Probleme können mit einem Schwert gelöst werden."</DefaultText>
+      <DefaultText>"Du bist wie einer dieser Dyrwälder, die immer mit einem Feuer im Magen darauf warten, es auf jemand zu speien, der ihnen in den Weg kommt. Manchmal kommt die Zeit zum Kämpfen, aber nicht alle Probleme können mit einem Schwert gelöst werden."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_watcher_reaction.stringtable
+++ b/text/conversations/companions/companion_cv_watcher_reaction.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>8</ID>
-      <DefaultText>"Also ... [Player Name] ... geht es dir gut? Hast du dir bei den Dyrwäldlern die Trunksucht eingefangen?" Als er dich von oben bis unten betrachtet und auf Zeichen von Verletzungen sucht, wird sein Lächeln nervös.
+      <DefaultText>"Also ... [Player Name] ... geht es dir gut? Hast du dir bei den Dyrwäldern die Trunksucht eingefangen?" Als er dich von oben bis unten betrachtet und auf Zeichen von Verletzungen sucht, wird sein Lächeln nervös.
 
 "Einen Augenblick lang schienst du dich in deinem eigenen kleinen Traum zu befinden ... was ist mit dir los?"</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/poi/poi_bs_brighthollow.stringtable
+++ b/text/conversations/companions/poi/poi_bs_brighthollow.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>"Ich kann mir vorstellen, das viele dyrwäldlerische Männer nachts in diese Quelle pinkeln, weil es zu anstrengend wäre, den ganzen Weg bis nach draußen zu gehen."</DefaultText>
+      <DefaultText>"Ich kann mir vorstellen, das viele dyrwälderische Männer nachts in diese Quelle pinkeln, weil es zu anstrengend wäre, den ganzen Weg bis nach draußen zu gehen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>17</ID>
-      <DefaultText>"Die dyrwäldlerische Architektur ist nicht gerade reich an Brunnen."</DefaultText>
+      <DefaultText>"Die dyrwälderische Architektur ist nicht gerade reich an Brunnen."</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/companions/poi/poi_bs_brothel.stringtable
+++ b/text/conversations/companions/poi/poi_bs_brothel.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Zu stark frittierter Kabeljau, wässriges Ale und Prostitution. Eine Bastion dyrwäldlerischer Kultur."</DefaultText>
+      <DefaultText>"Zu stark frittierter Kabeljau, wässriges Ale und Prostitution. Eine Bastion dyrwälderischer Kultur."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/poi/poi_bs_great_hall.stringtable
+++ b/text/conversations/companions/poi/poi_bs_great_hall.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>"Eindeutig aedyranischer Machart ... Torbögen mögen sie wirklich."</DefaultText>
+      <DefaultText>"Eindeutig aedyrischer Machart ... Torbögen mögen sie wirklich."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/poi/poi_bs_ondra_docks.stringtable
+++ b/text/conversations/companions/poi/poi_bs_ondra_docks.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"An diesen Deichen zerschellten während des Widerstandskriegs ein Dutzend aedyranische Schiffe. Was die Fluten betrifft, sollte man sich wohl nach dem Rat der Astrologen richten."</DefaultText>
+      <DefaultText>"An diesen Deichen zerschellten während des Widerstandskriegs ein Dutzend aedyrische Schiffe. Was die Fluten betrifft, sollte man sich wohl nach dem Rat der Astrologen richten."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/poi/poi_bs_woedica_church.stringtable
+++ b/text/conversations/companions/poi/poi_bs_woedica_church.stringtable
@@ -31,7 +31,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>"Das ist unsere Woedica-Kirche. Ha, Dyrwäldler. Vermutlich das Erste, was wir während der Revolution niedergebrannt haben."</DefaultText>
+      <DefaultText>"Das ist unsere Woedica-Kirche. Ha, Dyrwälder. Vermutlich das Erste, was wir während der Revolution niedergebrannt haben."</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/endgameslides.stringtable
+++ b/text/conversations/endgameslides.stringtable
@@ -60,12 +60,12 @@ Mit einer Festung, die ihm Schutz bot, und einer Garnison treuer Soldaten, die i
       <ID>11</ID>
       <DefaultText>Fürst Raedrics Eifer hatte ihn einmal wieder zum Leben erweckt, doch ein zweites Mal sollte das nicht geschehen. Raedrics Vernichtung durch deine Hände bedeutete das Ende seiner erdrückenden Herrschaft über Goldtal und die umliegenden Gebiete. Ohne ihn blühte das Dorf auf. Viele neue Siedler ließen sich dort nieder, die wegen der Aufstände aus Trutzbucht geflohen waren. 
 
-Ohne einen Herrscher in der Nähe wurde Goldtal auch wilder - nicht wenige Siedler zogen sehr bald weiter, erschreckt von der selbst für dyrwäldische Verhältnisse extremen Gesetzlosigkeit. Dennoch, auch wenn das Leben dort eine Herausforderung war - Goldtal hatte überlebt und würde auch für die absehbare Zukunft weiter überleben.</DefaultText>
+Ohne einen Herrscher in der Nähe wurde Goldtal auch wilder - nicht wenige Siedler zogen sehr bald weiter, erschreckt von der selbst für dyrwälderische Verhältnisse extremen Gesetzlosigkeit. Dennoch, auch wenn das Leben dort eine Herausforderung war - Goldtal hatte überlebt und würde auch für die absehbare Zukunft weiter überleben.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>Du hattest Fürst Raedric zwar in seinem Thronsaal getötet, doch sein Eifer, sein Land von den Eothasianern zu befreien, war so stark, dass er als Todeswächter ins Leben zurückkehrte, als todloser Kreuzritter für seine brutale Sache. Nachdem er auch die letzten Überreste seiner Menschlichkeit verloren hatte, sah Raedric in allen Bürgern von Goldtal Eothasianer und führte eines Tages persönlich seine Truppen in das Dorf, um sein Land von ihnen zu befreien. Goldtal blieb als leere Hülle zurück, die Gebäude zerstört, die Bewohner niedergemetzelt. Selbst Reisende und Obdachlose wagten es nicht, in den Stadtgrenzen Zuflucht zu suchen. 
+      <DefaultText>Du hattest Fürst Raedric zwar in seinem Thronsaal getötet, doch sein Eifer, sein Land von den Eothasiern zu befreien, war so stark, dass er als Todeswächter ins Leben zurückkehrte, als todloser Kreuzritter für seine brutale Sache. Nachdem er auch die letzten Überreste seiner Menschlichkeit verloren hatte, sah Raedric in allen Bürgern von Goldtal Eothasier und führte eines Tages persönlich seine Truppen in das Dorf, um sein Land von ihnen zu befreien. Goldtal blieb als leere Hülle zurück, die Gebäude zerstört, die Bewohner niedergemetzelt. Selbst Reisende und Obdachlose wagten es nicht, in den Stadtgrenzen Zuflucht zu suchen. 
 
 Fürst Raedric kehrte zu Raedrics Festung zurück, wo er ewige Wache über sein ödes Reich hält.</DefaultText>
       <FemaleText />
@@ -88,7 +88,7 @@ In den folgenden Wochen wurden auch die Überlebenden von wütenden Mobs getöte
       <ID>15</ID>
       <DefaultText>Die Ermordung des Ducs, mutmaßlich durch die Hand eines Beseelers, hatte zu verheerenden Aufständen auf den Straßen von Trutzbucht gesorgt. Nur wenige Beseeler überlebten den ersten Tag. 
 
-Viele Dyrwäldler sahen das Ende von Waidwens Vermächtnis als ein Zeichen dafür, dass die Götter die Beseelung nicht guthießen, durch die Vertreibung der Beseeler aus Trutzbucht aber besänftigt worden waren. Mit der Zeit legte sich der Zorn der Bürger und einige überlebende Beseeler blieben in Trutzbucht und der näheren Umgebung. Um ihrer wissenschaftlichen Arbeit ungestört nachgehen zu können, zogen sie oft in die Wildnis.</DefaultText>
+Viele Dyrwälder sahen das Ende von Waidwens Vermächtnis als ein Zeichen dafür, dass die Götter die Beseelung nicht guthießen, durch die Vertreibung der Beseeler aus Trutzbucht aber besänftigt worden waren. Mit der Zeit legte sich der Zorn der Bürger und einige überlebende Beseeler blieben in Trutzbucht und der näheren Umgebung. Um ihrer wissenschaftlichen Arbeit ungestört nachgehen zu können, zogen sie oft in die Wildnis.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -192,7 +192,7 @@ Du erfuhrst nie, ob und wo sie letztlich angelangten. Doch als du nach Zwillings
     </Entry>
     <Entry>
       <ID>35</ID>
-      <DefaultText>Auf dein Geheiß hin wurde die in Sonne im Schatten gesammelte Essenz über dem Dyrwald verstreut, um mit den Seelen seiner Bewohner zu verschmelzen und sie zu beleben. Viele Dyrwäldler, die mit Schwierigkeiten rangen und erwarteten, ihrer eigenen Schwäche ausgeliefert zu sein, stellten in den folgenden Tagen erstaunt fest, dass sie voller Stärke und Durchhaltevermögen waren. Wer trauerte, konnte trotz seines Verlustes mit seinem Leben fortfahren. Wer verzweifelt war, fand neuen Grund zur Hoffnung.</DefaultText>
+      <DefaultText>Auf dein Geheiß hin wurde die in Sonne im Schatten gesammelte Essenz über dem Dyrwald verstreut, um mit den Seelen seiner Bewohner zu verschmelzen und sie zu beleben. Viele Dyrwälder, die mit Schwierigkeiten rangen und erwarteten, ihrer eigenen Schwäche ausgeliefert zu sein, stellten in den folgenden Tagen erstaunt fest, dass sie voller Stärke und Durchhaltevermögen waren. Wer trauerte, konnte trotz seines Verlustes mit seinem Leben fortfahren. Wer verzweifelt war, fand neuen Grund zur Hoffnung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -249,7 +249,7 @@ In den folgenden Monaten wurden die grenznahen Siedlungen des Dyrwalds unerklär
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>Pallegina hatte ihre Befehle von den Ducs Bels befolgt und geholfen, ein exklusives Handelsabkommen zwischen den Vailianischen Republiken und den Stämmen von Eir Glanfath auszuhandeln. Gestärkt durch das Seelengeschenk des Wächters führten die zornigen Dyrwäldler zwei lange Jahre lang Krieg gegen die Republiken. Die Republiken konnten durch Handel großen Reichtum erlangen, mussten jedoch den Verlust vieler Handelsschiffe und Tausender von Leben hinnehmen. Mehrere Duc-Familien verloren die Gunst ihrer Bürger. Aufstände in Selona forderten das Leben des dortigen Ducs, und die anderen Ducs Bels mussten ihre exklusiven Handelsrechte nach großem Druck schließlich aufgeben, um den Konflikt mit dem Dyrwald zu beenden. Pallegina war zu Beginn der Handelsbeziehungen für ihre Dienste geehrt worden und ihr Ruf bei den Ducs und innerhalb der Bruderschaft litt nicht unter den folgenden Ereignissen.</DefaultText>
+      <DefaultText>Pallegina hatte ihre Befehle von den Ducs Bels befolgt und geholfen, ein exklusives Handelsabkommen zwischen den Vailianischen Republiken und den Stämmen von Eir Glanfath auszuhandeln. Gestärkt durch das Seelengeschenk des Wächters führten die zornigen Dyrwälder zwei lange Jahre lang Krieg gegen die Republiken. Die Republiken konnten durch Handel großen Reichtum erlangen, mussten jedoch den Verlust vieler Handelsschiffe und Tausender von Leben hinnehmen. Mehrere Duc-Familien verloren die Gunst ihrer Bürger. Aufstände in Selona forderten das Leben des dortigen Ducs, und die anderen Ducs Bels mussten ihre exklusiven Handelsrechte nach großem Druck schließlich aufgeben, um den Konflikt mit dem Dyrwald zu beenden. Pallegina war zu Beginn der Handelsbeziehungen für ihre Dienste geehrt worden und ihr Ruf bei den Ducs und innerhalb der Bruderschaft litt nicht unter den folgenden Ereignissen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -302,7 +302,7 @@ Die Geheimnisse der Götter würden bewahrt werden und damit die geistige Gesund
       <ID>58</ID>
       <DefaultText>Nachdem der Wächter ihn fortgeschickt hatte, fand Aloth sich von allen Autoritäten und Verbündeten abgeschnitten, die er je gekannt hatte - seiner Familie, seiner Heimat, dem Bleiernen Schlüssel und schließlich dem Wächter.
 
-Er wanderte mehrere Tage lang allein umher, durch Dörfer und Siedlungen. Die Dyrwäldler, an denen er vorbeiwanderte, blickten den zerlumpten Aedyraner misstrauisch an. Er verweilte nicht lange genug, um ihr Misstrauen in Gewalt umschlagen zu lassen.</DefaultText>
+Er wanderte mehrere Tage lang allein umher, durch Dörfer und Siedlungen. Die Dyrwälder, an denen er vorbeiwanderte, blickten den zerlumpten Aedyrer misstrauisch an. Er verweilte nicht lange genug, um ihr Misstrauen in Gewalt umschlagen zu lassen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -500,7 +500,7 @@ Doch die letzte Hohlgeburt war nun Vergangenheit, und die Eltern, die das Risiko
     </Entry>
     <Entry>
       <ID>90</ID>
-      <DefaultText>Für den Drywald selbst aber war die letzte Hohlgeburt nun Vergangenheit, und das Land feierte das Ende von Waidwens Vermächtnis, ohne zu wissen, welchen Preis es in der Zukunft dafür würde zahlen müssen.</DefaultText>
+      <DefaultText>Für den Dyrwald selbst aber war die letzte Hohlgeburt nun Vergangenheit, und das Land feierte das Ende von Waidwens Vermächtnis, ohne zu wissen, welchen Preis es in der Zukunft dafür würde zahlen müssen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -515,12 +515,12 @@ Doch die letzte Hohlgeburt war nun Vergangenheit, und die Eltern, die das Risiko
     </Entry>
     <Entry>
       <ID>93</ID>
-      <DefaultText>Für die Bewohner des Dyrwaldes blieb die Frage bestehen, wie eh und je, denn selbst die Wahrheit war schlicht nicht zu glauben. Eines Tages hatten die Hohlgeburten ein Ende genommen, so jäh und unerklärlich, wie sie begonnen hatten. Und bei all ihrer Freude über das Ende des Vermächtnisses mussten die Dyrwäldler sich mit ihren eigenen Theorien über das Wie und Warum zufriedengeben. Aber vielleicht war das, was Wael beabsichtigt hatte.</DefaultText>
+      <DefaultText>Für die Bewohner des Dyrwalds blieb die Frage bestehen, wie eh und je, denn selbst die Wahrheit war schlicht nicht zu glauben. Eines Tages hatten die Hohlgeburten ein Ende genommen, so jäh und unerklärlich, wie sie begonnen hatten. Und bei all ihrer Freude über das Ende des Vermächtnisses mussten die Dyrwälder sich mit ihren eigenen Theorien über das Wie und Warum zufriedengeben. Aber vielleicht war das, was Wael beabsichtigt hatte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>94</ID>
-      <DefaultText>Die Himmel des Dyrwalds verdunkelten sich. Gewaltige Schwärme von Vögeln und anderen geflügelten Kreaturen waren zusammengerufen wurden, um sich zu nehmen, was die Himmelsmutter als ihr Recht erachtete. Monatelang waren die Bewohner des Dyrwalds gezwungen, sich versteckt zu halten, aus Furcht vor den brutalen, unerklärlichen Angriffen vom Himmel, die ganze Dörfer dezimiert zurückließen und die Straßen von Trutzbucht mit Leichen pflasterten, die mit tausenden von Hieb-, Stich- und Hackwunden übersät waren.</DefaultText>
+      <DefaultText>Der Himmel des Dyrwalds verdunkelte sich. Gewaltige Schwärme von Vögeln und anderen geflügelten Kreaturen waren zusammengerufen worden, um sich zu nehmen, was die Himmelsmutter als ihr Recht erachtete. Monatelang waren die Bewohner des Dyrwalds gezwungen, sich versteckt zu halten, aus Furcht vor den brutalen, unerklärlichen Angriffen vom Himmel, die ganze Dörfer dezimiert zurückließen und die Straßen von Trutzbucht mit Leichen pflasterten, die mit tausenden von Hieb-, Stich- und Hackwunden übersät waren.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -544,12 +544,12 @@ Wer die Beteiligung des Zwillingsgottes spürte, der bezeichnete die Katastrophe
     </Entry>
     <Entry>
       <ID>98</ID>
-      <DefaultText>Im Herzen der geschäftigen Stadt Neu-Heomar verstümmelten und entstellten Skaeniten ein Mitglied ihrer eigenen Gemeinde, entfernten Augen, Haare, Nase und Genitalien, ritzten den Leichnam blutig und ersetzten seine Augen durch schwarze Steine. Der auserwählten Hülle gab man Blut zu trinken - nicht das eines Adligen, wie das Ritual es eigentlich verlangte, sondern das von einem Dutzend gewöhnlicher Dyrwäldler. Die Inkarnation des Bildnisses, die in jenen Körper geboren wurde, war brutaler als alle in der bekannten Geschichtsschreibung erwähnten. Unermüdlich tötete sie Hunderte und verstümmelte ihre Leichen auf rituelle Weise, ehe sie selbst tot umfiel, endlich zufrieden.</DefaultText>
+      <DefaultText>Im Herzen der geschäftigen Stadt Neu-Heomar verstümmelten und entstellten Skaeniten ein Mitglied ihrer eigenen Gemeinde, entfernten Augen, Haare, Nase und Genitalien, ritzten den Leichnam blutig und ersetzten seine Augen durch schwarze Steine. Der auserwählten Hülle gab man Blut zu trinken - nicht das eines Adligen, wie das Ritual es eigentlich verlangte, sondern das von einem Dutzend gewöhnlicher Dyrwälder. Die Inkarnation des Bildnisses, die in jenen Körper geboren wurde, war brutaler als alle in der bekannten Geschichtsschreibung erwähnten. Unermüdlich tötete sie Hunderte und verstümmelte ihre Leichen auf rituelle Weise, ehe sie selbst tot umfiel, endlich zufrieden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>99</ID>
-      <DefaultText>Goldtal verblieb unter der brutalen Herrschaft von Fürst Raedric, der nach dem Tod seines Vetters Kolsc unangefochten regierte und die Bewohner weiter terrorisierte, auf der Suche nach Eothasianern in ihrer Mitte.
+      <DefaultText>Goldtal verblieb unter der brutalen Herrschaft von Fürst Raedric, der nach dem Tod seines Vetters Kolsc unangefochten regierte und die Bewohner weiter terrorisierte, auf der Suche nach Eothasiern in ihrer Mitte.
 
 Für Raedric aber war das plötzliche und unerwartete Ende von Waidwens Vermächtnis ein Zeichen des Erfolges und der Rechtschaffenheit seiner Bemühungen, und mit der Zeit begann auch sein Volk, das zu glauben. Er lockerte seinen Einsatz von Autorität und Gewalt, da er sein eigenes Volk nicht länger als Bedrohung ansah, und nach und nach gewann Goldtal einen Teil seines früheren Glanzes zurück.</DefaultText>
       <FemaleText />
@@ -558,7 +558,7 @@ Für Raedric aber war das plötzliche und unerwartete Ende von Waidwens Vermäch
       <ID>103</ID>
       <DefaultText>Als das Vermächtnis aufgehoben worden war, betrachteten die Leute das nicht als Zeichen, dass die Aufstände den Wünschen der Götter entsprochen hatten, wie Thaos es erhofft hatte, sondern als Bestätigung, dass die Beseelung niemals je die Ursache des Problems gewesen war. 
 
-Stattdessen überzeugten die Dyrwäldler sich, dass die Aufstände Trutzbucht irgendwie von Spionen des Bleiernen Schlüssels befreit hatte, und dass das Ende von Waidwens Vermächtnis ihre wohlverdiente Belohnung war.
+Stattdessen überzeugten die Dyrwälder sich, dass die Aufstände Trutzbucht irgendwie von Spionen des Bleiernen Schlüssels befreit hatte, und dass das Ende von Waidwens Vermächtnis ihre wohlverdiente Belohnung war.
 
 Der Zorn gegen die Beseeler war bald vergessen, und wer überlebt hatte, durfte zum Sanatorium von Farnheim zurückkehren und es wieder aufbauen, um seine Forschungsarbeiten fortzusetzen.</DefaultText>
       <FemaleText />
@@ -683,7 +683,7 @@ Sagani kehrte in ein Dorf zurück, das ihr Gesicht vergessen hatte, sich aber an
       <ID>126</ID>
       <DefaultText>Zudem erfuhr sie, dass Kallu einige Jahre zuvor am Winterfieber gestorben war und ihr mittleres Kind, Najuo, bei einem Überfall ums Leben gekommen war.
 
-Sie fand jedoch ihre Tochter Yakuna vor, eine Jägerin und selbst Mutter dreier Kinder, sowie ihren Sohn Malaak, Erbauer mächtiger Wände. Durch sie fand sie schließlich ihren Platz in dem Dorf wieder - und in den vertrauten Konturen einer Welt, die sich während ihrer Abwesenheit verändert hatte.</DefaultText>
+Sie fand jedoch ihre Tochter Yakona vor, eine Jägerin und selbst Mutter dreier Kinder, sowie ihren Sohn Malaak, Erbauer mächtiger Wände. Durch sie fand sie schließlich ihren Platz in dem Dorf wieder - und in den vertrauten Konturen einer Welt, die sich während ihrer Abwesenheit verändert hatte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/prototype_2/p2_cv_hendyna.stringtable
+++ b/text/conversations/prototype_2/p2_cv_hendyna.stringtable
@@ -229,7 +229,7 @@ Sie beugt sich näher zu dir heran. "Und komm immer bei mir vorbei, wenn du Trä
     </Entry>
     <Entry>
       <ID>74</ID>
-      <DefaultText>"Weißt du irgendwas über eine nahegelegene Engwithan-Ruine?"</DefaultText>
+      <DefaultText>"Weißt du irgendwas über eine nahegelegene engwithanische Ruine?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/prototype_2/p2_cv_osmaer.stringtable
+++ b/text/conversations/prototype_2/p2_cv_osmaer.stringtable
@@ -66,7 +66,7 @@
     </Entry>
     <Entry>
       <ID>16</ID>
-      <DefaultText>"Hier stand einst eine Burg. Wurde von irgendeiner Familie aedryanischer Thayns in den Anfangszeiten des Kaiserreichs gebaut. Nur ein Turm davon steht noch, und der gehört jetzt zu Trygils Laden."
+      <DefaultText>"Hier stand einst eine Burg. Wurde von irgendeiner Familie aedyrischer Thayns in den Anfangszeiten des Kaiserreichs gebaut. Nur ein Turm davon steht noch, und der gehört jetzt zu Trygils Laden."
 
 "Wenn dich das so interessiert, könnte dir Sid, die Bardin da beim Feuer, das Garn dazu spinnen."</DefaultText>
       <FemaleText />
@@ -185,7 +185,7 @@
     </Entry>
     <Entry>
       <ID>71</ID>
-      <DefaultText>"Weißt du irgendwas über eine nahegelegene Engwithan-Ruine?"</DefaultText>
+      <DefaultText>"Weißt du irgendwas über eine nahegelegene engwithanische Ruine?"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/backstory.stringtable
+++ b/text/game/backstory.stringtable
@@ -551,7 +551,7 @@
     </Entry>
     <Entry>
       <ID>110</ID>
-      <DefaultText>Du trafst ein Abkommen mit Galawain, Magran und Abydon, die von Thaos gestohlenen Seelen zur Festigung der Seelen der überlebenden Dyrwäldler zu nutzen, und sie auf diese Weise stärker und fähiger zu machen.</DefaultText>
+      <DefaultText>Du trafst ein Abkommen mit Galawain, Magran und Abydon, die von Thaos gestohlenen Seelen zur Festigung der Seelen der überlebenden Dyrwälder zu nutzen, und sie auf diese Weise stärker und fähiger zu machen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1921,7 +1921,7 @@
     </Entry>
     <Entry>
       <ID>385</ID>
-      <DefaultText>Hiravias traf Scathden, einen anderen Druiden, mit dem er die Herbst-Stelgaer-Gestalt gemeinsam hat. Hiravias arrangierte sich mit seinen vor langer Zeit erlittenen Wunden und darauffolgender Ächtung.</DefaultText>
+      <DefaultText>Hiravias traf Scâthden, einen anderen Druiden, mit dem er die Herbst-Stelgaer-Gestalt gemeinsam hat. Hiravias arrangierte sich mit seinen vor langer Zeit erlittenen Wunden und darauffolgender Ächtung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/characters.stringtable
+++ b/text/game/characters.stringtable
@@ -3161,7 +3161,7 @@
     </Entry>
     <Entry>
       <ID>686</ID>
-      <DefaultText>Menpwgra</DefaultText>
+      <DefaultText>Mênpŵgra</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/characters.stringtable
+++ b/text/game/characters.stringtable
@@ -1441,7 +1441,7 @@
     </Entry>
     <Entry>
       <ID>332</ID>
-      <DefaultText>Aedyranische Adlige</DefaultText>
+      <DefaultText>Aedyrische Adlige</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2251,7 +2251,7 @@
     </Entry>
     <Entry>
       <ID>500</ID>
-      <DefaultText>Glanfathan</DefaultText>
+      <DefaultText>Glanfathaner</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2506,7 +2506,7 @@
     </Entry>
     <Entry>
       <ID>552</ID>
-      <DefaultText>Dyrwäldler</DefaultText>
+      <DefaultText>Dyrwälder</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2566,7 +2566,7 @@
     </Entry>
     <Entry>
       <ID>566</ID>
-      <DefaultText>Llensî</DefaultText>
+      <DefaultText>Llensi</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2736,7 +2736,7 @@
     </Entry>
     <Entry>
       <ID>600</ID>
-      <DefaultText>Glanfathan</DefaultText>
+      <DefaultText>Glanfathanerin</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3161,7 +3161,7 @@
     </Entry>
     <Entry>
       <ID>686</ID>
-      <DefaultText>Mênpŵgra</DefaultText>
+      <DefaultText>Menpwgra</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3526,7 +3526,7 @@
     </Entry>
     <Entry>
       <ID>762</ID>
-      <DefaultText>Dyrwäldlerischer Zaubergürtel</DefaultText>
+      <DefaultText>Dyrwälderischer Zaubergürtel</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3601,7 +3601,7 @@
     </Entry>
     <Entry>
       <ID>777</ID>
-      <DefaultText>Ring der Selonan</DefaultText>
+      <DefaultText>Ring der Selonier</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5356,12 +5356,12 @@
     </Entry>
     <Entry>
       <ID>1131</ID>
-      <DefaultText>Aedyranischer Würdenträger</DefaultText>
+      <DefaultText>Aedyrischer Würdenträger</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1132</ID>
-      <DefaultText>Dyrwäldlerischer Söldner</DefaultText>
+      <DefaultText>Dyrwälderischer Söldner</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5826,7 +5826,7 @@
     </Entry>
     <Entry>
       <ID>1227</ID>
-      <DefaultText>Umhang eines eothasiatischen Priesters</DefaultText>
+      <DefaultText>Umhang eines eothasischen Priesters</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5991,12 +5991,12 @@
     </Entry>
     <Entry>
       <ID>1260</ID>
-      <DefaultText>Aedyranischer Sklavenhalter</DefaultText>
+      <DefaultText>Aedyrischer Sklavenhalter</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1261</ID>
-      <DefaultText>Aedyranischer Priester</DefaultText>
+      <DefaultText>Aedyrischer Priester</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6006,7 +6006,7 @@
     </Entry>
     <Entry>
       <ID>1263</ID>
-      <DefaultText>Aedyranischer Scharfschütze</DefaultText>
+      <DefaultText>Aedyrischer Scharfschütze</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6021,7 +6021,7 @@
     </Entry>
     <Entry>
       <ID>1266</ID>
-      <DefaultText>Aedyranischer Zuchtmeister</DefaultText>
+      <DefaultText>Aedyrischer Zuchtmeister</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6046,22 +6046,22 @@
     </Entry>
     <Entry>
       <ID>1271</ID>
-      <DefaultText>Eothasiatischer Fanatiker</DefaultText>
+      <DefaultText>Eothasischer Fanatiker</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1272</ID>
-      <DefaultText>Eothasiatischer Wärter</DefaultText>
+      <DefaultText>Eothasischer Wärter</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1273</ID>
-      <DefaultText>Eothasiatischer Asket</DefaultText>
+      <DefaultText>Eothasischer Asket</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1274</ID>
-      <DefaultText>Eothasiatischer Kriegsmagier</DefaultText>
+      <DefaultText>Eothasischer Kriegsmagier</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6076,7 +6076,7 @@
     </Entry>
     <Entry>
       <ID>1277</ID>
-      <DefaultText>Kapitän Muarumi</DefaultText>
+      <DefaultText>Kapitän Muārumi</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6116,7 +6116,7 @@
     </Entry>
     <Entry>
       <ID>1285</ID>
-      <DefaultText>Devwen</DefaultText>
+      <DefaultText>Devŵen</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6176,7 +6176,7 @@
     </Entry>
     <Entry>
       <ID>1297</ID>
-      <DefaultText>Dyrwäldlerischer Händler</DefaultText>
+      <DefaultText>Dyrwälderischer Händler</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6651,7 +6651,7 @@
     </Entry>
     <Entry>
       <ID>1416</ID>
-      <DefaultText>Naedle</DefaultText>
+      <DefaultText>Naelde</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/cyclopedia.stringtable
+++ b/text/game/cyclopedia.stringtable
@@ -131,7 +131,7 @@
     </Entry>
     <Entry>
       <ID>26</ID>
-      <DefaultText>Aedyranische Bräuche</DefaultText>
+      <DefaultText>Aedyrische Bräuche</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -141,12 +141,12 @@
     </Entry>
     <Entry>
       <ID>28</ID>
-      <DefaultText>Poesie aus Naasitaq</DefaultText>
+      <DefaultText>Naasitaqi Poesie</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>Poesie aus Glanfathan</DefaultText>
+      <DefaultText>Glanfathanische Poesie</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -171,12 +171,12 @@
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>Heiliger Eothasia-Schrift</DefaultText>
+      <DefaultText>Heilige Eothas-Schrift</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>35</ID>
-      <DefaultText>Dyrwäldlerische Farce</DefaultText>
+      <DefaultText>Dyrwälderische Farce</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -273,12 +273,12 @@ Lauerer sind dafür berüchtigt, sich in voller Sicht zu verstecken. Oft warten 
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwäldlerischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
+      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwälderischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>"Wo auch immer es Hirsche gibt, bald sind die Wölfe da." Dieses aedyranische Sprichwort, bei dem oft der erste Satzteil ausgelassen wird, deutet die Verwundbarkeit an, die von den frühen Siedlern im Östlichen Abschnitt oft empfunden wurde. Außerdem steht es für die langjährige Assoziation der Aedyraner (wörtlich: "Das Volk des Hirschen") mit den vierbeinigen Raubtieren, die im Dyrwald wie im aedyranischen Reich gleichermaßen allgegenwärtig sind.
+      <DefaultText>"Wo auch immer es Hirsche gibt, bald sind die Wölfe da." Dieses aedyrische Sprichwort, bei dem oft der erste Satzteil ausgelassen wird, deutet die Verwundbarkeit an, die von den frühen Siedlern im Östlichen Abschnitt oft empfunden wurde. Außerdem steht es für die langjährige Assoziation der Aedyrer (wörtlich: "Das Volk des Hirschen") mit den vierbeinigen Raubtieren, die im Dyrwald wie im aedyrischen Reich gleichermaßen allgegenwärtig sind.
 
 Die Geschwindigkeit von Wölfen ist ebenso legendär wie ihre Fähigkeit, ihre Beute zu Boden zu bringen, um sie mit verheerenden Angriffen zu töten.</DefaultText>
       <FemaleText />
@@ -1075,7 +1075,7 @@ Manche Waffen oder Angriffe können mehrere Schadensarten anrichten oder zeigen 
     </Entry>
     <Entry>
       <ID>197</ID>
-      <DefaultText>Der Dyrwald besitzt eine gesunde Bärenpopulation, auch wenn die meisten der Tiere die zivilisierten Gebiete und Straßen der Gestandenen meiden. Adlige jagen manchmal zum Vergnügen Bären, doch die meisten Kolonisten, älteren Dyrwäldler und Glanfathaner gehen ihnen einfach aus dem Weg. In den Wäldern des Östlichen Abschnitts ist reichlich Wild zu finden, das sich sehr viel weniger erbittert wehrt als ein zorniger Bär.</DefaultText>
+      <DefaultText>Der Dyrwald besitzt eine gesunde Bärenpopulation, auch wenn die meisten der Tiere die zivilisierten Gebiete und Straßen der Gestandenen meiden. Adlige jagen manchmal zum Vergnügen Bären, doch die meisten Kolonisten, älteren Dyrwälder und Glanfathaner gehen ihnen einfach aus dem Weg. In den Wäldern des Östlichen Abschnitts ist reichlich Wild zu finden, das sich sehr viel weniger erbittert wehrt als ein zorniger Bär.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1322,7 +1322,7 @@ Das bedeutet, dass alle Statistiken der Waffen weiter gelten, insbesondere der S
     </Entry>
     <Entry>
       <ID>242</ID>
-      <DefaultText>Eine koloniale Nation, die von Siedlern aus dem aedyranischen Reich gegründet wurde. Nach einer Reihe von Konflikten mit Aedyr erlangte das Gebiet im Jahr 2672 AI seine Unabhängigkeit. Heute herrscht ein Duc über das Land, der von sieben Grafen gewählt wird, welche seine Grafschaften überwachen.</DefaultText>
+      <DefaultText>Eine koloniale Nation, die von Siedlern aus dem aedyrischen Reich gegründet wurde. Nach einer Reihe von Konflikten mit Aedyr erlangte das Gebiet im Jahr 2672 AI seine Unabhängigkeit. Heute herrscht ein Duc über das Land, der von sieben Grafen gewählt wird, welche seine Grafschaften überwachen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1352,7 +1352,7 @@ Das bedeutet, dass alle Statistiken der Waffen weiter gelten, insbesondere der S
     </Entry>
     <Entry>
       <ID>248</ID>
-      <DefaultText>Dyrwalds Nachbar im Norden. Readceras ist eine Nation, die fest in ihrem eothasianischen Glauben verwurzelt ist. Begonnen hat dieser Eifer während des Kriegs des Heiligen, und selbst, nachdem Eothas offenbar tot ist, lässt er nicht nach.</DefaultText>
+      <DefaultText>Dyrwalds Nachbar im Norden. Readceras ist eine Nation, die fest in ihrem eothasischen Glauben verwurzelt ist. Begonnen hat dieser Eifer während des Kriegs des Heiligen, und selbst, nachdem Eothas offenbar tot ist, lässt er nicht nach.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1452,7 +1452,7 @@ Das bedeutet, dass alle Statistiken der Waffen weiter gelten, insbesondere der S
     </Entry>
     <Entry>
       <ID>268</ID>
-      <DefaultText>Nach dem Krieg des Heiligen trachteten dyrwäldische Mobs danach, alle Anhänger von Eothas zu töten, insbesondere in ländlichen Gebieten. Ausgehend von der Stadt Kaltmorg, die Waidwens Truppen angeblich widerstandslos passieren ließ, wurden Eothasianer gejagt, gefoltert und auf den Straßen ermordet.</DefaultText>
+      <DefaultText>Nach dem Krieg des Heiligen trachteten dyrwälderische Mobs danach, alle Anhänger von Eothas zu töten, insbesondere in ländlichen Gebieten. Ausgehend von der Stadt Kaltmorg, die Waidwens Truppen angeblich widerstandslos passieren ließ, wurden Eothasier gejagt, gefoltert und auf den Straßen ermordet.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/gui.stringtable
+++ b/text/game/gui.stringtable
@@ -2386,7 +2386,7 @@
     </Entry>
     <Entry>
       <ID>479</ID>
-      <DefaultText>Orlaner sind die Kleinste der Rassen der Gestandenen, obwohl viele Kulturen sie überhaupt nicht als zivilisiert betrachten. Orlaner stechen auch wegen ihrer großen Ohren, ihrer zweifarbigen Haut und ihrer behaarten Körper hervor, und man findet sie gewöhnlich in Eir&#160;Glanfath, den Ixamitl-Ebenen und Teilen des Dyrwaldes. Sie sind bekannt für ihre mentale Stärke und ihre Schnelligkeit.</DefaultText>
+      <DefaultText>Orlaner sind die Kleinste der Rassen der Gestandenen, obwohl viele Kulturen sie überhaupt nicht als zivilisiert betrachten. Orlaner stechen auch wegen ihrer großen Ohren, ihrer zweifarbigen Haut und ihrer behaarten Körper hervor, und man findet sie gewöhnlich in Eir&#160;Glanfath, den Ixamitl-Ebenen und Teilen des Dyrwalds. Sie sind bekannt für ihre mentale Stärke und ihre Schnelligkeit.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2431,7 +2431,7 @@ Elementare Geduld - Alle Bleichelfen haben erhöhte Schadensreduktionen gegen Br
     </Entry>
     <Entry>
       <ID>486</ID>
-      <DefaultText>Bergzwerge (Aptapo) stammen aus der Region östlich des Dyrwaldes und haben sich in dieser Gegend mehrmals ausgebreitet. Anders als die ebenso sehr kleinen Orlaner, die regelmäßig unterjocht werden, haben die Aptapo Bedrohungen durch größere Gestandene immer direkt zurückgeschlagen und sich dazu entschieden, ihre Wohnorte zu befestigen, statt weiterzuziehen. Bergzwerge sind in den Vailianischen Republiken verbreitet, im Dyrwald und in Readceras werden sie jedoch nicht so häufig gesehen. 
+      <DefaultText>Bergzwerge (Aptapo) stammen aus der Region östlich des Dyrwalds und haben sich in dieser Gegend mehrmals ausgebreitet. Anders als die ebenso sehr kleinen Orlaner, die regelmäßig unterjocht werden, haben die Aptapo Bedrohungen durch größere Gestandene immer direkt zurückgeschlagen und sich dazu entschieden, ihre Wohnorte zu befestigen, statt weiterzuziehen. Bergzwerge sind in den Vailianischen Republiken verbreitet, im Dyrwald und in Readceras werden sie jedoch nicht so häufig gesehen. 
 
 Gesund und Zäh - Bergzwerge erhalten einen Bonus auf die Verteidigung gegen Gift- und Krankheitsangriffe.</DefaultText>
       <FemaleText />
@@ -2474,14 +2474,14 @@ Silberflut - In jeder Begegnung generieren Mond-Gottähnliche, wenn sie auf unte
     </Entry>
     <Entry>
       <ID>492</ID>
-      <DefaultText>Sesshafte Orlaner sind in Readceras und in den Vailianischen Republiken oftmals Sklaven. Eine der Vertragsbedingungen zwischen dem Dyrwald und dem Volk aus Eír&#160;Glanfath war die Befreiung der orlanischen Sklaven, und obwohl diese eingehalten wurde, leben im Dyrwald noch immer viele sesshafte Orlaner als Schuldknechte .
+      <DefaultText>Sesshafte Orlaner sind in Readceras und in den Vailianischen Republiken oftmals Sklaven. Eine der Vertragsbedingungen zwischen dem Dyrwald und dem Volk aus Eir&#160;Glanfath war die Befreiung der orlanischen Sklaven, und obwohl diese eingehalten wurde, leben im Dyrwald noch immer viele sesshafte Orlaner als Schuldknechte .
 
 Geringe Bedrohung - Greift ein sesshafter Orlaner ein Ziel an, das von einem Gruppenmitglied ebenfalls als Ziel ausgewählt worden ist, verwandelt der sesshafte Orlaner einen Teil seiner T&#2060;reffer in Kritische Treffer.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>493</ID>
-      <DefaultText>Wilde Orlaner sind die "ursprünglichen" Orlaner, die in den tiefsten Wäldern und Dschungeln zwischen den Tropen lebten. Auch wenn sie nur etwa tausend Jahre merklich von den sesshaften Orlanern getrennt waren, sind schnell ein paar genetische Unterschiede aufgetaucht. Bemerkenswert ist dabei vor allem die fehlende Gesichtsbehaarung im Zweig der sesshaften Orlaner. Wilde Orlaner sind in den Tiefen von Eír&#160;Glanfath verbreitet. Im Gegensatz zu ihren sesshaften Brüdern sieht man sie nur selten im Dyrwald, in Readceras oder in den Vailianischen Republiken. 
+      <DefaultText>Wilde Orlaner sind die "ursprünglichen" Orlaner, die in den tiefsten Wäldern und Dschungeln zwischen den Tropen lebten. Auch wenn sie nur etwa tausend Jahre merklich von den sesshaften Orlanern getrennt waren, sind schnell ein paar genetische Unterschiede aufgetaucht. Bemerkenswert ist dabei vor allem die fehlende Gesichtsbehaarung im Zweig der sesshaften Orlaner. Wilde Orlaner sind in den Tiefen von Eir&#160;Glanfath verbreitet. Im Gegensatz zu ihren sesshaften Brüdern sieht man sie nur selten im Dyrwald, in Readceras oder in den Vailianischen Republiken. 
 
 Trotzige Entschlossenheit - Nachdem sie einem Willensangriff ausgesetzt waren, erhalten wilde Orlaner vorübergehend einen Bonus auf alle Verteidigungen.</DefaultText>
       <FemaleText />
@@ -2495,7 +2495,7 @@ Turmhohe Statur - Küsten-Aumaua erhalten Boni auf die Verteidigung gegen die Wi
     </Entry>
     <Entry>
       <ID>495</ID>
-      <DefaultText>Insel-Aumaua stammen aus dem Todesfeuer-Archipel tausend Meilen südlich der Vailianischen Republiken. Obwohl sie mit ihren Küsten-Vetter physiologische Ähnlichkeiten teilen, unterscheidet sich die Färbung der Insel-Aumaua – Braun und Gelb – sehr stark von der Färbung der Küsten-Aumaua – Blau und Grün. Auch wenn sie im Dyrwald und den angrenzenden Umgebungen immer noch selten sind, trifft man dort häufiger auf Insel-Aumaua als auf Küsten-Aumaua. Wenn man sie in der Nähe des Dyrwaldes antrifft, sind sie oftmals Arbeiter, Fischer oder Seefahrer. 
+      <DefaultText>Insel-Aumaua stammen aus dem Todesfeuer-Archipel tausend Meilen südlich der Vailianischen Republiken. Obwohl sie mit ihren Küsten-Vetter physiologische Ähnlichkeiten teilen, unterscheidet sich die Färbung der Insel-Aumaua – Braun und Gelb – sehr stark von der Färbung der Küsten-Aumaua – Blau und Grün. Auch wenn sie im Dyrwald und den angrenzenden Umgebungen immer noch selten sind, trifft man dort häufiger auf Insel-Aumaua als auf Küsten-Aumaua. Wenn man sie in der Nähe des Dyrwalds antrifft, sind sie oftmals Arbeiter, Fischer oder Seefahrer. 
 
 Bis an die Zähne bewaffnet - Alle Insel-Aumaua erhalten ein zusätzliches Waffenset</DefaultText>
       <FemaleText />
@@ -2560,7 +2560,7 @@ Tierischer Gefährte - Alle Waldläufer besitzen eine starke Verbindung zu einem
     </Entry>
     <Entry>
       <ID>502</ID>
-      <DefaultText>Als Animisten im Herzen zapfen Druiden jene spirituelle Kraft an, die durch die einfachen, lebenden Dinge in Eora strömt: Pflanzen, Tiere und manchmal sogar lebende Steine. Obwohl nicht unbedingt religiös, verehren Druiden die natürliche Welt und haben ein leidenschaftliches Interesse, ihre Mysterien zu verstehen. In den meisten Kulturen werden Druiden als eine Art Urmagier verstanden. Unter den Glanfathanern, den Naasitaqis und vielen ländlichen Kulturen können sie jedoch hohe Positionen mit Einfluss und Autorität einnehmen. 
+      <DefaultText>Als Animisten im Herzen zapfen Druiden jene spirituelle Kraft an, die durch die einfachen, lebenden Dinge in Eora strömt: Pflanzen, Tiere und manchmal sogar lebende Steine. Obwohl nicht unbedingt religiös, verehren Druiden die natürliche Welt und haben ein leidenschaftliches Interesse, ihre Mysterien zu verstehen. In den meisten Kulturen werden Druiden als eine Art Urmagier verstanden. Unter den Glanfathanern, den Naasitaqi und vielen ländlichen Kulturen können sie jedoch hohe Positionen mit Einfluss und Autorität einnehmen. 
 
 Anfängliche Fähigkeiten:
 
@@ -3671,12 +3671,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>723</ID>
-      <DefaultText>In Aedyranisch als „Berath“ und in Vailianisch als „Cirono“ bekannt; ist der Gott der Kreise, der Türen und des Lebens und des Todes selbst. Gewöhnlich schnitzen oder platzieren Menschen die Figur von Berath in Türeingänge, Fenster und andere „Portale“, die von einem Ort zum anderen führen. Berath hat eine relativ kleine Priesterschaft. Zum Teil, weil er nicht oft zu ihnen spricht. Dennoch hat Berath viele Bittsteller und gelegentliche Anhänger.</DefaultText>
+      <DefaultText>In Aedyrisch als „Berath“ und in Vailianisch als „Cirono“ bekannt; ist der Gott der Kreise, der Türen und des Lebens und des Todes selbst. Gewöhnlich schnitzen oder platzieren Menschen die Figur von Berath in Türeingänge, Fenster und andere „Portale“, die von einem Ort zum anderen führen. Berath hat eine relativ kleine Priesterschaft. Zum Teil, weil er nicht oft zu ihnen spricht. Dennoch hat Berath viele Bittsteller und gelegentliche Anhänger.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>724</ID>
-      <DefaultText>Eothas ist der aedyranische Name für den Gott des Lichtes, der Erlösung und der Wiedergeburt. Während im Reich Aedyr und Readceras die Verehrung von Eothas immer noch weit verbreitet ist, wird der Glaube in den meisten Städten des Dyrwaldes aufgrund der Geschehnisse im Heilligen Krieg geächtet. Der heilige Waidwen, der angeblich zu einem lebenden Gefäß für Eothas wurde, hatte versucht, in den Dyrwald einzufallen, bevor er vor den Toren der Zitadelle von Halgot vernichtet wurde. Seitdem hat man nichts mehr von Eothas gehört, weshalb er von vielen für tot gehalten wird.</DefaultText>
+      <DefaultText>Eothas ist der aedyrische Name für den Gott des Lichtes, der Erlösung und der Wiedergeburt. Während im Reich Aedyr und Readceras die Verehrung von Eothas immer noch weit verbreitet ist, wird der Glaube in den meisten Städten des Dyrwalds aufgrund der Geschehnisse im Heiligen Krieg geächtet. Der heilige Waidwen, der angeblich zu einem lebenden Gefäß für Eothas wurde, hatte versucht, in den Dyrwald einzufallen, bevor er vor den Toren der Zitadelle von Halgot vernichtet wurde. Seitdem hat man nichts mehr von Eothas gehört, weshalb er von vielen für tot gehalten wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3741,7 +3741,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>737</ID>
-      <DefaultText>Schildknappen der heiligen&#160;Elcga</DefaultText>
+      <DefaultText>Schildknappen der heiligen Elcga</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3771,7 +3771,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>743</ID>
-      <DefaultText>Während einer Friedensverhandlung schoss ein Bogenschütze aus dem Reich von Aedyr der adligen Abgesandten von Kulkin, Elcga, in den Arm, um einen Kampf zu provozieren. Nichtsdestotrotz machte Elcga einen zweiten Verhandlungsversuch und wurde währenddessen von drei Elfenkriegern begleitet, die nur mit einem Schild ausgerüstet waren, den sie vor Elcga hielten, um sie zu beschützen. Elcga hatte Erfolg und half bei der Gründung des Reiches Aedyr mit. Die Ritter, die sie beschützt hatten, gründeten die Schildknappen&#160;der heiligen&#160;Elcga, die weiterhin als Beschützer und Diplomaten in Aedyr und jenseits davon agieren. Sie sind für ihre Rechtschaffenheit und ihre Verhandlungsfertigkeit sehr bekannt.</DefaultText>
+      <DefaultText>Während einer Friedensverhandlung schoss ein Bogenschütze aus dem Reich von Aedyr der adligen Abgesandten von Kulkin, Elcga, in den Arm, um einen Kampf zu provozieren. Nichtsdestotrotz machte Elcga einen zweiten Verhandlungsversuch und wurde währenddessen von drei Elfenkriegern begleitet, die nur mit einem Schild ausgerüstet waren, den sie vor Elcga hielten, um sie zu beschützen. Elcga hatte Erfolg und half bei der Gründung des Reiches Aedyr mit. Die Ritter, die sie beschützt hatten, gründeten die Schildknappen der heiligen Elcga, die weiterhin als Beschützer und Diplomaten in Aedyr und jenseits davon agieren. Sie sind für ihre Rechtschaffenheit und ihre Verhandlungsfertigkeit sehr bekannt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/gui.stringtable
+++ b/text/game/gui.stringtable
@@ -2440,7 +2440,6 @@ Gesund und Zäh - Bergzwerge erhalten einen Bonus auf die Verteidigung gegen Gif
       <ID>487</ID>
       <DefaultText>Die meisten Nordzwerge (Enutanik) leben auf der abgeschiedenen südlichen Insel von Naasitaq, wo sie die felsige Tundra und die schneebedeckten Wälder mit den eingewanderten Bleichelfen und den küstennah fahrenden Schiffen der Aumaua teilen. Wie ihre nördlichen Vettern teilen die Enutanik eine instinktive Liebe für Erkundungen. Nordzwerge sind in den Vailianischen Republiken einigermaßen verbreitet, im Dyrwald trifft man sie jedoch nur selten an. 
 
-
 Instinkte des Jägers - Nordzwerge erhalten +15 Genauigkeit im Kampf gegen Wesen der Kategorien "Wilde" oder "Primitive".</DefaultText>
       <FemaleText />
     </Entry>
@@ -2474,7 +2473,7 @@ Silberflut - In jeder Begegnung generieren Mond-Gottähnliche, wenn sie auf unte
     </Entry>
     <Entry>
       <ID>492</ID>
-      <DefaultText>Sesshafte Orlaner sind in Readceras und in den Vailianischen Republiken oftmals Sklaven. Eine der Vertragsbedingungen zwischen dem Dyrwald und dem Volk aus Eir&#160;Glanfath war die Befreiung der orlanischen Sklaven, und obwohl diese eingehalten wurde, leben im Dyrwald noch immer viele sesshafte Orlaner als Schuldknechte .
+      <DefaultText>Sesshafte Orlaner sind in Readceras und in den Vailianischen Republiken oftmals Sklaven. Eine der Vertragsbedingungen zwischen dem Dyrwald und dem Volk aus Eir&#160;Glanfath war die Befreiung der orlanischen Sklaven, und obwohl diese eingehalten wurde, leben im Dyrwald noch immer viele sesshafte Orlaner als Schuldknechte.
 
 Geringe Bedrohung - Greift ein sesshafter Orlaner ein Ziel an, das von einem Gruppenmitglied ebenfalls als Ziel ausgewählt worden ist, verwandelt der sesshafte Orlaner einen Teil seiner T&#2060;reffer in Kritische Treffer.</DefaultText>
       <FemaleText />

--- a/text/game/interactables.stringtable
+++ b/text/game/interactables.stringtable
@@ -156,7 +156,7 @@
     </Entry>
     <Entry>
       <ID>55</ID>
-      <DefaultText>Dies ist das Meisterwerk eines berühmten aedyranischen Malers.</DefaultText>
+      <DefaultText>Dies ist das Meisterwerk eines berühmten aedyrischen Malers.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -476,7 +476,7 @@
     </Entry>
     <Entry>
       <ID>143</ID>
-      <DefaultText>Obwohl vom Zahn der Zeit angenagt, sind bei vielen dieser Nischen Gravuren mit aedyranischen Nachnamen erkennbar.</DefaultText>
+      <DefaultText>Obwohl vom Zahn der Zeit angenagt, sind bei vielen dieser Nischen Gravuren mit aedyrischen Nachnamen erkennbar.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1029,7 +1029,7 @@ Nach Trutzbucht im Westen</DefaultText>
     </Entry>
     <Entry>
       <ID>278</ID>
-      <DefaultText>Das Porträt stellt einen Mann und eine Frau in aedyranischer Kleidung da, die wohl vor einem Jahrhundert in Mode gewesen ist. Der schwere Bilderrahmen ist ramponiert und das Schild, auf dem einst der Name des Gönners stand, wurde herausgekratzt.
+      <DefaultText>Das Porträt stellt einen Mann und eine Frau in aedyrischer Kleidung da, die wohl vor einem Jahrhundert in Mode gewesen ist. Der schwere Bilderrahmen ist ramponiert und das Schild, auf dem einst der Name des Gönners stand, wurde herausgekratzt.
 
 Die beiden umarmen sich leidenschaftlich, was angesichts der Abneigung auf ihren Gesichtern seltsam wirkt.</DefaultText>
       <FemaleText />
@@ -1693,7 +1693,7 @@ Dämmerung nur Dunkelheit bringt, aber niemals eine Karte in den Sternen am Himm
     </Entry>
     <Entry>
       <ID>413</ID>
-      <DefaultText>Die meisten dieser schimmelnden und verfallenden Bücher sind geschwärzt und zerbröselt. Die verbliebenen lesbaren Seiten scheinen in Alt-Aedyranisch gehalten zu sein.</DefaultText>
+      <DefaultText>Die meisten dieser schimmelnden und verfallenden Bücher sind geschwärzt und zerbröselt. Die verbliebenen lesbaren Seiten scheinen in Alt-Aedyrisch gehalten zu sein.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2510,7 +2510,7 @@ Dämmerung nur Dunkelheit bringt, aber niemals eine Karte in den Sternen am Himm
     </Entry>
     <Entry>
       <ID>592</ID>
-      <DefaultText>Dieses Angebot legt die Details eines Abkommens zur Zusammenarbeit zwischen dyrwäldlerischen und vailianischen Beseelern dar.</DefaultText>
+      <DefaultText>Dieses Angebot legt die Details eines Abkommens zur Zusammenarbeit zwischen dyrwälderischen und vailianischen Beseelern dar.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2565,7 +2565,7 @@ Dämmerung nur Dunkelheit bringt, aber niemals eine Karte in den Sternen am Himm
     </Entry>
     <Entry>
       <ID>604</ID>
-      <DefaultText>Ein Ladungsverzeichnis der Fracht der "Prìncipa me Ciamena" - vierhundert Stück Haihaut aus Rauatai, zwanzig Bündel Schwarzholz aus dem Land der Lebenden, und sechs Dutzend Fässer Aedyre-Ale.</DefaultText>
+      <DefaultText>Ein Ladungsverzeichnis der Fracht der "Prìncipa me Ciamena" - vierhundert Stück Haihaut aus Rauatai, zwanzig Bündel Schwarzholz aus dem Land der Lebenden, und sechs Dutzend Fässer aedyrisches Ale.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2839,7 +2839,7 @@ Während Ihre Ambitionen jedem Sohn der Republiken gut zu Gesicht stünden, so k
     </Entry>
     <Entry>
       <ID>658</ID>
-      <DefaultText>Blässlichgelbe und tief bernsteinfarbene Whiskeysorten aus dem Dyrwald und dem Land der Lebenden liegen nebeneinander.</DefaultText>
+      <DefaultText>Blässlichgelbe und tief bernsteinfarbene Whiskysorten aus dem Dyrwald und dem Land der Lebenden liegen nebeneinander.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3053,7 +3053,7 @@ G. Doemenel"</DefaultText>
     </Entry>
     <Entry>
       <ID>698</ID>
-      <DefaultText>Ein Roman über die glühende Affäre einer mutigen, jungen Beseelerin und einem schweigsamen, muskelbepackten Glanfatharianer. Im Buchdeckel steht eine Widmung:
+      <DefaultText>Ein Roman über die glühende Affäre einer mutigen, jungen Beseelerin und einem schweigsamen, muskelbepackten Glanfathaner. Im Buchdeckel steht eine Widmung:
 
 "Habe dieses Buch gefunden, als ich meine Bücherregale ausräumte, und musste an dich denken (also, natürlich nicht SO). Ich dachte, dass du auf deinen Reisen vielleicht etwas Zeit haben wirst, es zu lesen. Ein Freund hat mir gesagt, dass es gut sei. Ich selbst habe es noch gar nicht gelesen. Wirklich.
 
@@ -3119,7 +3119,7 @@ G. Doemenel"</DefaultText>
     </Entry>
     <Entry>
       <ID>711</ID>
-      <DefaultText>Dies sieht wie etwas aus einem aedyranischen Trinkspiel aus, bei dem mehrere Flaschen mit Wasser, eine aber mit hochkonzentriertem Sonnread-Likör gefüllt sind.</DefaultText>
+      <DefaultText>Dies sieht wie etwas aus einem aedyrischen Trinkspiel aus, bei dem mehrere Flaschen mit Wasser, eine aber mit hochkonzentriertem Sonnread-Likör gefüllt sind.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/items.stringtable
+++ b/text/game/items.stringtable
@@ -492,7 +492,7 @@ Nachdem das Schwarzstand-Fort von seinem neuen Grafen verstärkt worden war, ver
       <ID>103</ID>
       <DefaultText>Die Rose ist eine junge Waffe mit einer relativ kurzen Geschichte. Sie wurde aus geschwärztem ymyranischen Stahl geschmiedet und mit einer "Blüte" aus stark dornigen Blütenblättern versehen. Die Ähnlichkeit dieses Morgensterns mit seiner Namensvetterin hört aber nicht beim Blütenkopf auf. Sein langer, geschwungener Schaft ist auf der gesamten Länge mit kleinen Dornen besetzt, die selbst einem gepanzerten Waffenführer Unbehagen bereiten.
 
-Hacran Grist, ein erfolgreicher Abenteurer aus dem readceranischen Fischerdorf Salzhöhle, ließ die knorrige Waffe anfertigen, nachdem seine Freunde Witze darüber rissen, dass nichts im alkalischen Boden ihrer Heimat wachsen würde. Hacran setzte die Rose zur Verteidigung von Salzhöhle gegen Banditen ein und half seinen Kameraden mit ihr, zwei Flugdrachen zur Strecke zu bringen, die ihr Nest nahe einer zum Dorf führenden Straße gebaut hatten. Als Salzhöhle für sie die frühere Faszination verloren hatte, brachen Hacran und seine Freunde in den Dyrwald auf, um in den Ruinen von Eír Glanfath ihr Glück zu suchen. Seitdem hat niemand mehr etwas von ihnen gehört.</DefaultText>
+Hacran Grist, ein erfolgreicher Abenteurer aus dem readceranischen Fischerdorf Salzhöhle, ließ die knorrige Waffe anfertigen, nachdem seine Freunde Witze darüber rissen, dass nichts im alkalischen Boden ihrer Heimat wachsen würde. Hacran setzte die Rose zur Verteidigung von Salzhöhle gegen Banditen ein und half seinen Kameraden mit ihr, zwei Flugdrachen zur Strecke zu bringen, die ihr Nest nahe einer zum Dorf führenden Straße gebaut hatten. Als Salzhöhle für sie die frühere Faszination verloren hatte, brachen Hacran und seine Freunde in den Dyrwald auf, um in den Ruinen von Eir&#160;Glanfath ihr Glück zu suchen. Seitdem hat niemand mehr etwas von ihnen gehört.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -809,7 +809,7 @@ Aloths hübsche, sorgfältige Schönschrift bildet auf den Seiten einen ordentli
     </Entry>
     <Entry>
       <ID>169</ID>
-      <DefaultText>Auf dieser Karte sind Gebiete im Dyrwald und in Eír Glanfath eingezeichnet, in denen es zu geologischen Aktivitäten kommt. Besonders beachtenswert ist die Beschreibung einer Höhle, in der geschmolzenes Gestein in einer tiefe Schlucht entlangfließt.</DefaultText>
+      <DefaultText>Auf dieser Karte sind Gebiete im Dyrwald und in Eir&#160;Glanfath eingezeichnet, in denen es zu geologischen Aktivitäten kommt. Besonders beachtenswert ist die Beschreibung einer Höhle, in der geschmolzenes Gestein in einer tiefe Schlucht entlangfließt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1212,7 +1212,7 @@ Die Seiten sind größtenteils gefüllt mit schlechter Dichtkunst und Kritzeleie
     </Entry>
     <Entry>
       <ID>255</ID>
-      <DefaultText>Streitäxte können mit ihren breiten, gebogenen Klingen schwere Schläge austeilen und sind unter Soldaten im ganzen Dyrwald und in Eír Glanfath sehr gebräuchlich.</DefaultText>
+      <DefaultText>Streitäxte können mit ihren breiten, gebogenen Klingen schwere Schläge austeilen und sind unter Soldaten im ganzen Dyrwald und in Eir&#160;Glanfath sehr gebräuchlich.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1292,7 +1292,7 @@ Die Seiten sind größtenteils gefüllt mit schlechter Dichtkunst und Kritzeleie
     </Entry>
     <Entry>
       <ID>272</ID>
-      <DefaultText>Jagdbogen sind im Dyrwald und in Eír Glanfath extrem beliebt. Sie werden zwar am häufigsten für die Jagd auf Hirsch und Kleinwild benutzt, aber auch gegen zweibeinige Beute können sie tödlich sein. Jagdbogen erreichen zwar nicht das hohe Zuggewicht von Kriegsbögen, dafür können sie aber häufiger abgefeuert werden.</DefaultText>
+      <DefaultText>Jagdbogen sind im Dyrwald und in Eir&#160;Glanfath extrem beliebt. Sie werden zwar am häufigsten für die Jagd auf Hirsch und Kleinwild benutzt, aber auch gegen zweibeinige Beute können sie tödlich sein. Jagdbogen erreichen zwar nicht das hohe Zuggewicht von Kriegsbögen, dafür können sie aber häufiger abgefeuert werden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1347,7 +1347,7 @@ Die Seiten sind größtenteils gefüllt mit schlechter Dichtkunst und Kritzeleie
     </Entry>
     <Entry>
       <ID>283</ID>
-      <DefaultText>Zepter sind die am autoritärsten aussehenden magischen Werkzeuge und werden aus diesem Grund oft von aedyranischen Zauberern bevorzugt. Wie Zauberstäbe und Kampfstäbe bieten sie flexible Schadenstypen.</DefaultText>
+      <DefaultText>Zepter sind die am autoritärsten aussehenden magischen Werkzeuge und werden aus diesem Grund oft von aedyrischen Zauberern bevorzugt. Wie Zauberstäbe und Kampfstäbe bieten sie flexible Schadenstypen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2751,9 +2751,9 @@ Dieses Amulett soll Fulvano gehört haben. Er war von leichtem Aberglauben sehr 
     </Entry>
     <Entry>
       <ID>563</ID>
-      <DefaultText>Schon Jahrhunderte, bevor die aedyranischen und vailianischen Beseeler das formelle Studium von Medien auf dem Kontinent einführten, waren die Brîshalgwin oder "Verstandsjäger" in ganz Eir&#160;Glanfath bekannt. Man respektierte - und fürchtete - sie für ihre Fähigkeiten, Seelenverbindungen wahrzunehmen.
+      <DefaultText>Schon Jahrhunderte, bevor die aedyrischen und vailianischen Beseeler das formelle Studium von Medien auf dem Kontinent einführten, waren die Brîshalgwin oder "Verstandsjäger" in ganz Eir&#160;Glanfath bekannt. Man respektierte - und fürchtete - sie für ihre Fähigkeiten, Seelenverbindungen wahrzunehmen.
 
-Als sich die ersten aedyranischen Kolonisten im Dyrwald niederließen, zogen sie sich schnell den Zorn ihrer glanfathanischen Nachbarn zu, weil sie - manchmal unabsichtlich, manchmal mit voller Absicht - in engwithanische Ruinen eindrangen. Eine taubstumme Orlanerin des Drei-Stoßzahn-Stelgaer-Stammes, ein übernatürlich begabtes Medium, setzte ihre Fähigkeiten zur Überwachung der Grenzen zu den Ruinen und zum Aufspüren der Kolonisten ein, die sie durch ihre Handlungen schändeten. 
+Als sich die ersten aedyrischen Kolonisten im Dyrwald niederließen, zogen sie sich schnell den Zorn ihrer glanfathanischen Nachbarn zu, weil sie - manchmal unabsichtlich, manchmal mit voller Absicht - in engwithanische Ruinen eindrangen. Eine taubstumme Orlanerin des Drei-Stoßzahn-Stelgaer-Stammes, ein übernatürlich begabtes Medium, setzte ihre Fähigkeiten zur Überwachung der Grenzen zu den Ruinen und zum Aufspüren der Kolonisten ein, die sie durch ihre Handlungen schändeten. 
 
 Um sie bei ihren Nachforschungen zu unterstützen, gab ihr der Anamfath des Drei-Stoßzahn-Stelgaer-Stammes dieses Amulett, das man für eine engwithanische Reliquie hielt. Die öffentliche Überreichung eines derart verehrten Geschenks war nicht nur pragmatisch, sondern auch politisch motiviert, und rüttelte den glanfathanischen Widerstand gegen die Siedler wach - besonders im Drei-Stoßzahn-Stelgaer-Stamm. Als das Medium aber bei einem Überfall auf ein Bauerndorf getötet wurde, ging das Amulett verloren.</DefaultText>
       <FemaleText />
@@ -3380,7 +3380,7 @@ Um sie bei ihren Nachforschungen zu unterstützen, gab ihr der Anamfath des Drei
     </Entry>
     <Entry>
       <ID>688</ID>
-      <DefaultText>Argwes Adra</DefaultText>
+      <DefaultText>Argŵes Adra</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3655,7 +3655,7 @@ Um sie bei ihren Nachforschungen zu unterstützen, gab ihr der Anamfath des Drei
     </Entry>
     <Entry>
       <ID>744</ID>
-      <DefaultText>Auf dem Griff dieses schweren Eisenschlüssels befindet sich ein aedyranisches Zeichen. Der Griff ist mit einer dicken Staubschicht überzogen.</DefaultText>
+      <DefaultText>Auf dem Griff dieses schweren Eisenschlüssels befindet sich ein aedyrisches Zeichen. Der Griff ist mit einer dicken Staubschicht überzogen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3827,12 +3827,12 @@ Irgendwas summt in ihnen, ein verblichenes Überbleibsel einer Essenz. Welche Ma
     </Entry>
     <Entry>
       <ID>775</ID>
-      <DefaultText>Hüte gibt es in vielen verschiedenen Formen, Größen und einer großen Auswahl an Farben. Dyrwäldler sind für ihre bescheidenen, rustikalen Hüte bekannt, während Vailianer mit breitkrempigen Hüten, geschmückt mit verschiedenen exotischen Federn, assoziiert werden.</DefaultText>
+      <DefaultText>Hüte gibt es in vielen verschiedenen Formen, Größen und einer großen Auswahl an Farben. Dyrwälder sind für ihre bescheidenen, rustikalen Hüte bekannt, während Vailianer mit breitkrempigen Hüten, geschmückt mit verschiedenen exotischen Federn, assoziiert werden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>776</ID>
-      <DefaultText>Von den Jägern der dyrwäldlerischen Wildnis bis hin zu den verhüllten Zauberern, die ein Flair für das Mysteriöse haben, wissen alle Bewohner des Östlichen Abschnitts die Wärme und Anonymität einer Kapuze zu schätzen.</DefaultText>
+      <DefaultText>Von den Jägern der dyrwälderischen Wildnis bis hin zu den verhüllten Zauberern, die ein Flair für das Mysteriöse haben, wissen alle Bewohner des Östlichen Abschnitts die Wärme und Anonymität einer Kapuze zu schätzen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3957,7 +3957,7 @@ Irgendwas summt in ihnen, ein verblichenes Überbleibsel einer Essenz. Welche Ma
     </Entry>
     <Entry>
       <ID>801</ID>
-      <DefaultText>Dyrwäldlerische Kleidung</DefaultText>
+      <DefaultText>Dyrwälderische Kleidung</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4068,7 +4068,7 @@ Der Griff ist mit Adra-Stücken versehen und in den Schaft wurden Runen eingerit
     </Entry>
     <Entry>
       <ID>828</ID>
-      <DefaultText>Dieser Ring bedeutet die Mitgliedschaft im Klub der kultivierten und angesehenen Ehrenmänner. Unterhalb seines Siegels wurde in Alt-Aedyranisch ein Motto eingraviert: "Fréod ond Eathmédu."</DefaultText>
+      <DefaultText>Dieser Ring bedeutet die Mitgliedschaft im Klub der kultivierten und angesehenen Ehrenmänner. Unterhalb seines Siegels wurde in Alt-Aedyrisch ein Motto eingraviert: "Fréod ond Eathmédu."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5055,7 +5055,7 @@ Wir dürfen nicht vergessen, dass Reisende und Dörfler die Straße in der Nähe
 
 "1. Ydit - lässt die Fenster in der Nacht offen. Kleines Haus am Rand von Flackertal.
 
-2. Higerto - Besucher aus Alt-Vailia, spricht kein Aedyranisch. Sondert sich ab, wird nicht vermisst werden.
+2. Higerto - Besucher aus Alt-Vailia, spricht kein Aedyrisch. Sondert sich ab, wird nicht vermisst werden.
 
 3. Tirfeyst - lebt in einem kleinen Lager auf dem Weg nach Stammheim. Geht jeden Morgen bei Sonnenaufgang allein spazieren, sollte dann am verwundbarsten sein.
 
@@ -5100,7 +5100,7 @@ Merec war fröhlich wie ein Kleinkind und sich sicher, dass wir die Xaurips übe
 Und jetzt? Jetzt seid ihr alle wie die Hasen davongelaufen. Währenddessen stehe ich hier bis zu den Achseln in Knochen und Xauripscheiße. 
 
 Ich hoffe, dass ihr alle hier unten verrotten werdet. Ich hoffe, dass Merec direkt über den Rand der Welt fällt und Drafden den Rest seines winzigen Verstands verliert und den Rest von euch ausweidet. Fünf von uns waren übrig, und ihr rennt weg. Verflucht sollt ihr sein, jeder einzelne von euch. Ich verfluche auch mich selbst, weil ich hier wegen ein paar wimmernden Jämmerlingen sterben werde.
-Und hier ist noch was für euch, falls einer von euch miesen Echsenbastarden jemals Aedyranisch lernen sollte - hoffentlich erstickt ihr alle zusammen!"</DefaultText>
+Und hier ist noch was für euch, falls einer von euch miesen Echsenbastarden jemals Aedyrisch lernen sollte - hoffentlich erstickt ihr alle zusammen!"</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5409,12 +5409,12 @@ Trindig</DefaultText>
     </Entry>
     <Entry>
       <ID>1104</ID>
-      <DefaultText>Diese robuste Brigandine wurde von der aedyranischen Abenteurerin, der sie einst gehörte, mehrfach verstärkt. Die dick ausgepolsterte Rüstung wurde Äru-Brekr genannt (Pfeilbrecher). Sie leistete der Abenteurerin gute Dienste, bis ihr Ruhm und ihr Reichtum sie nachlässig werden ließen und sie einen Gegner zu nah an sich heran ließ. Pfeilbrecher beschützte sie zwar vor Geschossen, bot jedoch nicht denselben Schutz gegen den Streitkolben, der ihr gegen die Schläfe geschlagen wurde.</DefaultText>
+      <DefaultText>Diese robuste Brigandine wurde von der aedyrischen Abenteurerin, der sie einst gehörte, mehrfach verstärkt. Die dick ausgepolsterte Rüstung wurde Äru-Brekr genannt (Pfeilbrecher). Sie leistete der Abenteurerin gute Dienste, bis ihr Ruhm und ihr Reichtum sie nachlässig werden ließen und sie einen Gegner zu nah an sich heran ließ. Pfeilbrecher beschützte sie zwar vor Geschossen, bot jedoch nicht denselben Schutz gegen den Streitkolben, der ihr gegen die Schläfe geschlagen wurde.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1105</ID>
-      <DefaultText>Der Mantel der schlechten Bezahlung gelangte in den Besitz eines aedyranischen Glücksspielers, als er ihn - welch Wunder - beim Glücksspiel gewann. Da er nicht genau wusste, was er damit anfangen sollte, begann er, ihn beim Spielen als Glücksbringer zu tragen. Ein Gegner warf ihm vor, zu betrügen, und wollte seine Bezahlung aus dem Glücksspieler herausprügeln - schreckte jedoch vor Schmerzen zurück, nachdem er den ersten Hieb gelandet hatte. Der Glücksspieler erkannte, dass die Rüstung ihm einen gewissen magischen Schutz bot - und ließ sich etwas einfallen. 
+      <DefaultText>Der Mantel der schlechten Bezahlung gelangte in den Besitz eines aedyrischen Glücksspielers, als er ihn - welch Wunder - beim Glücksspiel gewann. Da er nicht genau wusste, was er damit anfangen sollte, begann er, ihn beim Spielen als Glücksbringer zu tragen. Ein Gegner warf ihm vor, zu betrügen, und wollte seine Bezahlung aus dem Glücksspieler herausprügeln - schreckte jedoch vor Schmerzen zurück, nachdem er den ersten Hieb gelandet hatte. Der Glücksspieler erkannte, dass die Rüstung ihm einen gewissen magischen Schutz bot - und ließ sich etwas einfallen. 
 
 Er stieg in ein Spiel an, betrog ganz offenkundig - oder gab es zumindest vor - und prügelte sich dann mit seinem wütenden Gegenspieler, oft mit noch höherem Einsatz. Damit hatte er großen Erfolg - bis er es eines Tages übertrieb und plötzlich mehr wütende Fäuste auf ihn einprasselten, als die Rüstung abwehren konnte.</DefaultText>
       <FemaleText />
@@ -5456,12 +5456,12 @@ Der Schöpfer dieser Rüstung bevorzugt die erste Version der Geschichte, denn i
     </Entry>
     <Entry>
       <ID>1112</ID>
-      <DefaultText>Einer dyrwäldlerischen Volkssage nach verleiht Rüstung, die aus der Haut der nachtaktiven, scheuen Skuldr gefertigt wird, ihrem Träger eine übernatürliche Fähigkeit, unbemerkt zu bleiben. Ein leidenschaftlicher Jäger war entschlossen, diesen Aberglauben auf die Probe zu stellen und fertigte diese Rüstung aus nicht weniger als sieben Skuldrhäuten. Welche Auswirkung die schiere Zahl hatte, ist unklar, doch das Ergebnis ist eine dunkle Rüstung, die sich ohne Zweifel nahtlos in die Schatten einfügt.</DefaultText>
+      <DefaultText>Einer dyrwälderischen Volkssage nach verleiht Rüstung, die aus der Haut der nachtaktiven, scheuen Skuldr gefertigt wird, ihrem Träger eine übernatürliche Fähigkeit, unbemerkt zu bleiben. Ein leidenschaftlicher Jäger war entschlossen, diesen Aberglauben auf die Probe zu stellen und fertigte diese Rüstung aus nicht weniger als sieben Skuldrhäuten. Welche Auswirkung die schiere Zahl hatte, ist unklar, doch das Ergebnis ist eine dunkle Rüstung, die sich ohne Zweifel nahtlos in die Schatten einfügt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1113</ID>
-      <DefaultText>Diese Rüstung gehörte einst einem Aedyraner, der Mitglied einer Söldnerbande war, die sich "die Schreiter" nannte. Es gab immer nur fünf Mitglieder, von denen jedes ganz bestimmte Fähigkeiten besaß. Der erste Schreiter war stark, der zweite wendig, der dritte ein unerreichter Scharfschütze, der vierte mit unglaublicher Ausdauer gesegnet, der fünfte mit unwiderstehlichem Charme. Jeder der Schreiter trug eine Rüstung, die seine bereits formidablen Fähigkeiten noch verstärkte. In Kerdhed Pames ("Fünfter Schreiter") gekleidet überzeugte der Aedyraner einst einen Adligen aus Kulklin, seine preisgekrönte Stute gegen einen halbleeren Humpen Ale einzutauschen.</DefaultText>
+      <DefaultText>Diese Rüstung gehörte einst einem Aedyrer, der Mitglied einer Söldnerbande war, die sich "die Schreiter" nannte. Es gab immer nur fünf Mitglieder, von denen jedes ganz bestimmte Fähigkeiten besaß. Der erste Schreiter war stark, der zweite wendig, der dritte ein unerreichter Scharfschütze, der vierte mit unglaublicher Ausdauer gesegnet, der fünfte mit unwiderstehlichem Charme. Jeder der Schreiter trug eine Rüstung, die seine bereits formidablen Fähigkeiten noch verstärkte. In Kerdhed Pames ("Fünfter Schreiter") gekleidet überzeugte der Aedyrer einst einen Adligen aus Kulklin, seine preisgekrönte Stute gegen einen halbleeren Humpen Ale einzutauschen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5500,7 +5500,7 @@ Er verzichtete auf Sicherheitsgurte und schließlich sogar auf jede Art von Sich
     </Entry>
     <Entry>
       <ID>1120</ID>
-      <DefaultText>Kakuma war eine berühmte Aumaua-Seefahrerin und die ursprüngliche Besitzerin dieses Kleidungsstücks. Sie segelte von ihrer Heimat Rauatai zum gefürchteten Todesfeuer-Archipel. Dort geleitete sie Handels- und Passagierschiffe durch die von Piraten heimgesuchten Gewässer. Zu ihren Stammkunden zählten die Zwerge von Naasistaqi, welche die Kontinente im Norden bereisten, aus persönlichen Gründen oder im Auftrag des Stammes.
+      <DefaultText>Kakuma war eine berühmte Aumaua-Seefahrerin und die ursprüngliche Besitzerin dieses Kleidungsstücks. Sie segelte von ihrer Heimat Rauatai zum gefürchteten Todesfeuer-Archipel. Dort geleitete sie Handels- und Passagierschiffe durch die von Piraten heimgesuchten Gewässer. Zu ihren Stammkunden zählten die Zwerge von Naasitaq, welche die Kontinente im Norden bereisten, aus persönlichen Gründen oder im Auftrag des Stammes.
 
 Ihre ehrliche Art, Geschäfte zu machen, ihr Mut im Kampf und ihr Können auf See machten Kakuma zu einer angesehenen und beliebten Frau im Archipel und unter den Naasitaqi.</DefaultText>
       <FemaleText />
@@ -5520,7 +5520,7 @@ Als sie schließlich im Umgang mit dem Stilett geübt war, zog sie aus, die Mör
 
 Viele findige Händler begannen aber, Kopien herzustellen und zu verkaufen. Viele Fälschungen waren so täuschend echt, dass selbst Gelehrte sie nicht von echten Stücken unterscheiden konnten. Manchmal wurde gar ein Medium angeheuert, um die Echtheit von wertvollen Stücken zu bestätigen.
 
-Argwes Adra ("Adra-Rüstung") stammte aus den Ruinen beim Hof der verneigenden Asche, ähnelte zwei bekannten Fälschungen jedoch so sehr, dass sie durch Trutzbucht, Ancenze und Selona gereicht wurde, ehe ein Beseeler in Barda erkannte, dass es sich um ein Original handelt.</DefaultText>
+Argŵes Adra ("Adra-Rüstung") stammte aus den Ruinen beim Hof der verneigenden Asche, ähnelte zwei bekannten Fälschungen jedoch so sehr, dass sie durch Trutzbucht, Ancenze und Selona gereicht wurde, ehe ein Beseeler in Barda erkannte, dass es sich um ein Original handelt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5586,7 +5586,7 @@ Diese Roben bestehen aus wenig mehr als einem einfachen, ungefärbten Stück Sto
     </Entry>
     <Entry>
       <ID>1131</ID>
-      <DefaultText>Ein junger Aedyraner, der in eine Fischerfamilie geboren wurde, beschloss eines Tages, mit der Tradition zu brechen und stattdessen zum Schwert zu greifen. Er schwor, dass er größeren Reichtum finden würde, als er seiner Familie je beschieden war. Als er aber nach Gelegenheiten suchte, sich zu beweisen, wurde er oft verspottet - denn er kam aus einer einfachen Familie, die nie etwas Bemerkenswertes geleistet hatte. 
+      <DefaultText>Ein junger Aedyrer, der in eine Fischerfamilie geboren wurde, beschloss eines Tages, mit der Tradition zu brechen und stattdessen zum Schwert zu greifen. Er schwor, dass er größeren Reichtum finden würde, als er seiner Familie je beschieden war. Als er aber nach Gelegenheiten suchte, sich zu beweisen, wurde er oft verspottet - denn er kam aus einer einfachen Familie, die nie etwas Bemerkenswertes geleistet hatte. 
 Entmutigt kehrte der Bursche nach Hause zurück - wo seine Familie ihre dürftigen Ersparnisse zusammengekratzt hatte, um ihm eine Rüstung fertigen zu lassen, die ihn bei der Erfüllung seines Herzenswunsches beschützen sollte. Der Bursche bat den Schmied, eine glänzende Schuppenrüstung zu fertigen, so hell wie die blitzenden Schuppen eines Fisches, und ebenso leicht und schnell. Er nannte sie Stolz der Pike, und wenn er sie trug, so war er immun gegen alle Beleidigungen, die seine Zweifler ihm an den Kopf warfen.</DefaultText>
       <FemaleText />
     </Entry>
@@ -5599,7 +5599,7 @@ Der Sieg über die Oger war zwar nur von kurzer Dauer, doch die Geschichte wird 
     </Entry>
     <Entry>
       <ID>1133</ID>
-      <DefaultText>Aedrins Zerstörer war schon vielen bekannt, als Aedrin selbst noch kaum jemandem bekannt war. Sie war eine Schurkin und eine hervorragende Scharfschützin, die im Widerstandskrieg kämpfte und aedyranische Soldaten aus den Schatten heraus niederstreckte. Sie sagte einst einem Schüler, sie würde einem Feind lieber in den Rücken schießen, als ihm die Gelegenheit zu geben, zurückzuschlagen. Für ihre Geduld war sie noch berühmter als für ihre Zielfertigkeit. Sie soll sich einmal drei Tage lang in einem Baum versteckt haben, während sie darauf wartete, dass ein aedyranischer General die Straße nach Madsdam entlangkam. Sie war jedoch so fähig, dass niemand diese Geschichte je bestätigen konnte.</DefaultText>
+      <DefaultText>Aedrins Zerstörer war schon vielen bekannt, als Aedrin selbst noch kaum jemandem bekannt war. Sie war eine Schurkin und eine hervorragende Scharfschützin, die im Widerstandskrieg kämpfte und aedyrische Soldaten aus den Schatten heraus niederstreckte. Sie sagte einst einem Schüler, sie würde einem Feind lieber in den Rücken schießen, als ihm die Gelegenheit zu geben, zurückzuschlagen. Für ihre Geduld war sie noch berühmter als für ihre Zielfertigkeit. Sie soll sich einmal drei Tage lang in einem Baum versteckt haben, während sie darauf wartete, dass ein aedyrischer General die Straße nach Madsdam entlangkam. Sie war jedoch so fähig, dass niemand diese Geschichte je bestätigen konnte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5629,7 +5629,7 @@ Der Sieg über die Oger war zwar nur von kurzer Dauer, doch die Geschichte wird 
     </Entry>
     <Entry>
       <ID>1139</ID>
-      <DefaultText>Streitäxte können mit ihren breiten, gebogenen Klingen schwere Schläge austeilen und sind unter Soldaten im ganzen Dyrwald und in Eír Glanfath sehr gebräuchlich.</DefaultText>
+      <DefaultText>Streitäxte können mit ihren breiten, gebogenen Klingen schwere Schläge austeilen und sind unter Soldaten im ganzen Dyrwald und in Eir&#160;Glanfath sehr gebräuchlich.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5654,7 +5654,7 @@ Der Sieg über die Oger war zwar nur von kurzer Dauer, doch die Geschichte wird 
     </Entry>
     <Entry>
       <ID>1144</ID>
-      <DefaultText>Scon Mica, der Oger aus den aedyranischen Mythen, der unzählige Helden besiegte, bevor er schließlich von einem einfachen Hirten getötet wurde, konnte mit seinem Brüllen angeblich den Regen aus den Wolken schütteln. Wenn er in die Schlacht zog, warf sein Geschrei seine Feinde um und ließ ihre Knochen aneinanderrasseln.</DefaultText>
+      <DefaultText>Scon Mica, der Oger aus den aedyrischen Mythen, der unzählige Helden besiegte, bevor er schließlich von einem einfachen Hirten getötet wurde, konnte mit seinem Brüllen angeblich den Regen aus den Wolken schütteln. Wenn er in die Schlacht zog, warf sein Geschrei seine Feinde um und ließ ihre Knochen aneinanderrasseln.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5689,7 +5689,7 @@ Der Sieg über die Oger war zwar nur von kurzer Dauer, doch die Geschichte wird 
     </Entry>
     <Entry>
       <ID>1151</ID>
-      <DefaultText>Die Barbarin Blesca wurde aus der Not heraus zur Anführerin - und erwies sich in dieser Rolle als äußerst effektiv. Sie stoppte die aedyranische Expansion nördlich von Readceras, indem sie die südlichen Ixamitl-Stämme vereinte. Sie hielt ihr ungleiches Bündnis durch Überzeugungskraft, Zwang und notfalls Gewalt beisammen. Ihre Koalition bestand gerade lang genug, um den Vormarsch abzuwehren.</DefaultText>
+      <DefaultText>Die Barbarin Blesca wurde aus der Not heraus zur Anführerin - und erwies sich in dieser Rolle als äußerst effektiv. Sie stoppte die aedyrische Expansion nördlich von Readceras, indem sie die südlichen Ixamitl-Stämme vereinte. Sie hielt ihr ungleiches Bündnis durch Überzeugungskraft, Zwang und notfalls Gewalt beisammen. Ihre Koalition bestand gerade lang genug, um den Vormarsch abzuwehren.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5764,7 +5764,7 @@ Nach seinen ersten Begegnungen mit Lindwürmern ließ Saelfors Interesse an der 
     </Entry>
     <Entry>
       <ID>1165</ID>
-      <DefaultText>Ein aedyranischer Entdeckter hörte einst die Legende eines engwithanischen Grabs, das mit den größten Schätzen des untergegangenen Reichs gefüllt sei. Entschlossen, sich einen Namen zu machen und gleichzeitig reich zu werden, ließ er einen der besten Schmiede im Dyrwald eine Klinge fertigen, die der Aufgabe würdig sei. 
+      <DefaultText>Ein aedyrischer Entdeckter hörte einst die Legende eines engwithanischen Grabs, das mit den größten Schätzen des untergegangenen Reichs gefüllt sei. Entschlossen, sich einen Namen zu machen und gleichzeitig reich zu werden, ließ er einen der besten Schmiede im Dyrwald eine Klinge fertigen, die der Aufgabe würdig sei. 
 
 Er stieg an einen Ort hinab, der die Endlosen Pfade von Od Nua genannt wird ... und es ward nie wieder von ihm gehört. Die unbekannten Grauen, die dort hausen, fielen über seine Besitztümer her, und seine wertvolle Klinge wurde zertrümmert.</DefaultText>
       <FemaleText />
@@ -5795,9 +5795,9 @@ Gauns Anteil soll von einem verstörten Schmied aus dem Dyrwald gefertigt worden
     </Entry>
     <Entry>
       <ID>1170</ID>
-      <DefaultText>Anhänger Ondras entlang der Nordküste der Ixamitl-Ebenen beobachten jeden Abend, wie der Mond und die Sterne im Meer versinken, und huldigen der Göttin der Gezeiten. Ein reisender aedyranischer Anthropologe studierte ihre Rituale und füllte sein Tagebuch mit Skizzen von Gestalten, die ihre Arme gen Himmel schwangen, und mit Beschreibungen der Sterne, die vom nächtlichen Firmament fielen.
+      <DefaultText>Anhänger Ondras entlang der Nordküste der Ixamitl-Ebenen beobachten jeden Abend, wie der Mond und die Sterne im Meer versinken, und huldigen der Göttin der Gezeiten. Ein reisender aedyrischer Anthropologe studierte ihre Rituale und füllte sein Tagebuch mit Skizzen von Gestalten, die ihre Arme gen Himmel schwangen, und mit Beschreibungen der Sterne, die vom nächtlichen Firmament fielen.
 
-Das Tagebuch wurde in den jungen aedyranischen und vailianischen Kolonien in großer Auflage veröffentlicht. Eines Tages fiel einer Waffenschmiedin in der Ausbildung ein Exemplar in die Hand. Sie war so verzaubert von den Bildern der Rituale, dass sie begann, eine Hommage daran zu schaffen. Ihr Meisterwerk war Sternenrufer, ein Streitflegel von solcher Qualität, dass man sagte, er sei vom Himmel gefallen.</DefaultText>
+Das Tagebuch wurde in den jungen aedyrischen und vailianischen Kolonien in großer Auflage veröffentlicht. Eines Tages fiel einer Waffenschmiedin in der Ausbildung ein Exemplar in die Hand. Sie war so verzaubert von den Bildern der Rituale, dass sie begann, eine Hommage daran zu schaffen. Ihr Meisterwerk war Sternenrufer, ein Streitflegel von solcher Qualität, dass man sagte, er sei vom Himmel gefallen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5819,13 +5819,13 @@ Dieses große Schwert scheint mit Rost überzogen zu sein, doch bei näherer Bet
     </Entry>
     <Entry>
       <ID>1174</ID>
-      <DefaultText>St. Rumbalt gehörte zu den ersten eothasianischen Pilgern, die das Angebot des Kaisers annahmen, in das entlegene Gebiet Readceras umzusiedeln. Rumbalt war ein treuer Priester des Strahlenden Gottes und galt in seiner Gemeinde als Anführer, bekannt für seine standhafte Hingabe an seine Gemeinde, aber auch für seine strenge Wachsamkeit gegen Verstöße gegen die Glaubenslehre. Seine überlieferten Predigten spiegeln diese Dualität wieder, denn er betonte die erlösende Kraft des Glaubens, während er gleichzeitig vor der strengen Bestrafung aller warnte, die Eothas' Wohlwollen ablehnten. 
+      <DefaultText>St. Rumbalt gehörte zu den ersten eothasischen Pilgern, die das Angebot des Kaisers annahmen, in das entlegene Gebiet Readceras umzusiedeln. Rumbalt war ein treuer Priester des Strahlenden Gottes und galt in seiner Gemeinde als Anführer, bekannt für seine standhafte Hingabe an seine Gemeinde, aber auch für seine strenge Wachsamkeit gegen Verstöße gegen die Glaubenslehre. Seine überlieferten Predigten spiegeln diese Dualität wieder, denn er betonte die erlösende Kraft des Glaubens, während er gleichzeitig vor der strengen Bestrafung aller warnte, die Eothas' Wohlwollen ablehnten. 
 
-Die Kolonialisierungsbemühungen führten zu unmittelbaren Konflikten zwischen eothasianischen Siedlern und den eingeborenen Orlanern. Rumbalt half mit, einige brutale Angriffe auf die Siedlung abzuwehren. Schließlich aber wurde er während eines Überfalls tödlich verwundet. Augenzeugen berichten, dass Rumbalts Körper im Moment seines Todes von einem überwältigenden Lichtstrahl durchströmt wurde, der die verbleibenden orlanischen Krieger zu Boden warf oder in den Wald flüchten ließ.
+Die Kolonialisierungsbemühungen führten zu unmittelbaren Konflikten zwischen eothasischen Siedlern und den eingeborenen Orlanern. Rumbalt half mit, einige brutale Angriffe auf die Siedlung abzuwehren. Schließlich aber wurde er während eines Überfalls tödlich verwundet. Augenzeugen berichten, dass Rumbalts Körper im Moment seines Todes von einem überwältigenden Lichtstrahl durchströmt wurde, der die verbleibenden orlanischen Krieger zu Boden warf oder in den Wald flüchten ließ.
  
 Es häuften sich die Berichte, nach denen am Tag vor Rumbalts Tode große Wunder geschahen. Eothas, so hieß es, habe Rumbalt von seinem bevorstehenden Schicksal in Kenntnis gesetzt, und der Priester habe es froh und furchtlos angenommen, da er wusste, dass der Tod nur der erste Schritt seiner Wiedergeburt war. In jeder der letzten 27 Stunden seines Lebens wirkte er demnach ein Wunder, auf dass seine Gemeinde das Geschenk erkenne, mit dem Eothas ihn bedacht hatte, und Rumbalts Werk an seiner Statt weiterführe. 
 
-Anstatt den Strom der eothasianischen Siedler versiegen zu lassen, ermutigte Rumbalts Tod nur noch mehr Pilger, die Reise über das Meer zu wagen, um die letzte Ruhestätte von Eothas' treuestem Diener zu besichtigen. Die Stunden von St. Rumbalt wurde zu Ehren dieses Schutzheiligen der Umsiedlung geschmiedet. In die Klinge sind Markierungen graviert, welche die 27 Stunden vor Rumbalts Tod repräsentieren. Auf diese Weise wurde die Klinge mit der Macht des Heiligen getränkt. Es heißt, dass ein Mann, der vor dem Schwert niederkniet, den Augenblick seines Todes genau voraussehen kann.</DefaultText>
+Anstatt den Strom der eothasischen Siedler versiegen zu lassen, ermutigte Rumbalts Tod nur noch mehr Pilger, die Reise über das Meer zu wagen, um die letzte Ruhestätte von Eothas' treuestem Diener zu besichtigen. Die Stunden von St. Rumbalt wurde zu Ehren dieses Schutzheiligen der Umsiedlung geschmiedet. In die Klinge sind Markierungen graviert, welche die 27 Stunden vor Rumbalts Tod repräsentieren. Auf diese Weise wurde die Klinge mit der Macht des Heiligen getränkt. Es heißt, dass ein Mann, der vor dem Schwert niederkniet, den Augenblick seines Todes genau voraussehen kann.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6007,7 +6007,7 @@ Anstatt eine einzelne Person den Bogen besitzen zu lassen, betrachtete der Stamm
     </Entry>
     <Entry>
       <ID>1217</ID>
-      <DefaultText>Zu den berühmten Rezepten der Rauatai, mit deren Liebe für Süßes es nur die Aedyraner aufnehmen können, gehören viele köstliche Nachspeisen und reichhaltige Leckerbissen. Zu den Spezialitäten, die bei reichen Feinschmeckern der bekannten Welt am höchsten im Kurs stehen, gehört auch der "schwärzeste" Schokoladenkeks. Diese Kekse werden von Rauatai-Botschafter gerne als kleine Aufmerksamkeiten verteilt, und viele ausländische Würdenträger empfangen Rauatai-Delegationen vor allem deshalb sehr warmherzig, weil sie auf Gastgeschenke in Form dieser Kekse hoffen.</DefaultText>
+      <DefaultText>Zu den berühmten Rezepten der Rauatai, mit deren Liebe für Süßes es nur die Aedyrer aufnehmen können, gehören viele köstliche Nachspeisen und reichhaltige Leckerbissen. Zu den Spezialitäten, die bei reichen Feinschmeckern der bekannten Welt am höchsten im Kurs stehen, gehört auch der "schwärzeste" Schokoladenkeks. Diese Kekse werden von Rauatai-Botschafter gerne als kleine Aufmerksamkeiten verteilt, und viele ausländische Würdenträger empfangen Rauatai-Delegationen vor allem deshalb sehr warmherzig, weil sie auf Gastgeschenke in Form dieser Kekse hoffen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6042,12 +6042,12 @@ Anstatt eine einzelne Person den Bogen besitzen zu lassen, betrachtete der Stamm
     </Entry>
     <Entry>
       <ID>1224</ID>
-      <DefaultText>Dieser Eiaufstrich kommt besonders bei den dyrwäldlerischen Bauern in Tenferths an Arbeitstagen oft auf den Tisch. Die Tenferther, die als unerschütterliche Zeitgenossen und rustikale Stoiker bekannt sind, finden sich oft als Zielscheibe von Witzen über ihr bescheidenes Essen wieder. Bei den verträglicheren Witzen geht es darum, dass Tenferther die Eierschalen versehentlich in den Aufstrich verarbeiten und ohne Murren alles aufessen. Böse Witze aber implizieren, dass Tenferther teilnahmslos Steine, Hühnerfedern, Nägel und andere scheußliche Sachen essen, die irgendwie in den Aufstrich geraten sind.</DefaultText>
+      <DefaultText>Dieser Eiaufstrich kommt besonders bei den dyrwälderischen Bauern in Tenferths an Arbeitstagen oft auf den Tisch. Die Tenferther, die als unerschütterliche Zeitgenossen und rustikale Stoiker bekannt sind, finden sich oft als Zielscheibe von Witzen über ihr bescheidenes Essen wieder. Bei den verträglicheren Witzen geht es darum, dass Tenferther die Eierschalen versehentlich in den Aufstrich verarbeiten und ohne Murren alles aufessen. Böse Witze aber implizieren, dass Tenferther teilnahmslos Steine, Hühnerfedern, Nägel und andere scheußliche Sachen essen, die irgendwie in den Aufstrich geraten sind.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1225</ID>
-      <DefaultText>Ein frisch gefangener Fisch mit silbernen Schuppen. Dyrwäldlerischen Legenden zufolge wird man klüger, wenn man die Augen eines Fischs isst (auch wenn sie dem Fisch selbst offenbar nicht geholfen haben).</DefaultText>
+      <DefaultText>Ein frisch gefangener Fisch mit silbernen Schuppen. Dyrwälderischen Legenden zufolge wird man klüger, wenn man die Augen eines Fischs isst (auch wenn sie dem Fisch selbst offenbar nicht geholfen haben).</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6069,7 +6069,7 @@ Als der örtliche Duc von ihrem Mut und der Not der Kinder hörte, ließ er Notv
     </Entry>
     <Entry>
       <ID>1229</ID>
-      <DefaultText>Zu den häufigsten Früchten im Dyrwald gehören importierte Sonnreads aus aedyranischen Obstgärten und die gewöhnliche Birne, aber auch vailianische Feigen sind unter wohlhabenden Dyrwäldlern sehr beliebt.</DefaultText>
+      <DefaultText>Zu den häufigsten Früchten im Dyrwald gehören importierte Sonnreads aus aedyrischen Obstgärten und die gewöhnliche Birne, aber auch vailianische Feigen sind unter wohlhabenden Dyrwäldern sehr beliebt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6108,7 +6108,7 @@ Doch wieder stand Mabec ungläubig vor dem Baum - er fand weder einen Hohlraum i
     </Entry>
     <Entry>
       <ID>1236</ID>
-      <DefaultText>Rinderbraten ist ein im ganzen Dyrwald weit verbreitetes Gericht, und hunderte Familien haben seit Generationen dieselben Rezepte verwendet. Niemand ist sich sicher, wie er als "Duc-Rinderbraten" bekannt wurde, aber diesbezüglich gibt es zwei Hauptlegenden: Die erste dreht sich um Admeth Hadret, den ersten Duc des Dyrwalds, der angeblich für seinen Gefangenen, den Glanfathaner Galven Rêgd, persönlich einen Rinderbraten zubereitete. Dem Orlaner schmeckte das Gericht angeblich so gut, dass er um das Rezept bat, um es nach seiner Freilassung an seine Verwandten weiterzugeben. Die zweite, wahrscheinlichere Erzählung dreht sich um eine skrupellosen Köchin, der in der altehrwürdigen Schänke Zum Schwarzen Hund in Goldtal arbeitete. Unzähligen Reisenden vertraute sie an, sie hätte das Rezept für den "Duc-Rinderbraten" -- was einfach nur ihr eigenes, köstliches Rezept war - und verkaufte es Dutzenden für horrende Preise. Jedes Opfer der List bereitete daraufhin Rinderbraten mit dem vermeintlich persönlichen Rezept des Ducs zu, was schließlich zu diesem Gebrauchsnamen führte.</DefaultText>
+      <DefaultText>Rinderbraten ist ein im ganzen Dyrwald weit verbreitetes Gericht, und hunderte Familien haben seit Generationen dieselben Rezepte verwendet. Niemand ist sich sicher, wie er als "Duc-Rinderbraten" bekannt wurde, aber diesbezüglich gibt es zwei Hauptlegenden: Die erste dreht sich um Admeth Hadret, den ersten Duc des Dyrwalds, der angeblich für seinen Gefangenen, den Glanfathaner Galven Regd, persönlich einen Rinderbraten zubereitete. Dem Orlaner schmeckte das Gericht angeblich so gut, dass er um das Rezept bat, um es nach seiner Freilassung an seine Verwandten weiterzugeben. Die zweite, wahrscheinlichere Erzählung dreht sich um eine skrupellosen Köchin, der in der altehrwürdigen Schänke Zum Schwarzen Hund in Goldtal arbeitete. Unzähligen Reisenden vertraute sie an, sie hätte das Rezept für den "Duc-Rinderbraten" -- was einfach nur ihr eigenes, köstliches Rezept war - und verkaufte es Dutzenden für horrende Preise. Jedes Opfer der List bereitete daraufhin Rinderbraten mit dem vermeintlich persönlichen Rezept des Ducs zu, was schließlich zu diesem Gebrauchsnamen führte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6189,7 +6189,7 @@ Der fähige Pikenier Solmar konnte jeden Versuch abwehren, ihn zu treffen, und f
     </Entry>
     <Entry>
       <ID>1252</ID>
-      <DefaultText>Eine Gruppe aedyranischer Pikeniere war so diszipliniert im Kampf, dass sie die Aufmerksamkeit des Fercönyngs auf sich zogen. Er machte sie zu Mitgliedern seiner persönlichen Garde und ließ eigens Waffen für sie fertigen. Sie marschierten an der Spitze seiner Prozession, ihre Bewegungen im perfekten Einklang und ihre Piken wie Grashalme im Wind schwankend. Die Pikeniere wurden zu einer Attraktion bei königlichen Festen und Paraden, und sowohl sie als auch ihre Waffen erhielten den Beinamen "Hohes Gras".</DefaultText>
+      <DefaultText>Eine Gruppe aedyrischer Pikeniere war so diszipliniert im Kampf, dass sie die Aufmerksamkeit des Fercönyngs auf sich zogen. Er machte sie zu Mitgliedern seiner persönlichen Garde und ließ eigens Waffen für sie fertigen. Sie marschierten an der Spitze seiner Prozession, ihre Bewegungen im perfekten Einklang und ihre Piken wie Grashalme im Wind schwankend. Die Pikeniere wurden zu einer Attraktion bei königlichen Festen und Paraden, und sowohl sie als auch ihre Waffen erhielten den Beinamen "Hohes Gras".</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6251,7 +6251,7 @@ Piken sind außerdem die bevorzugten Waffen der Xaurips. Diese Pike, einfach abe
     </Entry>
     <Entry>
       <ID>1264</ID>
-      <DefaultText>K'eel war ein Wachmann in dem kleinen dyrwäldlerischen Dorf Maidenfall. Er war ein guter Mann, der seine Pflichten ehrenhaft ausführte. Oft fand er sich in gewalttätigen Auseinandersetzungen mit Grobianen und Söldnern wieder, die in das Dorf kamen, um die Ruinen in der Nähe zu plündern.
+      <DefaultText>K'eel war ein Wachmann in dem kleinen dyrwälderischen Dorf Maidenfall. Er war ein guter Mann, der seine Pflichten ehrenhaft ausführte. Oft fand er sich in gewalttätigen Auseinandersetzungen mit Grobianen und Söldnern wieder, die in das Dorf kamen, um die Ruinen in der Nähe zu plündern.
 
 K'eel war dürr, mit einem knabenhaften Gesicht und einem unbeholfenen Gang, weshalb die Missetäter ihn selten für voll nahmen. Sie verspotteten ihn und sagten ihm, er würde sie nie im Leben ins Gefängnis werfen. "Du hast Recht", antwortete K'eel. "Ich bringe Vergebung."</DefaultText>
       <FemaleText />
@@ -6335,7 +6335,7 @@ Eine schreckliche Waffe, die jeden enttäuscht, der sie verwendet. Auf den erste
     </Entry>
     <Entry>
       <ID>1280</ID>
-      <DefaultText>Verdienst des Verräters befand sich einst im Besitz eines aedyranischen Fürsten namens Ygendurl und erhielt seinen Titel während des Widerstandskriegs. Ygendurls Truppen waren von Hadrets Armee besiegt und zerschlagen worden. Sie wussten, ihre Seite würde den Krieg verlieren. Ygendurl bat um einen Waffenstillstand und handelte eine Vereinbarung aus - wenn seine Soldaten verschont werden würden, würden sie in Zukunft für Hadret kämpfen. Anschließend richtete Ygendurl seine Waffe und seine verbleibenden Truppen gegen seine ehemaligen Verbündeten und flankierte sie, während sie auf Hadret konzentriert waren. In dem Chaos, das daraufhin entstand, erlitten die völlig überraschten kaiserlichen Truppen verheerende Verluste.
+      <DefaultText>Verdienst des Verräters befand sich einst im Besitz eines aedyrischen Fürsten namens Ygendurl und erhielt seinen Titel während des Widerstandskriegs. Ygendurls Truppen waren von Hadrets Armee besiegt und zerschlagen worden. Sie wussten, ihre Seite würde den Krieg verlieren. Ygendurl bat um einen Waffenstillstand und handelte eine Vereinbarung aus - wenn seine Soldaten verschont werden würden, würden sie in Zukunft für Hadret kämpfen. Anschließend richtete Ygendurl seine Waffe und seine verbleibenden Truppen gegen seine ehemaligen Verbündeten und flankierte sie, während sie auf Hadret konzentriert waren. In dem Chaos, das daraufhin entstand, erlitten die völlig überraschten kaiserlichen Truppen verheerende Verluste.
 
 Trotz seiner Bemühungen überlebten weder Ygendurl noch seine Truppen den Krieg. Seine Ehrlosigkeit aber ist bis heute nicht vergessen. Beide Seiten denken nicht gern an ihn zurück.</DefaultText>
       <FemaleText />
@@ -6568,7 +6568,7 @@ Während des Widerstandskriegs wurde mehrfach versucht, die Waffe wiederzufinden
     </Entry>
     <Entry>
       <ID>1317</ID>
-      <DefaultText>Die Sonnenlanzenfalle ist unter Eothasianern sehr beliebt. Sie ruft eine mächtige Lanze aus purem, gleißenden Licht herab, die mit tödlicher Kraft einschlägt. Eindringlinge, die nicht sofort aufgespießt werden, werden durch die Hitze oft bei lebendigem Leib verbrannt.</DefaultText>
+      <DefaultText>Die Sonnenlanzenfalle ist unter Eothasiern sehr beliebt. Sie ruft eine mächtige Lanze aus purem, gleißenden Licht herab, die mit tödlicher Kraft einschlägt. Eindringlinge, die nicht sofort aufgespießt werden, werden durch die Hitze oft bei lebendigem Leib verbrannt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6583,14 +6583,14 @@ Während des Widerstandskriegs wurde mehrfach versucht, die Waffe wiederzufinden
     </Entry>
     <Entry>
       <ID>1320</ID>
-      <DefaultText>Jeder in Baelreach kannte Gerun als missmutigen alten Mann mit einer ungewöhnlichen Vorliebe für Rüben und keinerlei Geduld für Plaudereien. Niemand kannte ihn als den aedyranischen Schläger, dessen Vergangenheit ihn gezwungen hatte, ein neues Leben in den Kolonien anzufangen.
+      <DefaultText>Jeder in Baelreach kannte Gerun als missmutigen alten Mann mit einer ungewöhnlichen Vorliebe für Rüben und keinerlei Geduld für Plaudereien. Niemand kannte ihn als den aedyrischen Schläger, dessen Vergangenheit ihn gezwungen hatte, ein neues Leben in den Kolonien anzufangen.
 
-Als daher aedyranische Soldaten zu Beginn des Widerstandskriegs in Baelreach einmarschierten, waren alle vollkommen überrascht, dass der alte Gerun sich den Verteidigern des Dorfes mit Schwert und Schild anschloss und die aedyranischen Truppen ebenso gut zurückhielt wie seine deutlich jüngeren Kameraden.</DefaultText>
+Als daher aedyrische Soldaten zu Beginn des Widerstandskriegs in Baelreach einmarschierten, waren alle vollkommen überrascht, dass der alte Gerun sich den Verteidigern des Dorfes mit Schwert und Schild anschloss und die aedyrischen Truppen ebenso gut zurückhielt wie seine deutlich jüngeren Kameraden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1321</ID>
-      <DefaultText>Dieser beeindruckend große Schild ist mit einem Relief von Dev Clef versehen. Dev Clef ist einer der wichtigsten Orte der Glanfathaner, der Schauplatz einer brutalen Schlacht mit den Dyrwäldlern während der turbulenten Zeiten vor der Unterzeichnung der Zehnjahresverträge. Die Felsen und Höhlen entlang der Klippen boten den Glanfathanern hervorragende Deckung, aus der sie ihre Angriffe gegen die Dyrwäldler starten konnten, nur um sofort wieder zu verschwinden, sobald Gefahr drohte. Dank dieses natürlichen Vorteils konnten die Glanfathaner die Dyrwäldler aus dieser Gegend vertreiben.</DefaultText>
+      <DefaultText>Dieser beeindruckend große Schild ist mit einem Relief von Dev Clef versehen. Dev Clef ist einer der wichtigsten Orte der Glanfathaner, der Schauplatz einer brutalen Schlacht mit den Dyrwäldern während der turbulenten Zeiten vor der Unterzeichnung der Zehnjahresverträge. Die Felsen und Höhlen entlang der Klippen boten den Glanfathanern hervorragende Deckung, aus der sie ihre Angriffe gegen die Dyrwälder starten konnten, nur um sofort wieder zu verschwinden, sobald Gefahr drohte. Dank dieses natürlichen Vorteils konnten die Glanfathaner die Dyrwälder aus dieser Gegend vertreiben.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6617,7 +6617,7 @@ Als daher aedyranische Soldaten zu Beginn des Widerstandskriegs in Baelreach ein
       <ID>1326</ID>
       <DefaultText>Ilfan Byrngar war nicht der fähigste Soldat. Im Gegenteil, er neigte dazu, über seine eigenen Füße zu stolpern. Seine Familie, die sich seiner Tollpatschigkeit nur allzu gut bewusst war, ließ ihm einen Schild von außergewöhnlicher Stärke und Haltbarkeit fertigen. Wenn er schon keine Hiebe auf seine Gegner herabregnen lassen konnte, so hofften sie, er könnte sie wenigstens daran hindern, ihrerseits auf ihn einzuprügeln. 
 
-Der Schild erwies sich für diesen Zweck als äußerst wirkungsvoll, denn Ilfarn wurde durch ihn so gründlich verdeckt, selbst, wenn er benommen im Schlamm lag, dass viele Feinde sich aus purer Frustration neue Ziele suchten.</DefaultText>
+Der Schild erwies sich für diesen Zweck als äußerst wirkungsvoll, denn Ilfan wurde durch ihn so gründlich verdeckt, selbst, wenn er benommen im Schlamm lag, dass viele Feinde sich aus purer Frustration neue Ziele suchten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6627,7 +6627,7 @@ Der Schild erwies sich für diesen Zweck als äußerst wirkungsvoll, denn Ilfarn
     </Entry>
     <Entry>
       <ID>1328</ID>
-      <DefaultText>Scâth Gwannek ("Winterschild") wurde bei einer der ersten Erkundungen der engwithanischen Ruinen in der Weißmark entdeckt und dem aedyranischen Thayn übergeben, der Fort Knochenbeißer befehligte. Der Thayn wusste nicht von der Macht des Schildes und war zu eitel, um einem Artefakt aus den Ruinen zu vertrauen. Er hängte den Schild daher in der Ratskammer des Forts auf, als Zeichen der Herrschaft Aedrys über die Weißmark und den eingeborenen Stamm der Steindornen.</DefaultText>
+      <DefaultText>Scâth Gwannek ("Winterschild") wurde bei einer der ersten Erkundungen der engwithanischen Ruinen in der Weißmark entdeckt und dem aedyrischen Thayn übergeben, der Fort Knochenbeißer befehligte. Der Thayn wusste nicht von der Macht des Schildes und war zu eitel, um einem Artefakt aus den Ruinen zu vertrauen. Er hängte den Schild daher in der Ratskammer des Forts auf, als Zeichen der Herrschaft Aedyrs über die Weißmark und den eingeborenen Stamm der Steindornen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7061,7 +7061,7 @@ Die Handschuhe aus weichem Samt sind mit kryptischen Stickereien verziert. Eine 
     </Entry>
     <Entry>
       <ID>1399</ID>
-      <DefaultText>Kaninchenfellhandschuhe waren über viele Jahrhunderte Bestandteil von aedyranischen Fabeln und Gutenachtgeschichten, meist als glücksbringende Geschenke für besonders tugendhafte Figuren. 
+      <DefaultText>Kaninchenfellhandschuhe waren über viele Jahrhunderte Bestandteil von aedyrischen Fabeln und Gutenachtgeschichten, meist als glücksbringende Geschenke für besonders tugendhafte Figuren. 
  
 Zum ersten Mal erwähnt wurden die Handschuhe in einer Gutenachtgeschichte über ein Mädchen, das inmitten einer Hungersnot einer alten Greisin ein Stück Obst schenkte. Die alte Frau überreichte dem Mädchen daraufhin Kaninchenfellhandschuhe, und obwohl Sommer war, nahm das Mädchen sie dankbar an. Sie trug sie und konnte genug Essen sammeln, um ihre Familie zu ernähren. Wenige Jahre später war sie zu einer Jägerin mit erstaunlichen Fähigkeiten herangewachsen. 
 
@@ -7166,7 +7166,7 @@ Mit der Zeit ging die Krankheit auch auf ihn über, schmolz ihm das Fleisch vom 
       <ID>1416</ID>
       <DefaultText>Dieses Amulett wurde im Jahr 2664 AI von kaiserlichen Agenten aus den Ruinen von Eir&#160;Glanfath geborgen. In dem Versuch, den neuen und instabilen Frieden zwischen Gréf Admeth Hadret und den Glanfathanern zu zerschlagen, fanden sie sich plötzlich im Besitz zahlreicher mächtiger und mysteriöser Artefakte wieder. 
 
-Aedyranische Zauberer und Beseeler zeigten besonders großes Interesse an diesem Stück - zumal, nachdem ein kaiserlicher Wächter behauptete, er würde darin die Seele der Wälder des Dyrwalds sehen. Als einer der Zauberer, die das Amulett studierten, allerdings in den Wahnsinn getrieben wurde, kamen die Forschungen zum Erliegen. Das Artefakt wechselte den Besitzer und es wird angenommen, dass es von einem glanfathanischen Schurken zurückgestohlen wurde.
+Aedyrische Zauberer und Beseeler zeigten besonders großes Interesse an diesem Stück - zumal, nachdem ein kaiserlicher Wächter behauptete, er würde darin die Seele der Wälder des Dyrwalds sehen. Als einer der Zauberer, die das Amulett studierten, allerdings in den Wahnsinn getrieben wurde, kamen die Forschungen zum Erliegen. Das Artefakt wechselte den Besitzer und es wird angenommen, dass es von einem glanfathanischen Schurken zurückgestohlen wurde.
 
 Das tränenförmige Amulett hängt an einer silbernen Kette. Auf der Vorderseite zeigt es das Bild eines Kardinals im Flug, auf der Rückseite ist es mit Runen versehen. Wenn man es trägt, gibt es eine seltsame Vibration ab, die eher gespürt als gehört wird, als würde irgendetwas in dem Amulett die Seele des Trägers zum Schwingen bringen.</DefaultText>
       <FemaleText />
@@ -7254,7 +7254,7 @@ Unter den roten, schwarzen und braunen Federn des Umhangs sind auch einige silbe
     </Entry>
     <Entry>
       <ID>1428</ID>
-      <DefaultText>Dieser Umhang wurde in der Frühzeit des aedyranischen Reichs dem Ritter Erij von einem Kulklin-Gesandten als Freundschaftsgeschenk überreicht. Beeindruckt von den edlen Eigenschaften des Ritters wurde das Geschenk schnell zu einem Symbol des neuen Bündnisses zwischen Elfen und Volk. Der Umhang hat seitdem häufig den Besitzer gewechselt, doch es gilt noch immer als große Ehre, ihn zu empfangen.
+      <DefaultText>Dieser Umhang wurde in der Frühzeit des aedyrischen Reichs dem Ritter Erij von einem Kulkin-Gesandten als Freundschaftsgeschenk überreicht. Beeindruckt von den edlen Eigenschaften des Ritters wurde das Geschenk schnell zu einem Symbol des neuen Bündnisses zwischen Elfen und Volk. Der Umhang hat seitdem häufig den Besitzer gewechselt, doch es gilt noch immer als große Ehre, ihn zu empfangen.
 
 Das glänzende Goldgewebe ist mit rotem und silbernem Schweifwerk aus edler Seide verziert. Auf der Rückseite des Umhangs ist der Umriss einer offenen Rose zu sehen. Er ist immer sauber und in gutem Zustand.</DefaultText>
       <FemaleText />
@@ -7491,7 +7491,7 @@ Da sie besonders unter den Kriegern der Vailianischen Republiken weit verbreitet
       <ID>1473</ID>
       <DefaultText>Dieser Umhang fühlt sich so leicht an, dass man fast vergessen kann, dass man ihn trägt. Der Stoff riecht unverkennbar nach einer Seebrise, kühl und salzig. Auch wenn er von Motten zerfressen und zerfranst ist, hält er die Kälte ab. Die ausgeblichenen Farben fügen sich fast wie ein Tarnmuster in die Umgebung ein.
 
-Du hast diesen Gegenstand im Leuchtturm von Ondras Geschenk gefunden. Der Turm war anderthalb Jahrhunderte lang unbewohnt. Die letzte Bewohnerin, die Leuchtturmwärterin, starb angeblich während der Invasion durch die Aedyraner. Es heißt, dass ihr Geist noch immer in dem Turm haust und Ausschau nach Schiffen am Horizont hält.</DefaultText>
+Du hast diesen Gegenstand im Leuchtturm von Ondras Geschenk gefunden. Der Turm war anderthalb Jahrhunderte lang unbewohnt. Die letzte Bewohnerin, die Leuchtturmwärterin, starb angeblich während der Invasion durch die Aedyrer. Es heißt, dass ihr Geist noch immer in dem Turm haust und Ausschau nach Schiffen am Horizont hält.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7510,7 +7510,7 @@ Dieser Gürtel ist nach diesen Monstern benannt und verleiht dem Träger auf mag
       <ID>1476</ID>
       <DefaultText>Die berühmteste Schlacht im Krieg des Heiligen - abgesehen von der bei der Zitadelle von Halgot - war die Schlacht im Gnadental. 
 
-Während der Haupttrupp von St. Waidwens Armee von Norden her in den Dyrwald einmarschierte, näherten sich zwei Brigaden aus Richtung Osten. Sie erreichten Kaltmorg durch einen Pass aus der Weißmark. Die Bewohner von Kaltmorg ließen die Readceraner ungehindert passieren, ein Akt der Feigheit, für den die Dyrwäldler sie noch heute verfluchen. Die Soldaten zogen nach Norden, wo sie sich bei Neu-Yarma der übrigen Armee anschließen wollten. 
+Während der Haupttrupp von St. Waidwens Armee von Norden her in den Dyrwald einmarschierte, näherten sich zwei Brigaden aus Richtung Osten. Sie erreichten Kaltmorg durch einen Pass aus der Weißmark. Die Bewohner von Kaltmorg ließen die Readceraner ungehindert passieren, ein Akt der Feigheit, für den die Dyrwälder sie noch heute verfluchen. Die Soldaten zogen nach Norden, wo sie sich bei Neu-Yarma der übrigen Armee anschließen wollten. 
 
 Die Bewohner des Gnadentals hatten kaum Vorwarnung und daher wenig Zeit, sich zu rüsten, doch sie kämpften erbittert, um die Readceraner so lange sie konnten zurückzuhalten. Die Stadt wurde zwar nach einigen Tagen des Kampfes niedergebrannt, doch die Gnadentaler hatten den Dörfern und Stämmen auf dem Weg nach Neu-Yarma genügend Zeit verschafft, um erfolgreiche Guerillaangriffe zu planen. Es wird allgemein angenommen, dass die Schlacht im Gnadental und die vielen Scharmützel in der Wildnis die Readceraner daran gehindert haben, die Zitadelle von Halgot zu erreichen, ehe der Götterhammer bereit war.
 
@@ -7592,7 +7592,7 @@ Sie verbrachte das letzte Jahrhundert ihres Lebens damit, einen Weg zu suchen, i
     </Entry>
     <Entry>
       <ID>1490</ID>
-      <DefaultText>Dieser dicke Eisenring ist verbeult und verkratzt und scheint lange und intensiv genutzt worden zu sein. Er ist mit elf kleinen Perlen besetzt, eine für jeden Gott. Er wurde von einem aedyranischen Priester gefertigt, um ihn an seinen Glauben zu erinnern, insbesondere im Eifer des Gefechts. Es heißt, wenn er mit den Fingern gegen die Perlen rieb, stieß er ein kurzes Gebet an jeden der Götter aus, die ihn im Gegenzug segneten.</DefaultText>
+      <DefaultText>Dieser dicke Eisenring ist verbeult und verkratzt und scheint lange und intensiv genutzt worden zu sein. Er ist mit elf kleinen Perlen besetzt, eine für jeden Gott. Er wurde von einem aedyrischen Priester gefertigt, um ihn an seinen Glauben zu erinnern, insbesondere im Eifer des Gefechts. Es heißt, wenn er mit den Fingern gegen die Perlen rieb, stieß er ein kurzes Gebet an jeden der Götter aus, die ihn im Gegenzug segneten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7636,7 +7636,7 @@ Das Monokel aus dunklem Messing ist mit filigranen Drahtarbeiten in der Form von
     </Entry>
     <Entry>
       <ID>1498</ID>
-      <DefaultText>Der Legende nach gehörte dieser Hut einst einem berühmten Prinzen eines kleinen Königreichs, das vom Aedyranischen Kaiserreich erobert wurde und darin aufging. Der Prinz und sein Hofstaat waren für ihre ausgefallene Kleidung bekannt, unglücklicherweise aber nicht für ihr Geschick im Kampf. Als der Prinz erfuhr, dass die aedyranische Armee auf ihn zumarschierte, ließ er ein rauschendes Fest ausrichten, um die Invasoren zu begrüßen. 
+      <DefaultText>Der Legende nach gehörte dieser Hut einst einem berühmten Prinzen eines kleinen Königreichs, das vom Aedyrischen Kaiserreich erobert wurde und darin aufging. Der Prinz und sein Hofstaat waren für ihre ausgefallene Kleidung bekannt, unglücklicherweise aber nicht für ihr Geschick im Kampf. Als der Prinz erfuhr, dass die aedyrische Armee auf ihn zumarschierte, ließ er ein rauschendes Fest ausrichten, um die Invasoren zu begrüßen. 
 
 Dieser Hut überlebte den Krieg und die anschließende Besatzung und wurde seitdem in vielen dunklen Ecken von Ehrgeizlingen gehandelt, die ihre gesellschaftliche Stellung mit Stil verbessern wollten.
 
@@ -7674,15 +7674,15 @@ Dieser abgewetzte und ramponierte Lederhelm passt über den Kopf und bedeckt den
     </Entry>
     <Entry>
       <ID>1504</ID>
-      <DefaultText>Niemand konnte wissen, dass der Mann, der einst einen Teil seines eigenen Landes durch Feuer zerstörte, einmal zum beliebtesten Anführer des Dyrwalds werden würde. Admeth starb als Märtyrer in dem Krieg, den er begonnen hatte, um sein Volk von der Unterdrückung zu befreien. Jeder Dyrwäldler kennt und verehrt ihn für seine Taten.
+      <DefaultText>Niemand konnte wissen, dass der Mann, der einst einen Teil seines eigenen Landes durch Feuer zerstörte, einmal zum beliebtesten Anführer des Dyrwalds werden würde. Admeth starb als Märtyrer in dem Krieg, den er begonnen hatte, um sein Volk von der Unterdrückung zu befreien. Jeder Dyrwälder kennt und verehrt ihn für seine Taten.
 
-Obwohl es Aufzeichnungen über die Kindheit seines Vaters Edrang gibt - und obwohl er vom Adel des Dyrwalds (als dieser noch zu aedyranischem Gebiet gehörte) großgezogen wurde, sind über Admeths frühe Jahre kaum Informationen zu finden. Aber Admeth ist nicht für seine Kindheit bekannt. Er ist dafür bekannt, den Dyrwald gerettet und mit seinem Erzfeind vereint zu haben - den Glanfathanern.
+Obwohl es Aufzeichnungen über die Kindheit seines Vaters Edrang gibt - und obwohl er vom Adel des Dyrwalds (als dieser noch zu aedyrischem Gebiet gehörte) großgezogen wurde, sind über Admeths frühe Jahre kaum Informationen zu finden. Aber Admeth ist nicht für seine Kindheit bekannt. Er ist dafür bekannt, den Dyrwald gerettet und mit seinem Erzfeind vereint zu haben - den Glanfathanern.
 
 Im Jahr 2652 AI hatten die Schwierigkeiten des Dyrwalds mit seinem Fercönyng ihren Höhepunkt erreicht. Mehrere der Grafen unter Edrangs Herrschaft - angestachelt vom kaiserlichen Hof in Aedyr - plünderten die Ruinen im gesamten Dyrwald, die den Glanfathanern heilig waren. Als die Glanfathaner schließlich Vergeltung übten, taten sie dies mit gewaltiger Brutalität und es kam zu einem Sklavenaufstand. Galven Regd, den Edrang schon einmal bekämpft hatte, übernahm die Führung über die glanfathanischen Truppen. Regd konnte auch einige Delemgan überzeugen, sich dem Kampf anzuschließen.
 
 Edrang war zu diesem Zeitpunkt schon viel zu alt, um seine Truppen in die Schlacht zu führen, also schickte er seinen Sohn Admeth an seiner Statt, um die Gefahr zu bannen. Admeth hatte offensichtlich von seinem Vater die Kunst der Taktik erlernt und machte ihm alle Ehre, als er eine gefährliche aber effektive Entscheidung traf. Um zu verhindern, dass Regds Truppen den Wald als Deckung nutzten und weiter durch sein Land vorrücken konnten, setzte er den Wald am Zufluss des Flusses Isce Uar in Brand und postierte seine Truppen so, dass sie die Glanfathaner am Rückzug hinderten. Diese Taktik erwies sich als äußerst effektiv. Einige Glanfathaner und Delemgan konnten zwar entkommen, doch Tausende starben. In dem Scharmützel, das folgte, wurde Galven Regd gefangen genommen und nach Neu-Heomar gebracht. Admeth gelang, was sein Vater jahrzehntelang versucht hatte. Er hielt Galven Regd auf.
 
-Der Konflikt mit den Glanfathanern dauerte noch mehrere Monate an und Admeth setzte die Taktik der verbrannten Erde noch mehrmals ein, um die feindlichen Truppen von zentralen Schlachtfeldern zu treiben. Er konnte den Konflikt beenden, noch ehe das Jahr sich zu Ende neigte. Doch die Dyrwäldler hatten sich den Sieg teuer erkauft. Admeths Taktiken führten dazu, dass der Konflikt als "Krieg der Schwarzen Bäume" in die Geschichte einging.
+Der Konflikt mit den Glanfathanern dauerte noch mehrere Monate an und Admeth setzte die Taktik der verbrannten Erde noch mehrmals ein, um die feindlichen Truppen von zentralen Schlachtfeldern zu treiben. Er konnte den Konflikt beenden, noch ehe das Jahr sich zu Ende neigte. Doch die Dyrwälder hatten sich den Sieg teuer erkauft. Admeths Taktiken führten dazu, dass der Konflikt als "Krieg der Schwarzen Bäume" in die Geschichte einging.
 
 Nach Edrangs Tod im Jahr 2654 wurde Admeth zum Gréf des Dyrwalds, zum Entsetzen des kaiserlichen Hofs und der anderen Grafen. Im Verlauf des nächsten Jahres widersetzten sie sich seiner Herrschaft bei jeder Gelegenheit. Sie wiesen seine Dekrete zurück und widersetzten sich seinen Befehlen.
 
@@ -7700,7 +7700,7 @@ Dank seiner neuen Stellung hatte Admeth keine Mühe, die rebellischen Grafen spu
     </Entry>
     <Entry>
       <ID>1506</ID>
-      <DefaultText>Aedyranische Bräuche</DefaultText>
+      <DefaultText>Aedyrische Bräuche</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7725,7 +7725,7 @@ Dank seiner neuen Stellung hatte Admeth keine Mühe, die rebellischen Grafen spu
     </Entry>
     <Entry>
       <ID>1511</ID>
-      <DefaultText>Der Beherzte Dieb: Eine dyrwäldlerische Farce, Teil 1</DefaultText>
+      <DefaultText>Der Beherzte Dieb: Eine dyrwälderische Farce, Teil 1</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7740,7 +7740,7 @@ Dank seiner neuen Stellung hatte Admeth keine Mühe, die rebellischen Grafen spu
     </Entry>
     <Entry>
       <ID>1514</ID>
-      <DefaultText>Eothasianische Gebete</DefaultText>
+      <DefaultText>Eothasische Gebete</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7885,13 +7885,13 @@ Dank seiner neuen Stellung hatte Admeth keine Mühe, die rebellischen Grafen spu
     </Entry>
     <Entry>
       <ID>1543</ID>
-      <DefaultText>Aedyr ist ein Land, das reich an Tradition und Brauchtum ist. Die strikte Einhaltung dieser Traditionen ist einer der Grundpfeiler der aedyranischen Gesellschaft. Das Spektrum der Bräuche reicht dabei von großen Feiern - wie dem Festmahl der Festmahle - bis zu trivialem Aberglauben - wie den Möglichkeiten, eine Svef-Sucht zu vermeiden. Dieser Band beschäftigt sich primär mit größeren Feierlichkeiten, denn niemand weiß rauschendere Feste auszurichten als ein Aedyraner.
+      <DefaultText>Aedyr ist ein Land, das reich an Tradition und Brauchtum ist. Die strikte Einhaltung dieser Traditionen ist einer der Grundpfeiler der aedyrischen Gesellschaft. Das Spektrum der Bräuche reicht dabei von großen Feiern - wie dem Festmahl der Festmahle - bis zu trivialem Aberglauben - wie den Möglichkeiten, eine Svef-Sucht zu vermeiden. Dieser Band beschäftigt sich primär mit größeren Feierlichkeiten, denn niemand weiß rauschendere Feste auszurichten als ein Aedyrer.
 
 Das Festmahl der Festmahle
 
-Die größte und wichtigste aller aedyranischen Traditionen ist das Festmahl der Festmahle. Dieses Fest wird während der gesamten ersten Woche des Fonestu (Tiefsommers) gefeiert und ist dem Leben des Ersten Fercönyngs gewidmet. Jeder Tag der Woche beschäftigt sich mit einem anderen Aspekt des Lebens des Fercönyngs, und bei jeder Mahlzeit werden spezielle Gerichte serviert. 
+Die größte und wichtigste aller aedyrischen Traditionen ist das Festmahl der Festmahle. Dieses Fest wird während der gesamten ersten Woche des Fonestu (Tiefsommers) gefeiert und ist dem Leben des Ersten Fercönyngs gewidmet. Jeder Tag der Woche beschäftigt sich mit einem anderen Aspekt des Lebens des Fercönyngs, und bei jeder Mahlzeit werden spezielle Gerichte serviert. 
 
-Das Festmahl der Festmahle hat seinen Ursprung in einer Feier zur Geburt des ersten Sohnes des Fercönyngs und wurde schnell zu einer jährlichen Tradition in der Woche seines Geburtstages. Heute nutzen die Aedyraner es schlicht als Ausrede für ein rauschendes Fest, bei dem sie sich stets bemühen, das Fest des Vorjahres noch zu übertreffen.
+Das Festmahl der Festmahle hat seinen Ursprung in einer Feier zur Geburt des ersten Sohnes des Fercönyngs und wurde schnell zu einer jährlichen Tradition in der Woche seines Geburtstages. Heute nutzen die Aedyrer es schlicht als Ausrede für ein rauschendes Fest, bei dem sie sich stets bemühen, das Fest des Vorjahres noch zu übertreffen.
 
 Und sollte der geneigte Leser sich fragen (wie ich es tat), welcher Fercönyng während des Festmahls der Festmahle geehrt wird - es ist stets der momentan herrschende Fercönyng. Denn jeder Fercönyng ist der Erste und Einzige Fercönyng.
 
@@ -7901,7 +7901,7 @@ Der Brauch des Naschzeugs kam im Laufe der Jahre während des Festmahls der Fest
 
 Karneval der Masken
 
-Als die ersten aedryanischen Kolonisten in das neue Land reisten, um den Dyrwald im Namen des Fercönyngs von Aedyr zu gründen, trafen sie auf das glanfathanische Volk. Der Karneval der Masken wird zu Ehren dieser Begegnung gefeiert. Ursprünglich war er schlicht eine formelle historische Nachstellung - in Form eines Theaterstücks - der Spannungen zwischen den Glanfathanern und den aedyranischen Siedlern. Inzwischen aber hat er sich zu sehr viel mehr entwickelt. Die Teilnehmer wählen eine "Seite" und verkleiden sich in aufwendigen Kostümen, die deutlich machen, welcher Gruppe sie angehören - den Aedyranern oder den Glanfathanern. Alle nehmen an einem Maskenball teil, der heute das eigentliche Theaterstück längst verdrängt hat. Nur noch das Fest zählt.
+Als die ersten aedyrischen Kolonisten in das neue Land reisten, um den Dyrwald im Namen des Fercönyngs von Aedyr zu gründen, trafen sie auf das glanfathanische Volk. Der Karneval der Masken wird zu Ehren dieser Begegnung gefeiert. Ursprünglich war er schlicht eine formelle historische Nachstellung - in Form eines Theaterstücks - der Spannungen zwischen den Glanfathanern und den aedyrischen Siedlern. Inzwischen aber hat er sich zu sehr viel mehr entwickelt. Die Teilnehmer wählen eine "Seite" und verkleiden sich in aufwendigen Kostümen, die deutlich machen, welcher Gruppe sie angehören - den Aedyrern oder den Glanfathanern. Alle nehmen an einem Maskenball teil, der heute das eigentliche Theaterstück längst verdrängt hat. Nur noch das Fest zählt.
 
 Wintersend
 
@@ -7912,7 +7912,7 @@ Wintersend war nie etwas anderes als eine willkommene Gelegenheit für ein Fest.
       <ID>1544</ID>
       <DefaultText>Die Beseelung ist eine ebenso angesehene wie verteufelte Wissenschaft, oft von ein und derselben Person. Trotz all der Forschungen, die auf dem Gebiet angestellt werden und wurden, wissen wir noch sehr wenig. Das Leben selbst kontrollieren! Auf dieses Ziel arbeiten Beseeler seit Jahrhunderten hin. Es gibt keine echten Aufzeichnungen darüber, wie die Beseelung entdeckt wurde, doch nachdem der Funke des Wissens einmal entzündet war, ließen sich die unvermeidlichen Entdeckungen nicht mehr aufhalten.
 
-Im Jahr 2260 AI konnten Beseeler als Ergebnis ihrer aufwendigen Forschungen eine Seele erfolgreich bannen und übertragen. Die Versuchsperson des Experiments war ein unbekannter junger Mann, der zwar wohlhabend war, aber schwer krank. Seine Seele sollte aus seinem sterbenden Körper in den eines kürzlich bei einem Unfall ums Leben gekommenen Mannes übertragen werden. Der neue Körper, der nur geringfügigen Verfall aufwies, sollte der Seele ein Zuhause bieten und dem jungen Mann ein sehr viel besseres Leben bescheren. Das Ergebnis des Experiments führte zur Schmähung und zum Verbot der Beseelung im aedyranischen Reich.
+Im Jahr 2260 AI konnten Beseeler als Ergebnis ihrer aufwendigen Forschungen eine Seele erfolgreich bannen und übertragen. Die Versuchsperson des Experiments war ein unbekannter junger Mann, der zwar wohlhabend war, aber schwer krank. Seine Seele sollte aus seinem sterbenden Körper in den eines kürzlich bei einem Unfall ums Leben gekommenen Mannes übertragen werden. Der neue Körper, der nur geringfügigen Verfall aufwies, sollte der Seele ein Zuhause bieten und dem jungen Mann ein sehr viel besseres Leben bescheren. Das Ergebnis des Experiments führte zur Schmähung und zum Verbot der Beseelung im aedyrischen Reich.
 
 Wir besitzen keine echten Aufzeichnungen darüber, was geschehen ist (sie wurden nach dem Verbot der Beseelung allesamt vernichtet). Es wurde jedoch ein Tagebuch entdeckt, eine Art Geständnis eines Teilnehmers. Es folgen Auszüge aus diesem Tagebuch:
 
@@ -8039,18 +8039,18 @@ Davon ließ Galven Regd sich jedoch nicht aufhalten. Er begann einen Feldzug des
 
 Es dauerte nicht lang, bevor Edrangs Männer Regds Schritte vorhersehen und wieder und wieder vereiteln konnten. Als er gefragt wurde, wie er einen Feind besiegen konnte, der jeden Schritt voraussah, antwortete Edrang: "Genau so stand er kurz davor, uns zu überlisten. Unsere Schritte waren vorhersehbar. Jeder konnte die gewöhnlichen Taktiken durchschauen. Wenn man etwas dünn genug ausbreitet, kann man ein Loch hineinstechen. Ich habe einen unvorhersehbaren Feind durch Unvorhersehbarkeit besiegt."
 
-Da Edrang die Pläne von Regd vereiteln konnte, verlief sich der Konflikt schließlich im Sande. Regd sandte eine Botschaft an Edrang, in der er ihm seinen Respekt für seine Taktiken und sein militärisches Geschick aussprach. Dieses politische und militärische Patt führte dazu, das erstmals zwischen den Glanfathanern und den aedyranischen Kolonisten, die einmal zu den Dyrwäldlern werden sollten, Verträge unterzeichnet wurden.</DefaultText>
+Da Edrang die Pläne von Regd vereiteln konnte, verlief sich der Konflikt schließlich im Sande. Regd sandte eine Botschaft an Edrang, in der er ihm seinen Respekt für seine Taktiken und sein militärisches Geschick aussprach. Dieses politische und militärische Patt führte dazu, das erstmals zwischen den Glanfathanern und den aedyrischen Kolonisten, die einmal zu den Dyrwäldern werden sollten, Verträge unterzeichnet wurden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1550</ID>
-      <DefaultText>Die Geschichte von Eir&#160;Glanfath vor der Entdeckung durch die Aedyraner ist schlecht dokumentiert. Die mündlichen Überlieferungen widersprechen sich häufig. Manche berichten von einer fortschrittlichen Zivilisation, die einfach verschwand, ihr gesamtes Wissen mitnahm und nur ihre Ruinen zurückließ. Andere sagen, die Glanfathaner selbst hätten solche Macht und Technologie entwickelt, dass sie sich beinahe selbst zerstört hätten, weshalb sie niemandem Zugang zu den Ruinen auf ihrem Land gewähren. Wie dem auch sei, verlässliche Informationen über das Gebiet Eir&#160;Glanfath gibt es erst, seit aedyranische Entdecker es im Jahr 2602 AI entdeckten.
+      <DefaultText>Die Geschichte von Eir&#160;Glanfath vor der Entdeckung durch die Aedyrer ist schlecht dokumentiert. Die mündlichen Überlieferungen widersprechen sich häufig. Manche berichten von einer fortschrittlichen Zivilisation, die einfach verschwand, ihr gesamtes Wissen mitnahm und nur ihre Ruinen zurückließ. Andere sagen, die Glanfathaner selbst hätten solche Macht und Technologie entwickelt, dass sie sich beinahe selbst zerstört hätten, weshalb sie niemandem Zugang zu den Ruinen auf ihrem Land gewähren. Wie dem auch sei, verlässliche Informationen über das Gebiet Eir&#160;Glanfath gibt es erst, seit aedyrische Entdecker es im Jahr 2602 AI entdeckten.
  
-Die Glanfathaner waren zuvor nicht an Begegnungen mit Fremden gewöhnt, und betrachteten das Eindringen in ihr Land daher als eine Art Prüfung. Die Ruinen, die das Land bedeckten, galten als heilig, und diese Fremden plünderten sie trotz zahlreicher Warnungen und stahlen Artefakte. Glanfathaner, die sich zur Wehr setzten, wurden gefangen genommen und versklavt, sie wurden zum Eigentum der neuen Kolonisten. Ihr Volk, ihr Vermächtnis und ihr Land standen auf dem Spiel. Die Glanfathaner schlugen zurück, in der Hoffnung, die Eindringlinge dauerhaft aus ihrem Land zu vertreiben. Doch trotz ihrer Bemühungen kamen immer mehr aedyranische Invasoren. Als das Jahr 2623 AI heranbrach, hatten die Aedyraner Städte gegründet, die Glanfathaner aus einigen Gebieten verdrängt und jeden versklavt, der sich widersetzte. Die Glanfathaner versuchten, in Frieden zu leben und die Aedyraner im Auge zu behalten. Bis auf einige Einzelfälle schien das auch zu funktionieren. Im Jahr 2626 AI kam dieser brüchige Frieden jedoch zu einem blutigen Ende. Eine Gruppe von Bauern wollte Ackerland schaffen, inmitten eines Gebiets, auf dem zahlreiche heilige Ruinen standen. Dabei stießen sie einen der uralten Hinkelsteine um. Ob es ein Versehen war oder absichtlich geschah, ist nicht bekannt. Doch der Vorfall löste einen Konflikt aus, der als Krieg des Zerbrochenen Steins in die Geschichte einging. Der Krieg war kurz, er dauerte weniger als ein Jahr, aber er war blutig und brutal. Mehrere tausend aedyranische Kolonisten starben, genau wie hunderte von Glanfathanern.
+Die Glanfathaner waren zuvor nicht an Begegnungen mit Fremden gewöhnt, und betrachteten das Eindringen in ihr Land daher als eine Art Prüfung. Die Ruinen, die das Land bedeckten, galten als heilig, und diese Fremden plünderten sie trotz zahlreicher Warnungen und stahlen Artefakte. Glanfathaner, die sich zur Wehr setzten, wurden gefangen genommen und versklavt, sie wurden zum Eigentum der neuen Kolonisten. Ihr Volk, ihr Vermächtnis und ihr Land standen auf dem Spiel. Die Glanfathaner schlugen zurück, in der Hoffnung, die Eindringlinge dauerhaft aus ihrem Land zu vertreiben. Doch trotz ihrer Bemühungen kamen immer mehr aedyrische Invasoren. Als das Jahr 2623 AI heranbrach, hatten die Aedyrer Städte gegründet, die Glanfathaner aus einigen Gebieten verdrängt und jeden versklavt, der sich widersetzte. Die Glanfathaner versuchten, in Frieden zu leben und die Aedyrer im Auge zu behalten. Bis auf einige Einzelfälle schien das auch zu funktionieren. Im Jahr 2626 AI kam dieser brüchige Frieden jedoch zu einem blutigen Ende. Eine Gruppe von Bauern wollte Ackerland schaffen, inmitten eines Gebiets, auf dem zahlreiche heilige Ruinen standen. Dabei stießen sie einen der uralten Hinkelsteine um. Ob es ein Versehen war oder absichtlich geschah, ist nicht bekannt. Doch der Vorfall löste einen Konflikt aus, der als Krieg des Zerbrochenen Steins in die Geschichte einging. Der Krieg war kurz, er dauerte weniger als ein Jahr, aber er war blutig und brutal. Mehrere tausend aedyrische Kolonisten starben, genau wie hunderte von Glanfathanern.
 
-Auch, nachdem der Krieg endete, nahmen die Angriffe auf die Aedyraner kein Ende. Ein Orlaner namens Regd wurde als Galven der Glanfathaner auserwählt. Er schwor, jeden Fremden für die Ungerechtigkeiten bezahlen zu lassen, die dem Land seines Volkes angetan worden waren. Er organisierte die glanfathanischen Reißzähne und führte im Verlauf der nächsten zwei Jahre eine Reihe von Angriffen aus. Es schien, als würden Regds Taktiken Erfolg zeigen und die Aedyraner aus Eir&#160;Glanfath vertreiben, doch dann begannen sie, sich zu wehren. Sie wurden deutlich organisierter, ihre Taktiken weniger vorhersehbar. Immer weniger von Regds Angriffen waren erfolgreich. Er fand heraus, dass ein neuer Gréf ernannt worden war, Edrang Hadret - jemand, der ähnliches taktisches Geschick besaß wie er selbst. Es entwickelte sich eine Pattsituation, keiner der beiden Anführer konnte mehr einen Vorteil über den anderen erlangen.
+Auch, nachdem der Krieg endete, nahmen die Angriffe auf die Aedyrer kein Ende. Ein Orlaner namens Regd wurde als Galven der Glanfathaner auserwählt. Er schwor, jeden Fremden für die Ungerechtigkeiten bezahlen zu lassen, die dem Land seines Volkes angetan worden waren. Er organisierte die glanfathanischen Reißzähne und führte im Verlauf der nächsten zwei Jahre eine Reihe von Angriffen aus. Es schien, als würden Regds Taktiken Erfolg zeigen und die Aedyrer aus Eir&#160;Glanfath vertreiben, doch dann begannen sie, sich zu wehren. Sie wurden deutlich organisierter, ihre Taktiken weniger vorhersehbar. Immer weniger von Regds Angriffen waren erfolgreich. Er fand heraus, dass ein neuer Gréf ernannt worden war, Edrang Hadret - jemand, der ähnliches taktisches Geschick besaß wie er selbst. Es entwickelte sich eine Pattsituation, keiner der beiden Anführer konnte mehr einen Vorteil über den anderen erlangen.
 
-Als Ergebnis des Patts fanden die Feindseligkeiten zwischen den beiden Gruppen ein Ende. Die Feinde unterzeichneten Verträge, um die Gewalt und die Anspannungen beizulegen. Regd trat als Galven zurück und kehrte zu seinem einfachen Leben zurück. Hadret stellte das Plündern der Ruinen von Eir&#160;Glanfath unter Strafe. Als Zeichen des guten Willens versuchte Hadret außerdem, die Sklaverei zu verbieten, was jedoch von den anderen Grafen und dem Fercönyng von Aedyr abgelehnt wurde. Es kam daher weiterhin gelegentlich zu gewalttätigen Auseinandersetzungen. Hadrets Verträge führten zu 20&#160;Jahren des relativen Friedens für die Glanfathaner, die den Aedyranern zwar weiterhin misstrauisch gegenüberstanden, aber bereit waren, ihre Anwesenheit zu dulden, wenn es nicht anders ging.</DefaultText>
+Als Ergebnis des Patts fanden die Feindseligkeiten zwischen den beiden Gruppen ein Ende. Die Feinde unterzeichneten Verträge, um die Gewalt und die Anspannungen beizulegen. Regd trat als Galven zurück und kehrte zu seinem einfachen Leben zurück. Hadret stellte das Plündern der Ruinen von Eir&#160;Glanfath unter Strafe. Als Zeichen des guten Willens versuchte Hadret außerdem, die Sklaverei zu verbieten, was jedoch von den anderen Grafen und dem Fercönyng von Aedyr abgelehnt wurde. Es kam daher weiterhin gelegentlich zu gewalttätigen Auseinandersetzungen. Hadrets Verträge führten zu 20&#160;Jahren des relativen Friedens für die Glanfathaner, die den Aedyrern zwar weiterhin misstrauisch gegenüberstanden, aber bereit waren, ihre Anwesenheit zu dulden, wenn es nicht anders ging.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8103,11 +8103,11 @@ Eine weitere gute Frage, die von vielen gestellt wird, bezieht sich auf die Glan
       <ID>1553</ID>
       <DefaultText>Wenn man in Eir&#160;Glanfath den Namen Regd erwähnt, so werden einem Geschichten erzählt von einem glorreichen Freiheitskämpfer - einem Orlaner, der sein taktisches Geschick und seine militärische Ausbildung nutzte, um die Glanfathaner vor den Gräueltaten der Invasoren im Dyrwald zu beschützen. Fragt man im Dyrwald nach ihm, so hört man wütende Berichte über die schändlichen Taten eines hinterhältigen, unehrenhaften Orlaners, der die Bürger des Dyrwalds terrorisiert hat. Aus solchen Konflikten entstehen Legenden, und Galven Regd ist eine solche Legende.
 
-Der Krieg des Zerbrochenen Steins begann durch ein Missverständnis zwischen den Glanfathanern, die im Dyrwald lebten, und den aedryranischen Kolonisten, die sich dort niederließen. Es gab bereits Spannungen zwischen den beiden Gruppen, da die Aedyraner Land für sich beanspruchten, von dem die Glanfathaner sagten, es befände sich bereits in ihrem Besitz. Da zudem noch Glanfathaner von Aedyranern gefangen genommen und versklavt wurden, war es nur eine Frage der Zeit, bis etwas das Fass zum Überlaufen brachte und die zwei Völker gegeneinander Krieg führten. Es gab zwar gelegentliche Scharmützel und Kämpfe zwischen isolierten Gruppen, aber keinen echten Konflikt ... bis zum Krieg des Zerbrochenen Steins.
+Der Krieg des Zerbrochenen Steins begann durch ein Missverständnis zwischen den Glanfathanern, die im Dyrwald lebten, und den aedyrischen Kolonisten, die sich dort niederließen. Es gab bereits Spannungen zwischen den beiden Gruppen, da die Aedyrer Land für sich beanspruchten, von dem die Glanfathaner sagten, es befände sich bereits in ihrem Besitz. Da zudem noch Glanfathaner von Aedyrern gefangen genommen und versklavt wurden, war es nur eine Frage der Zeit, bis etwas das Fass zum Überlaufen brachte und die zwei Völker gegeneinander Krieg führten. Es gab zwar gelegentliche Scharmützel und Kämpfe zwischen isolierten Gruppen, aber keinen echten Konflikt ... bis zum Krieg des Zerbrochenen Steins.
 
-Ob beabsichtigt oder nicht, aedyranische Bauern, die Ackerland für ihre Feldfrüchte schaffen wollten, warfen einen der uralten Hinkelsteine um, die überall auf dem Land zu finden sind - und er zerbrach. Die Glanfathaner, welche die alten Ruinen im Dyrwald als heilig ansahen, reagierten schnell und gewalttätig, angeführt von einem besonders fanatischen Reißzahn namens Regd. Der Krieg war zwar nur von kurzer Dauer und die Glanfathaner gingen letztlich nicht als Sieger aus ihm hervor, doch Regd und seine Truppen konnten eine beträchtliche Zahl von Kolonisten eliminieren.
+Ob beabsichtigt oder nicht, aedyrische Bauern, die Ackerland für ihre Feldfrüchte schaffen wollten, warfen einen der uralten Hinkelsteine um, die überall auf dem Land zu finden sind - und er zerbrach. Die Glanfathaner, welche die alten Ruinen im Dyrwald als heilig ansahen, reagierten schnell und gewalttätig, angeführt von einem besonders fanatischen Reißzahn namens Regd. Der Krieg war zwar nur von kurzer Dauer und die Glanfathaner gingen letztlich nicht als Sieger aus ihm hervor, doch Regd und seine Truppen konnten eine beträchtliche Zahl von Kolonisten eliminieren.
 
-Nach dem Ende des Krieges wurde Regd zum Galven - oder Anführer - der glanfathanischen Stimme gewählt. Seine Eignung als Anführer und seine Stärke im Kampf hatten ihm den Respekt aller Stämme von Eir&#160;Glanfath eingebracht. Da alle Stämme vereint hinter ihm standen, konnte er die Krieger derart organisiert befehligen und koordinieren, dass sie zu einer effektiven Armee wurden, vor deren nächstem Angriff die aedyranischen Kolonisten sich täglich fürchteten. Sein Name und sein Ruf verbreiteten sich unter beiden Völkern. In den zwei Jahren nach dem Krieg des Zerbrochenen Steins tötete Regd mit seinen Truppen durch Täuschung, Fehlinformation und Guerillataktiken Hunderte von Aedyranern. Die verbleibenden Grafen drängten den Fercönyng, etwas zu unternehmen, ehe noch mehr Adlige getötet wurden, doch Regd terrorisierte die Kolonisten weiter - und es schien, als würde sein Feldzug niemals ein Ende nehmen.
+Nach dem Ende des Krieges wurde Regd zum Galven - oder Anführer - der glanfathanischen Stimme gewählt. Seine Eignung als Anführer und seine Stärke im Kampf hatten ihm den Respekt aller Stämme von Eir&#160;Glanfath eingebracht. Da alle Stämme vereint hinter ihm standen, konnte er die Krieger derart organisiert befehligen und koordinieren, dass sie zu einer effektiven Armee wurden, vor deren nächstem Angriff die aedyrischen Kolonisten sich täglich fürchteten. Sein Name und sein Ruf verbreiteten sich unter beiden Völkern. In den zwei Jahren nach dem Krieg des Zerbrochenen Steins tötete Regd mit seinen Truppen durch Täuschung, Fehlinformation und Guerillataktiken Hunderte von Aedyrern. Die verbleibenden Grafen drängten den Fercönyng, etwas zu unternehmen, ehe noch mehr Adlige getötet wurden, doch Regd terrorisierte die Kolonisten weiter - und es schien, als würde sein Feldzug niemals ein Ende nehmen.
 
 Bis er auf Edrang Hadret traf.</DefaultText>
       <FemaleText />
@@ -8122,11 +8122,11 @@ Das Fest der Ahnen findet während des Frühlingserwachens statt und wird zu Ehr
 
 Die Säuberung
 
-Die Säuberung begann als Protest, der das Leid nachstellte, das den Glanfathanern von den aedyranischen Kolonisten zugefügt wurde, als diese begannen, sich im Dyrwald niederzulassen. Mit den Jahren hat die Säuberung sich gewandelt, so dass sie heute eher einem Spiel gleicht, das auch dazu dient, die Glanfathaner die Geschichte ihres Volkes zu lehren. Die Säuberung findet an Neujahr und Mittjahr statt und ist nur mehr eine Metapher für reale Ereignisse, keine Nachstellung der Ereignisse selbst mehr. Xaurip-Bildnisse werden im Wald aufgestellt, hohle Tonhüllen, die mit Süßigkeiten und Geschenken gefüllt sind. Die Kinder suchen im Wald nach den Bildnissen und zerstören sie - sie "säubern" den Wald, damit die Glanfathaner ihn besetzen können. Nachdem das Gebiet gesäubert wurde, versammelt man sich zu einer Feier und einem Festmahl, bei dem die Ältesten den jüngeren Mitgliedern der Gesellschaft von der wahren Geschichte des Volkes berichten.
+Die Säuberung begann als Protest, der das Leid nachstellte, das den Glanfathanern von den aedyrischen Kolonisten zugefügt wurde, als diese begannen, sich im Dyrwald niederzulassen. Mit den Jahren hat die Säuberung sich gewandelt, so dass sie heute eher einem Spiel gleicht, das auch dazu dient, die Glanfathaner die Geschichte ihres Volkes zu lehren. Die Säuberung findet an Neujahr und Mittjahr statt und ist nur mehr eine Metapher für reale Ereignisse, keine Nachstellung der Ereignisse selbst mehr. Xaurip-Bildnisse werden im Wald aufgestellt, hohle Tonhüllen, die mit Süßigkeiten und Geschenken gefüllt sind. Die Kinder suchen im Wald nach den Bildnissen und zerstören sie - sie "säubern" den Wald, damit die Glanfathaner ihn besetzen können. Nachdem das Gebiet gesäubert wurde, versammelt man sich zu einer Feier und einem Festmahl, bei dem die Ältesten den jüngeren Mitgliedern der Gesellschaft von der wahren Geschichte des Volkes berichten.
 
 Festtag des Schwarzen Baums
 
-Der Festtag des Schwarzen Baums ist zugleich ein Gedenktag und ein Festmahl. Er findet am zweiten Tag des Herbsteinbruchs statt, wenn die Bäume noch bunt sind, ihre Blätter aber bereits verlieren und das Land kalt und dunkel wird. Die Glanfathaner erzählen an diesem Tag die Geschichte vom Krieg der Schwarzen Bäume und gedenken der Gefallenen. An Morgen hängen die Erwachsenen aufwendige Girlanden an den Ästen der Bäume auf. Die Girlanden bestehen aus roten, orangefarbenen und gelben Blumen. Sie stehen für die Flammen, die durch die Wälder von Eir&#160;Glanfath loderten und alles in ihrem Weg zerstörten. Nach einem Morgen des Fastens und der Besinnung dürfen die Kinder durch die Bäume rennen, die Girlanden abreißen und sie zurück zum Festmahl bringen, wo die Tische mit den Wildblumen dekoriert werden, um den Schrecken des Krieges in etwas Schönes zu verwandeln. Dann wird gegessen und es wird der Frieden gefeiert, der nun mit den Dyrwäldlern herrscht - und es wird darauf angestoßen, dass er noch viele Jahre halten möge.
+Der Festtag des Schwarzen Baums ist zugleich ein Gedenktag und ein Festmahl. Er findet am zweiten Tag des Herbsteinbruchs statt, wenn die Bäume noch bunt sind, ihre Blätter aber bereits verlieren und das Land kalt und dunkel wird. Die Glanfathaner erzählen an diesem Tag die Geschichte vom Krieg der Schwarzen Bäume und gedenken der Gefallenen. An Morgen hängen die Erwachsenen aufwendige Girlanden an den Ästen der Bäume auf. Die Girlanden bestehen aus roten, orangefarbenen und gelben Blumen. Sie stehen für die Flammen, die durch die Wälder von Eir&#160;Glanfath loderten und alles in ihrem Weg zerstörten. Nach einem Morgen des Fastens und der Besinnung dürfen die Kinder durch die Bäume rennen, die Girlanden abreißen und sie zurück zum Festmahl bringen, wo die Tische mit den Wildblumen dekoriert werden, um den Schrecken des Krieges in etwas Schönes zu verwandeln. Dann wird gegessen und es wird der Frieden gefeiert, der nun mit den Dyrwäldern herrscht - und es wird darauf angestoßen, dass er noch viele Jahre halten möge.
 
 Bemerkenswert an der glanfathanischen Kultur ist auch die Vielzahl der Reisebräuche. Als halbnomadisches Volk besitzen die Glanfathaner eine Reihe von Traditionen, die ihre Sicherheit während der Reise gewährleisten sollen.
 
@@ -8187,11 +8187,11 @@ Das ist mein Versprechen. Das ist mein Schwur. Das ist mein Eid."</DefaultText>
       <ID>1556</ID>
       <DefaultText>Was lässt sich über das Haus Doemenel sagen, was nicht in einem Hinterzimmer im fahlen Schein eines langsam erlöschenden Feuers geflüstert wird, angsterfüllt, die falschen Ohren könnten es hören? Die Geschichte der Doemenels ist farbenfroh und gewalttätig, aufregend und mehr als nur ein klein wenig blutig.
 
-Die Doemenels waren eine kleine aedyranische Familie, die fast ausschließlich mit Textilien handelte. Sie erhielten dadurch ein bescheidenes Einkommen und erarbeiteten sich langsam den Ruf, hochwertige Ware anzubieten. Dieser Ruf brachte ihnen Verbindungen ein - geschäftliche, gesellschaftliche, manchmal eheliche. Durch diese Verbindungen wurden sie zur wichtigsten Familie der Region. Wollte man jemandem vorgestellt werden, so fragte man die Doemenels.
+Die Doemenels waren eine kleine aedyrische Familie, die fast ausschließlich mit Textilien handelte. Sie erhielten dadurch ein bescheidenes Einkommen und erarbeiteten sich langsam den Ruf, hochwertige Ware anzubieten. Dieser Ruf brachte ihnen Verbindungen ein - geschäftliche, gesellschaftliche, manchmal eheliche. Durch diese Verbindungen wurden sie zur wichtigsten Familie der Region. Wollte man jemandem vorgestellt werden, so fragte man die Doemenels.
 
 Bald gab es in jeder Stadt ein Geschäft, das zumindest teilweise den Doemenels gehörte. Ihre Macht und ihr Einfluss wuchsen, bis viele sagten, die Familie habe mehr Macht als der Fercönyng von Aedyr selbst.
 
-Doch mit der Macht kam das Verbrechen. Man kann keinen solchen Einfluss haben und ihn allein auf rechtmäßigem Wege aufrechterhalten. Bald kamen Gerüchte von Drohungen auf, von Erpressung. Natürlich lässt sich nichts beweisen, doch hinter vorgehaltener Hand wird gemunkelt, dass die Doemenels für den Tod von Trindig Byrnwigr verantwortlich waren, dessen lukratives Transportunternehmen von seiner Frau übernommen wurde - Udele Doemenel Byrnwigr.
+Doch mit der Macht kam das Verbrechen. Man kann keinen solchen Einfluss haben und ihn allein auf rechtmäßigem Wege aufrechterhalten. Bald kamen Gerüchte von Drohungen auf, von Erpressung. Natürlich lässt sich nichts beweisen, doch hinter vorgehaltener Hand wird gemunkelt, dass die Doemenels für den Tod von Trindig Byrnwigar verantwortlich waren, dessen lukratives Transportunternehmen von seiner Frau übernommen wurde - Udele Doemenel Byrnwigar.
 
 Nachdem die Doemenels das Land sicher im Griff hatten, hielten sie sich nicht weiter in den Schatten, sondern gingen fortan offen und dreist vor - sie eliminierten Widersacher, manipulierten Geschäfte und drohten jedem, der zu einem Problem werden könnte. Da sie nun die Handelsroute dominierten, wagte es niemand, sich ihnen zu widersetzen, aus Angst, sein Geschäft würde darunter leiden.
 
@@ -8408,7 +8408,7 @@ Ein plötzlicher Frieden überkam mich, spülte meine Furcht fort, ließ meine a
 
 'Fürchte dich nicht', sprach es zu mir, 'denn du bist auserwählt. Du wirst das Licht sein, welches die Wiedergeburt eines Reichs einleitet.' Das Wesen streckte seine Hand aus und beschenkte mich mit einer Vision von solcher Macht, dass ich sie kaum aufnehmen konnte."
 
-Am nächsten Morgen stolperte Waidwen zerzaust und schmutzig in sein Dorf und berichtete allen, die bereit waren, ihm zuzuhören, von dem Wunder, das sich auf seinen Feldern zugetragen hatte. Eothas selbst sei ihm erschienen! Er habe ihm aufgetragen, den aedyranischen Gouverneur dafür zu bestrafen, dass er sein Volk in das Verderben geführt habe. Es werde ihm ein Weg aufgezeigt werden und die Gläubigen, die ihm halfen, würden gesegnet werden, wenn "die Gottheit sich manifestierte". Die Dorfbewohner ignorierten ihn. Sie glaubten, der Verlust seiner Eltern habe ihn in den Wahnsinn getrieben.
+Am nächsten Morgen stolperte Waidwen zerzaust und schmutzig in sein Dorf und berichtete allen, die bereit waren, ihm zuzuhören, von dem Wunder, das sich auf seinen Feldern zugetragen hatte. Eothas selbst sei ihm erschienen! Er habe ihm aufgetragen, den aedyrischen Gouverneur dafür zu bestrafen, dass er sein Volk in das Verderben geführt habe. Es werde ihm ein Weg aufgezeigt werden und die Gläubigen, die ihm halfen, würden gesegnet werden, wenn "die Gottheit sich manifestierte". Die Dorfbewohner ignorierten ihn. Sie glaubten, der Verlust seiner Eltern habe ihn in den Wahnsinn getrieben.
 
 Doch Waidwen predigte weiter von der Macht von Eothas und der Fäulnis des Gouverneurs, was ihm schließlich den Zorn der Dorfbewohner einbrachte. Der Konflikt eskalierte eines Tages im Mittherbst. Eine Menge hatte sich um Waidwen versammelt. Sie verspotteten ihn und sagten ihm, er solle das Dorf verlassen. Die Vorlas-Ernte war schlecht ausgefallen und die Dorfbewohner gaben Waidwen die Schuld daran. Sie sagten, er habe mit seiner Blasphemie die Götter erzürnt, insbesondere Eothas. Sie trieben ihn in eines der welken Felder und schrien, er solle verschwinden. Es gibt unterschiedliche Berichte darüber, was der Auslöser für das war, was nun geschah. Manche sagen, ein Stein sei geworfen worden. Andere, er sei geschubst worden. Wieder andere, er sei schlicht über eine Wurzel gestolpert. Was auch der Auslöser war, Waidwen landete mit dem Gesicht nach unten auf dem Boden. Die Dorfbewohner standen über ihm und lachten.
 
@@ -8421,11 +8421,11 @@ Die Menge war stumm. Aus den hinteren Reihen ertönte der Ruf "Gelobet sei Eotha
     </Entry>
     <Entry>
       <ID>1564</ID>
-      <DefaultText>Etwa um das Jahr 2200 AI herum vereinigte sich eine Gruppe von Stämmen, genannt das Hirschvolk, zu einer neuen Zivilisation, dem Königreich von Aedyr. Die Stämme waren klein und über das gesamte Land verstreut. Sie wussten, für ihre anhaltende Existenz wäre es besser, sich zusammenzuschließen. Die Anführer jedes Stammes wurden zu Beratern des Königs, der von der Gruppe gewählt wurde. Jeder Berater war weiterhin Fürst seines Volkes, doch jeder Fürst unterstand dem Fercönyng (FER-kö-ning, "erster König"). Diese Entscheidung erwies sich als goldrichtig. Das aedyranische Königreich blühte auf, breitete sich über das Land aus, begründete starke Handelsrouten und war bald als Reich der gerechten - aber klugen - Geschäftsmänner bekannt. Während das Land florierte und es im Inneren kaum Zwietracht gab, gab es aber doch gelegentlich Scharmützel mit dem benachbarten Elfenkönigreich Kulklin.
+      <DefaultText>Etwa um das Jahr 2200 AI herum vereinigte sich eine Gruppe von Stämmen, genannt das Hirschvolk, zu einer neuen Zivilisation, dem Königreich von Aedyr. Die Stämme waren klein und über das gesamte Land verstreut. Sie wussten, für ihre anhaltende Existenz wäre es besser, sich zusammenzuschließen. Die Anführer jedes Stammes wurden zu Beratern des Königs, der von der Gruppe gewählt wurde. Jeder Berater war weiterhin Fürst seines Volkes, doch jeder Fürst unterstand dem Fercönyng (FER-kö-ning, "erster König"). Diese Entscheidung erwies sich als goldrichtig. Das aedyrische Königreich blühte auf, breitete sich über das Land aus, begründete starke Handelsrouten und war bald als Reich der gerechten - aber klugen - Geschäftsmänner bekannt. Während das Land florierte und es im Inneren kaum Zwietracht gab, gab es aber doch gelegentlich Scharmützel mit dem benachbarten Elfenkönigreich Kulkin.
 
-Nicht lang, nachdem das Königreich gegründet worden war, begann das aedyranische Volk mit dem Studium der Beseelung. Diese Wissenschaft war damals noch weitgehend unbekannt. Sie war eine aufregende, aber auch beängstigende neue Welt, in der die aedyranischen Gelehrten großes Potenzial sahen. Dieses Potenzial trug im Jahr 2260 AI Früchte, als eine Gruppe von Beseelern die Seele eines kürzlich verstorbenen Mannes in einen anderen Körper übertrug - und damit die erste der Kreaturen schuf, die man später "Untote" nennen sollte. Die Reaktion auf diese Entdeckung war rasch und entschlossen. Sowohl der König von Aedyr als auch die Kirche von Woedica verurteilten dieses Ereignis und das Studium und die Praxis der Beseelung wurden verboten. Sie wurde auf aedyranischem Boden nie wieder offen praktiziert.
+Nicht lang, nachdem das Königreich gegründet worden war, begann das aedyrische Volk mit dem Studium der Beseelung. Diese Wissenschaft war damals noch weitgehend unbekannt. Sie war eine aufregende, aber auch beängstigende neue Welt, in der die aedyrischen Gelehrten großes Potenzial sahen. Dieses Potenzial trug im Jahr 2260 AI Früchte, als eine Gruppe von Beseelern die Seele eines kürzlich verstorbenen Mannes in einen anderen Körper übertrug - und damit die erste der Kreaturen schuf, die man später "Untote" nennen sollte. Die Reaktion auf diese Entdeckung war rasch und entschlossen. Sowohl der König von Aedyr als auch die Kirche von Woedica verurteilten dieses Ereignis und das Studium und die Praxis der Beseelung wurden verboten. Sie wurde auf aedyrischem Boden nie wieder offen praktiziert.
 
-Die Konflikte mit Kulklin setzten sich fort und gipfelten im Jahr 2398 AI in einem kleinen Krieg. Nach dem Krieg wurde ein Vertrag unterzeichnet und das Königreich Aedyr verschmolz mit Kulklin zum Kaiserreich Aedyr. Da die politische und militärische Zwietracht beendet war, wurde das Reich Aedyr zu einer wirtschaftlichen Macht. Das Reich konnte Ressourcen beschaffen, die in anderen Teilen der Welt schwer zu bekommen waren. Seine Handelsrouten wurden zu den lukrativsten der Welt.</DefaultText>
+Die Konflikte mit Kulkin setzten sich fort und gipfelten im Jahr 2398 AI in einem kleinen Krieg. Nach dem Krieg wurde ein Vertrag unterzeichnet und das Königreich Aedyr verschmolz mit Kulkin zum Kaiserreich Aedyr. Da die politische und militärische Zwietracht beendet war, wurde das Reich Aedyr zu einer wirtschaftlichen Macht. Das Reich konnte Ressourcen beschaffen, die in anderen Teilen der Welt schwer zu bekommen waren. Seine Handelsrouten wurden zu den lukrativsten der Welt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8436,7 +8436,7 @@ Die Schmelztiegelritter besitzen die vielleicht faszinierendste und reichhaltigs
 
 Die Gruppe besteht seit Jahren - lange, bevor sie als "Ritter" bekannt war. Sie begann als ein Zusammenschluss von Schmieden, die unter der Führung von Olrun Cyneheod zusammenkamen, um eine Gilde zu gründen. Olrun hielt es für unabdingbar, dass die Mitglieder sich zusammenschlossen und ihr Wissen innerhalb der Gilde teilten, um die Fähigkeiten und Techniken zu bewahren, die sie ihr ganzes Leben über mühsam perfektioniert hatten. Er gab der Gilde den Namen "Der Schmelztiegel", da er darauf bestand, dass ihr Werk zwar für die Zerstörung genutzt wurde, man sich an sie aber immer als Schöpfer erinnern sollte. Sie sollten bekannt werden als das Instrument, das dem Feuer widersteht, um neue Form in die Welt zu bringen, im Feuer geschmiedet und durch diese Prüfung umso stärker. Olrun, der in vielen Schlachten gekämpft hatte, wusste um die Bedeutung perfekt gefertigter Waffen und Rüstungen. Zudem legte er Wert darauf, dass die Mitglieder der Gilde in der Kampfkunst geschult sind - "Eine gute Rüstung kann man nur anfertigen, wenn man sie selbst tragen muss."
 
-Olrun stand der Gilde viele Jahre lang vor und legte fest, dass jedes neue Mitglied nicht nur ein fähiger Schmied sein musste, sondern auch lernen musste, sich auf dem Schlachtfeld zu behaupten. Er erweiterte das Gebäude der Gilde um einen Übungsplatz, auf dem den ganzen Tag lang Mitglieder zu sehen waren, die an ihren Kampffähigkeiten feilten. So verdiente die Gilde sich den Spitznamen "Schmelztiegelritter". Sie wurden zu einer Miliz für den Dyrwald, einer ehrenwerten Gruppe, an die viele Dyrwäldler sich wandten, wenn sie Hilfe brauchten. Sie galten als gerecht, moralisch und stets hilfsbereit.
+Olrun stand der Gilde viele Jahre lang vor und legte fest, dass jedes neue Mitglied nicht nur ein fähiger Schmied sein musste, sondern auch lernen musste, sich auf dem Schlachtfeld zu behaupten. Er erweiterte das Gebäude der Gilde um einen Übungsplatz, auf dem den ganzen Tag lang Mitglieder zu sehen waren, die an ihren Kampffähigkeiten feilten. So verdiente die Gilde sich den Spitznamen "Schmelztiegelritter". Sie wurden zu einer Miliz für den Dyrwald, einer ehrenwerten Gruppe, an die viele Dyrwälder sich wandten, wenn sie Hilfe brauchten. Sie galten als gerecht, moralisch und stets hilfsbereit.
 
 Die Ritter erwählten Abydon zu ihrem Schutzpatron und widmeten ihr Werk seinem Namen. Ihm zu Ehren nahmen sie sein Zeichen in das ihre auf und trugen es auf ihren Armen. Viele der Ritter gingen noch weiter - gleich, aus welchem Material eine Rüstung bestand, etwas am rechten Arm bestand immer aus Eisen, zu Ehren von Abydons Beinamen "der Eiserne Arm". Beide diese Traditionen befolgen einige Ritter bis zum heutigen Tag.
 
@@ -8453,9 +8453,9 @@ In jüngsten Jahren ist der Aspekt des "Schmelztiegels" etwas in den Hintergrund
       <ID>1566</ID>
       <DefaultText>Anni Iroccio: Neujahr
 
-Der iroccianische Kalender ist zwar erst 150&#160;Jahre alt (und noch dazu vailianischen Ursprungs), wird aber dennoch fast im gesamten Dyrwald und in den umliegenden Gegenden verwendet. Der Dyrwald verwendete bis vor kurzem den aedyranischen Kalender, gab ihn jedoch zugunsten des iroccianischen Kalenders auf. Der Wechsel verlief reibungslos und es gab kaum Widerstände, da der aedyranische Kalender hoffnungslos ungenau war.
+Der iroccianische Kalender ist zwar erst 150&#160;Jahre alt (und noch dazu vailianischen Ursprungs), wird aber dennoch fast im gesamten Dyrwald und in den umliegenden Gegenden verwendet. Der Dyrwald verwendete bis vor kurzem den aedyrischen Kalender, gab ihn jedoch zugunsten des iroccianischen Kalenders auf. Der Wechsel verlief reibungslos und es gab kaum Widerstände, da der aedyrische Kalender hoffnungslos ungenau war.
 
-Iroccio berechnete, dass der Planet etwa 334 Tage benötigt, um die Sonne zu umkreisen. Er nahm daher die neun Monate des aedyranischen Kalenders und teilte sie in sechzehn Monate von je zwanzig Tagen auf. Jede Jahreszeit besteht aus vier Monaten. Die Länge der Monate spiegelt wider, wie lange Belafa (einer unserer Monde) benötigt, um den Planeten zu umkreisen. Auf jede Jahreszeit folgen drei Tage, die keiner Jahreszeit zugehörig sind, und in denen der Übergang gefeiert wird. Die übrigen zwei Tage des Jahres - Neujahr und Mittjahr - dienen dazu, den Anfang und den Mittelpunkt des Jahres zu feiern.
+Iroccio berechnete, dass der Planet etwa 334 Tage benötigt, um die Sonne zu umkreisen. Er nahm daher die neun Monate des aedyrischen Kalenders und teilte sie in sechzehn Monate von je zwanzig Tagen auf. Jede Jahreszeit besteht aus vier Monaten. Die Länge der Monate spiegelt wider, wie lange Belafa (einer unserer Monde) benötigt, um den Planeten zu umkreisen. Auf jede Jahreszeit folgen drei Tage, die keiner Jahreszeit zugehörig sind, und in denen der Übergang gefeiert wird. Die übrigen zwei Tage des Jahres - Neujahr und Mittjahr - dienen dazu, den Anfang und den Mittelpunkt des Jahres zu feiern.
 
 Um beim Übergang vom alten auf den neuen Kalender Verwirrung zu vermeiden, behielt Iroccio das Jahr bei. Obwohl der Kalender also erst seit 150&#160;Jahren besteht, schreiben wir bereits das Jahr 2823 AI (Anni Iroccio).
 
@@ -8470,7 +8470,7 @@ Wintermonate (zwei zu Beginn des Jahres, zwei am Ende des Jahres)
 Vollwinter - Fonivèrno
 Spätwinter - Tarivèrno
 
-Frühlingserwachen (3 Tage) - Inprima - Dient zum Feiern des Übergangs der Welt, der Wiedergeburt und des Frühlings. Zu dieser Zeit werden besonders viele eothasianische Feste gefeiert - oder wurden es, vor dem Krieg des Heiligen. 
+Frühlingserwachen (3 Tage) - Inprima - Dient zum Feiern des Übergangs der Welt, der Wiedergeburt und des Frühlings. Zu dieser Zeit werden besonders viele eothasische Feste gefeiert - oder wurden es, vor dem Krieg des Heiligen. 
  
 Frühlingsmonate
 
@@ -8504,7 +8504,7 @@ Winterdämmerung (3 Tage) - Inivèrno - Während der Winterdämmerung wird das L
 
 Wintermonate
 
-Vorwinter - Préivèrno
+Vorwinter - Préïvèrno
 Mittwinter - Majivèrno</DefaultText>
       <FemaleText />
     </Entry>
@@ -8512,7 +8512,7 @@ Mittwinter - Majivèrno</DefaultText>
       <ID>1567</ID>
       <DefaultText>Vor kaum mehr als einem Jahrzehnt kämpften auf der Brücke von Evon Dewr sieben Männer und fünf Frauen tapfer, um ihr Heimatland zu beschützen. Sie hatten sich freiwillig für die Mission gemeldet. Sie wussten, es lag an ihnen - und nur an ihnen - St. Waidwen daran zu hindern, die Brücke zu überqueren. Sie hatten Erfolg - auch, wenn nur vier von ihnen die Schlacht überlebten - und Waidwen befand sich auf der Brücke, als der Götterhammer detonierte. Die letzten vier wurden durch die Explosion getötet, ihr Opfer ein Beleg für ihre Hingabe.
 
-Die Dutzenden, eine Gruppe, die angeblich zum Schutz des Dyrwalds gebildet wurde, wurde zu Ehren dieser Männer und Frauen gegründet. Ja, die Dutzenden erkoren diese zwölf posthum sogar zu ihren wahren "Gründern". Ursprünglich machte die Gruppe es sich zur Aufgabe, den Dyrwald vor einer Invasion zu schützen, indem sie unermüdlich die Grenzen patrouillierte, auf der Suche nach readceranischen Truppen, die sich für einen neuen Angriff sammelten. Als dieser Angriff nie erfolgte, glaubten viele der Dutzenden, die nächste Gefahr könnte von eothasianischen Loyalisten ausgehen, die im Dyrwald wohnten. Sie richteten ihre Aufmerksamkeit folglich nach innen.
+Die Dutzenden, eine Gruppe, die angeblich zum Schutz des Dyrwalds gebildet wurde, wurde zu Ehren dieser Männer und Frauen gegründet. Ja, die Dutzenden erkoren diese zwölf posthum sogar zu ihren wahren "Gründern". Ursprünglich machte die Gruppe es sich zur Aufgabe, den Dyrwald vor einer Invasion zu schützen, indem sie unermüdlich die Grenzen patrouillierte, auf der Suche nach readceranischen Truppen, die sich für einen neuen Angriff sammelten. Als dieser Angriff nie erfolgte, glaubten viele der Dutzenden, die nächste Gefahr könnte von eothasischen Loyalisten ausgehen, die im Dyrwald wohnten. Sie richteten ihre Aufmerksamkeit folglich nach innen.
 
 Alle neuen Mitglieder der Dutzenden müssen schwören, des Opfers ihrer Gründer zu gedenken und wachsam gegen Readceras und alle Anhänger Eothas' zu bleiben. Aus diesem Grund werden die Anhänger Eothas' von den Dutzenden regelmäßig drangsaliert.
 
@@ -8525,9 +8525,9 @@ Die Dutzenden sind keine große Gruppe, doch das machen sie mit ihrer unbedingte
       <ID>1568</ID>
       <DefaultText>Kein anderes Land hat eine solch wilde und blutige jüngere Geschichte. Von der Kolonie zum Palatinat zur freien Republik - der Dyrwald ist aus einer Feuertaufe als eine mächtige Kraft im Östlichen Abschnitt hervorgegangen.
 
-Die Geschichte des Dyrwalds beginnt im Jahr 2602 AI in Aedyr. Aedyranische Entdecker kehrten von einer Reise über den Ozean zurück und berichteten von den Schätzen, die sie dort gefunden hatten. Sie hatten in den Wäldern und auf den Ebenen nördlich der Bäume, die ideal als Vorlas-Ackerland geeignet wären, unzählige Ruinen entdeckt. Es gab jedoch ein Problem - die Einheimischen waren feindselig, es würde wohl Konflikte geben. Der Fercönyng von Aedyr (FER-kö-ning, "erster König") wusste, dass diese Gelegenheit genutzt werden musste. Er sandte weitere Entdecker aus, um das Gebiet zu erkunden und zu kartographieren.
+Die Geschichte des Dyrwalds beginnt im Jahr 2602 AI in Aedyr. Aedyrische Entdecker kehrten von einer Reise über den Ozean zurück und berichteten von den Schätzen, die sie dort gefunden hatten. Sie hatten in den Wäldern und auf den Ebenen nördlich der Bäume, die ideal als Vorlas-Ackerland geeignet wären, unzählige Ruinen entdeckt. Es gab jedoch ein Problem - die Einheimischen waren feindselig, es würde wohl Konflikte geben. Der Fercönyng von Aedyr (FER-kö-ning, "erster König") wusste, dass diese Gelegenheit genutzt werden musste. Er sandte weitere Entdecker aus, um das Gebiet zu erkunden und zu kartographieren.
 
-Die Erkundung dauerte zwanzig Jahre. Kleine Gruppen von Entdeckern reisten zwischen Aedyr und dieser neuen Welt hin und her. Eine Handvoll Kolonisten errichtete kleine Lager, um eine Basis für die Expeditionen zu schaffen. Konflikte mit den Einheimischen - den Glanfathanern, wie die Aedyraner inzwischen erfahren hatten - waren rar, aber dennoch häufig genug, dass der Fercönyng einen kleinen Wachtrupp schickte, um seine Bürger zu beschützen. Diese Wachen errichteten eine zentrale Basis an einem Fluss im westlichen Teil des Waldes. Aus dieser Siedlung entstand schließlich die Stadt Dyrfurt (auf deren Ruinen die heutige Stadt desselben Namens errichtet wurde). Nachdem diese Basis errichtet war, entstanden die ersten dauerhaften aedyranischen Siedlungen nördlich und westlich des Flusses Bael. In den nächsten drei Jahren übersiedelten tausende von Aedyranern in dieses neue Land. Die Glanfathaner, welche die im Wald verteilten Ruinen zu verehren schienen, machten den Siedlungen einige Probleme - insbesondere jenen, die in der Nähe der Ruinen gegründet wurden. Die Kolonisten konnten diese Probleme mit Hilfe der kaiserlichen Wache jedoch mühelos beseitigen. Um ihren Einfluss in dem Gebiet zu festigen und die glanfathanische Bevölkerung unter Kontrolle zu halten, begannen die Aedyraner, alle Glanfathaner zu versklaven, die während der Aufstände gefangen genommen wurden. Das führte zu einem deutlichen Anstieg der Spannungen zwischen den beiden Gruppen.
+Die Erkundung dauerte zwanzig Jahre. Kleine Gruppen von Entdeckern reisten zwischen Aedyr und dieser neuen Welt hin und her. Eine Handvoll Kolonisten errichtete kleine Lager, um eine Basis für die Expeditionen zu schaffen. Konflikte mit den Einheimischen - den Glanfathanern, wie die Aedyrer inzwischen erfahren hatten - waren rar, aber dennoch häufig genug, dass der Fercönyng einen kleinen Wachtrupp schickte, um seine Bürger zu beschützen. Diese Wachen errichteten eine zentrale Basis an einem Fluss im westlichen Teil des Waldes. Aus dieser Siedlung entstand schließlich die Stadt Dyrfurt (auf deren Ruinen die heutige Stadt desselben Namens errichtet wurde). Nachdem diese Basis errichtet war, entstanden die ersten dauerhaften aedyrischen Siedlungen nördlich und westlich des Flusses Bael. In den nächsten drei Jahren übersiedelten tausende von Aedyrern in dieses neue Land. Die Glanfathaner, welche die im Wald verteilten Ruinen zu verehren schienen, machten den Siedlungen einige Probleme - insbesondere jenen, die in der Nähe der Ruinen gegründet wurden. Die Kolonisten konnten diese Probleme mit Hilfe der kaiserlichen Wache jedoch mühelos beseitigen. Um ihren Einfluss in dem Gebiet zu festigen und die glanfathanische Bevölkerung unter Kontrolle zu halten, begannen die Aedyrer, alle Glanfathaner zu versklaven, die während der Aufstände gefangen genommen wurden. Das führte zu einem deutlichen Anstieg der Spannungen zwischen den beiden Gruppen.
 
 Als die Bevölkerung in der Gegend immer größer wird, etabliert der Fercönyng eine offizielle Regierungsstruktur. Er ernennt mehrere Grafen, die über das Land herrschen sollen, unterstützt von Thayns. Sie nennen das neue Gréfram den Dyrwald. Dyrfurt bleibt zwar das Zentrum der kaiserlichen Wache, doch die Siedlung im Perlholzgolf, Neu-Dunryd, ist der wahre Machtsitz der Gegend. Das Land liegt am Rand des Ozeans, besitzt Wälder, fruchtbaren Ackerboden und einen Fluss, der von der Küste bis in die Weißmark verläuft. Die Siedler kamen in Scharen, in der Hoffnung, sich einen Namen zu machen. Aedyr begann, sich in dem neuen Land auszubreiten.</DefaultText>
       <FemaleText />
@@ -8592,7 +8592,7 @@ Belafa hängt groß und tief am Himmel. Er legt seine Reise um die Welt raschen 
 
 Cawldha
 
-Vor 315&#160;Jahren wurde das Großreich von Vailia von schrecklichen Stürmen und beängstigenden Gezeiten heimgesucht. Die Aufzeichnungen zeigen, dass im Reich Aedyr dasselbe geschah, und dass mehrere neue aedyranische Kolonien entlang der Küste des Dyrwalds von Stürmen und Fluten völlig zerstört wurden. Zu jener Zeit beobachteten glanfathanische Astronomen während einer Finsternis etwas kleines, das neben Belafa kreiste.
+Vor 315&#160;Jahren wurde das Großreich von Vailia von schrecklichen Stürmen und beängstigenden Gezeiten heimgesucht. Die Aufzeichnungen zeigen, dass im Reich Aedyr dasselbe geschah, und dass mehrere neue aedyrische Kolonien entlang der Küste des Dyrwalds von Stürmen und Fluten völlig zerstört wurden. Zu jener Zeit beobachteten glanfathanische Astronomen während einer Finsternis etwas kleines, das neben Belafa kreiste.
 
 Nach ausgiebiger Erkundung erkannten sie, dass es ein kleiner Satellit mit einer äußerst unregelmäßigen Umlaufbahn war. Sie nannten ihn Cawldha Debh - den schwarzen Läufer. Da er kleiner ist als Belafa, wirkt er sich kaum auf die Welt aus, doch wenn seine Umlaufbahn mit der von Belafa zusammenfällt, lässt er die Gezeiten und das Wetter verrückt spielen - überall. Das geschieht mit einer launischen Häufigkeit und Schwere, so dass dieses Ereignis als "Liebespaargezeiten" bezeichnet wird. Cawldha wurde in den Ondra-Mythos integriert. Wenn beide Monde zu sehen sind, steigert sich Ondras Verlangen, sie zu erreichen, in das Zehnfache, wodurch die Wetterkatastrophen entstehen.</DefaultText>
       <FemaleText />
@@ -8609,7 +8609,7 @@ Unterstützt von einer Gruppe von Rittern und Adligen, die sich seiner Sache ang
 
 Der Gouverneur, in dem Wissen, dass er niemals einen Avatar von Eothas besiegen könnte, gab seine Macht ab. Das Volk bat Waidwen, die Kolonie zu führen. Er nahm an, wodurch er den Beinamen "Göttlicher König" von Readceras verdiente.
 
-Waidwens Herrschaft war nahezu unangefochten. Zunächst lag das daran, dass jeder ehrfürchtig kauerte, weil ein Gott entschieden hatte, sich zu manifestieren und sein Volk zu führen. Das änderte sich jedoch, als Waidwen begann, die Verbündeten des alten Reichs und des "Gifts der Welt" zu bestrafen - was er als korrupte Kirchen oder Kirchenoberste von Eothas ansah. Das Misstrauen stieg und bald wurden Anhänger Eothas' bestraft, sobald auch nur die leiseste Vermutung auftrat, sie könnten Ketzer sein. Auch Anhänger anderer Religionen wurden verfolgt, schlicht, weil sie einem anderen Glauben anhingen. Das führte dazu, dass große Teile der Bevölkerung aus Readceras flohen und im Dyrwald um Zuflucht baten. Das wiederum führte zu Zwietracht zwischen den beiden Nationen. Die Dyrwäldler wussten, dass sie nicht unbegrenzt Flüchtlinge aufnehmen konnten, sollte Waidwen weiter widerstandslos walten können. Außerdem fürchteten sie, dass er seinen Blick von Readceras abwenden und auf sie richten könnte, wenn sie nichts unternahmen. Genau das geschah schließlich auch, und es brach ein offener Krieg aus, als Waidwen versuchte, sein Reich auf die Lande des Dyrwalds auszudehnen.</DefaultText>
+Waidwens Herrschaft war nahezu unangefochten. Zunächst lag das daran, dass jeder ehrfürchtig kauerte, weil ein Gott entschieden hatte, sich zu manifestieren und sein Volk zu führen. Das änderte sich jedoch, als Waidwen begann, die Verbündeten des alten Reichs und des "Gifts der Welt" zu bestrafen - was er als korrupte Kirchen oder Kirchenoberste von Eothas ansah. Das Misstrauen stieg und bald wurden Anhänger Eothas' bestraft, sobald auch nur die leiseste Vermutung auftrat, sie könnten Ketzer sein. Auch Anhänger anderer Religionen wurden verfolgt, schlicht, weil sie einem anderen Glauben anhingen. Das führte dazu, dass große Teile der Bevölkerung aus Readceras flohen und im Dyrwald um Zuflucht baten. Das wiederum führte zu Zwietracht zwischen den beiden Nationen. Die Dyrwälder wussten, dass sie nicht unbegrenzt Flüchtlinge aufnehmen konnten, sollte Waidwen weiter widerstandslos walten können. Außerdem fürchteten sie, dass er seinen Blick von Readceras abwenden und auf sie richten könnte, wenn sie nichts unternahmen. Genau das geschah schließlich auch, und es brach ein offener Krieg aus, als Waidwen versuchte, sein Reich auf die Lande des Dyrwalds auszudehnen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8839,7 +8839,7 @@ Vergesst nicht eure Königin.</DefaultText>
       <ID>1579</ID>
       <DefaultText>Im Jahr 2626 AI warf eine Gruppe von Bauern, die Ackerland schaffen wollte, versehentlich einen der uralten Adra-Hinkelsteine auf ihrem Land um. Dieses unschuldige Versehen weckte den Zorn der Ureinwohner und führte zum Ausbruch des Kriegs des Zerbrochenen Steins. Im Verlauf des Kriegs starben mehrere tausend Kolonisten und einige hundert Glanfathaner. Nachdem der Krieg offiziell beendet war, setzten die Glanfathaner noch zwei Jahre lang ihre Angriffe auf die Siedler mit unverminderter oder gar noch gesteigerter Aggressivität fort. Ihren brutalen Taktiken fielen unzählige Kolonisten, mehrere hochrangige Militärs, ein Graf und sechs Thayns zum Opfer.
 
-Die Grafen wählten Graf Edrang Hadret zum Gréf, um den glanfathanischen Angriffen ein Ende zu bereiten. Edrang war angesehen und galt als Meister der militärischen Taktik. Er erhielt den Auftrag, die glanfathanische Bedrohung zu beseitigen. Zwei Jahre lang bekämpfte Edrang die Glanfathaner, die von einem Orlaner namens Regd angeführt wurden. Keine der beiden Seiten konnte einen entscheidenden Vorteil gegenüber der anderen erlangen. Es kam zu einer angespannten Pattsituation. Dieses Patt führte dazu, dass die Feindseligkeiten sich im Sande verliefen. Im Jahr 2631 unterzeichneten die Dyrwäldler einen Vertrag mit den Glanfathanern. Regd legte sein Amt nieder, die Glanfathaner stellten ihre Angriffe ein und die Dyrwäldler betraten die Ruinen nicht mehr. Der Vertrag erzürnte den Adel von Aedyr, da er den Nachschub an Artefakten versiegen ließ. Edrang versuchte auch, die Sklaverei verbieten zu lassen, was ihm jedoch nicht gelang. Der Frieden zwischen dem Dyrwald und Eir&#160;Glanfath war daher instabil und wackelig. Es kam immer wieder zu kleinen gewalttätigen Auseinandersetzungen auf dem Lande. Diese waren aber nie von langer Dauer, da keine Seite einen weiteren Krieg wollte.</DefaultText>
+Die Grafen wählten Graf Edrang Hadret zum Gréf, um den glanfathanischen Angriffen ein Ende zu bereiten. Edrang war angesehen und galt als Meister der militärischen Taktik. Er erhielt den Auftrag, die glanfathanische Bedrohung zu beseitigen. Zwei Jahre lang bekämpfte Edrang die Glanfathaner, die von einem Orlaner namens Regd angeführt wurden. Keine der beiden Seiten konnte einen entscheidenden Vorteil gegenüber der anderen erlangen. Es kam zu einer angespannten Pattsituation. Dieses Patt führte dazu, dass die Feindseligkeiten sich im Sande verliefen. Im Jahr 2631 unterzeichneten die Dyrwälder einen Vertrag mit den Glanfathanern. Regd legte sein Amt nieder, die Glanfathaner stellten ihre Angriffe ein und die Dyrwälder betraten die Ruinen nicht mehr. Der Vertrag erzürnte den Adel von Aedyr, da er den Nachschub an Artefakten versiegen ließ. Edrang versuchte auch, die Sklaverei verbieten zu lassen, was ihm jedoch nicht gelang. Der Frieden zwischen dem Dyrwald und Eir&#160;Glanfath war daher instabil und wackelig. Es kam immer wieder zu kleinen gewalttätigen Auseinandersetzungen auf dem Lande. Diese waren aber nie von langer Dauer, da keine Seite einen weiteren Krieg wollte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8849,13 +8849,13 @@ Die Grafen wählten Graf Edrang Hadret zum Gréf, um den glanfathanischen Angrif
     </Entry>
     <Entry>
       <ID>1581</ID>
-      <DefaultText>Nach dem Krieg des Zerbrochenen Steins herrschte 21&#160;Jahre lang Friede und Wohlstand. Abgesehen von gelegentlichen Sklavenaufständen oder Grenzstreitigkeiten geschah bis zum Jahr 2652 AI nichts Bemerkenswertes. Einige der Grafen des Dyrwalds waren es leid, von den Verträgen eingeschränkt zu sein. Ermutigt durch kaiserliche Quellen widersetzten sie sich den Dekreten und sandten Truppen aus, um die Ruinen im Dyrwald zu plündern. Die Reaktion der Glanfathaner kam nicht sofort, doch als sie schließlich kam, war sie brutal und blutig. Es kam zu einem Sklavenaufstand und Regd übernahm wieder das Kommando über seine Guerillakämpfer. Auch ein Kontingent von Delemgan schloss sich den Truppen an, so dass die Kämpfe in den Wäldern für die Soldaten des Drywalds noch tödlicher wurden.
+      <DefaultText>Nach dem Krieg des Zerbrochenen Steins herrschte 21&#160;Jahre lang Friede und Wohlstand. Abgesehen von gelegentlichen Sklavenaufständen oder Grenzstreitigkeiten geschah bis zum Jahr 2652 AI nichts Bemerkenswertes. Einige der Grafen des Dyrwalds waren es leid, von den Verträgen eingeschränkt zu sein. Ermutigt durch kaiserliche Quellen widersetzten sie sich den Dekreten und sandten Truppen aus, um die Ruinen im Dyrwald zu plündern. Die Reaktion der Glanfathaner kam nicht sofort, doch als sie schließlich kam, war sie brutal und blutig. Es kam zu einem Sklavenaufstand und Regd übernahm wieder das Kommando über seine Guerillakämpfer. Auch ein Kontingent von Delemgan schloss sich den Truppen an, so dass die Kämpfe in den Wäldern für die Soldaten des Dyrwalds noch tödlicher wurden.
 
-Edrang war zu dieser Zeit schon viel zu alt, um den Dyrwald in den Krieg zu führen. Er schickte seinen Sohn Admeth an seiner Statt. Admeth besaß das taktische Geschick seines Vaters. Er setzte den Wald am Fluss Isce Uar in Brand und versperrte den fliehenden Truppen den Weg. Einige der Glanfathaner konnten entkommen, doch Tausende starben in dem Inferno. Regd wurde gefangen genommen und nach Neu-Heomar gebracht. Mehrere Monate lang setzte Admeth immer wieder diese Taktik ein, um die Glanfthaner und Delemgan vom Schlachtfeld zu treiben. Der gesamte Krieg dauerte weniger als ein Jahr. Am Ende obsiegte der Dyrwald, allerdings zu einem grauenhaften Preis. Dieser Konflikt ging als der Krieg der Schwarzen Bäume in die Geschichte ein.
+Edrang war zu dieser Zeit schon viel zu alt, um den Dyrwald in den Krieg zu führen. Er schickte seinen Sohn Admeth an seiner Statt. Admeth besaß das taktische Geschick seines Vaters. Er setzte den Wald am Fluss Isce Uar in Brand und versperrte den fliehenden Truppen den Weg. Einige der Glanfathaner konnten entkommen, doch Tausende starben in dem Inferno. Regd wurde gefangen genommen und nach Neu-Heomar gebracht. Mehrere Monate lang setzte Admeth immer wieder diese Taktik ein, um die Glanfathaner und Delemgan vom Schlachtfeld zu treiben. Der gesamte Krieg dauerte weniger als ein Jahr. Am Ende obsiegte der Dyrwald, allerdings zu einem grauenhaften Preis. Dieser Konflikt ging als der Krieg der Schwarzen Bäume in die Geschichte ein.
 
 Im Jahr 2654 erlebte der Dyrwald eine Tragödie - Edrang, dessen Gesundheit immer weiter nachgelassen hatte, verlor die Kraft und kehrte in den Kreislauf zurück. Regd, der im Laufe der Jahre einen widerwilligen Respekt für seinen Widersacher entwickelt hatte, ließ Admeth aus der Gefangenschaft in Neu-Heomar sein ehrliches Beileid aussprechen. Admeth folgte auf den Thron seines Vaters und wurde Gréf des Dyrwalds. Den anderen Grafen missfiel diese Entwicklung. Sie begannen, sich Admeths Dekreten öffentlich zu widersetzen. Im Jahr 2662 AI hatte Admeth genug von den widerspenstigen Grafen. Er konnte auf die Unterstützung der neuen vailianischen Ducs und des einfachen Volks im Dyrwald zählen (schließlich hatte er es vor den Glanfathanern gerettet) und stellte dem Fercönyng von Aedyr ein Ultimatum. Er forderte, dass er zum Gréf-Palatin gemacht werden solle. Damit besäße er die Autorität und Macht über alle Grafen, ihre Besitztümer und ihre Titel. Der Dyrwald würde kein Gréfram mehr sein, sondern ein Palatinat. Der Fercönyng, der sich nicht mit einer Rebellion herumschlagen wollte, während er versuchte, die Kontrolle über den Vorlas-Handel in Readceras zu gewinnen, willigte zähneknirschend in Admeths Forderungen ein. Admeth nutzte seine neue Macht, um die Grafen spuren zu lassen. Im Tausch gegen seine Macht investierte Admeth Zeit und Geld in alle Häfen des Dyrwalds, um den Handelsverkehr zu steigern. Das wiederum erhöhte das Einkommen des Fercönyngs.
 
-Unter Admeths Herrschaft erlebte der Dyrwald sieben produktive und profitable Jahre. Im Jahr 2662 AI gelang ihm, was schon seit vielen Jahren erfolglos versucht worden war - er beendete die Sklaverei im Dyrwald. Er handelte die Zehnjahresverträge aus, deren Name sich dadurch erklärt, dass sie zehn Jahre nach dem Ende des Kriegs der Schwarzem Bäume entstanden. Es wurde ein Zeitplan für die Freilassung der Sklaven vereinbart. Die Eigentümer sollten für jeden freigelassenen Sklaven mit Geld oder Land entschädigt werden. Weigerten sie sich, ihre Sklaven freizulassen, so sollten sie ihnen weggenommen werden und die Eigentümer mit einer Geldstrafe belegt. Im Gegenzug sollten die Glanfathaner den Handel mit dem Dyrwald eröffnen und einige ihrer Gebiete an die Regierung des Dyrwalds abtreten (was in der Praxis bedeutete, dass sie akzeptieren würden, dass die Dyrwäldler dort schon lebten und herrschten). Hunderte von Sklavenbesitzern versuchten zu rebellieren. Admeth hatte diese Reaktion erwartet. Der Aufstand wurde schnell niedergeschlagen. Anschließend ließ Admeth im Volk Propaganda verbreiten, was sowohl die Küferaufstände als auch ihre Anstifter in viel schlechterem Licht darstellte als sie wirklich waren. Diese Taktik ging auf und es gab keine Unruhen mehr.</DefaultText>
+Unter Admeths Herrschaft erlebte der Dyrwald sieben produktive und profitable Jahre. Im Jahr 2662 AI gelang ihm, was schon seit vielen Jahren erfolglos versucht worden war - er beendete die Sklaverei im Dyrwald. Er handelte die Zehnjahresverträge aus, deren Name sich dadurch erklärt, dass sie zehn Jahre nach dem Ende des Kriegs der Schwarzem Bäume entstanden. Es wurde ein Zeitplan für die Freilassung der Sklaven vereinbart. Die Eigentümer sollten für jeden freigelassenen Sklaven mit Geld oder Land entschädigt werden. Weigerten sie sich, ihre Sklaven freizulassen, so sollten sie ihnen weggenommen werden und die Eigentümer mit einer Geldstrafe belegt. Im Gegenzug sollten die Glanfathaner den Handel mit dem Dyrwald eröffnen und einige ihrer Gebiete an die Regierung des Dyrwalds abtreten (was in der Praxis bedeutete, dass sie akzeptieren würden, dass die Dyrwälder dort schon lebten und herrschten). Hunderte von Sklavenbesitzern versuchten zu rebellieren. Admeth hatte diese Reaktion erwartet. Der Aufstand wurde schnell niedergeschlagen. Anschließend ließ Admeth im Volk Propaganda verbreiten, was sowohl die Küferaufstände als auch ihre Anstifter in viel schlechterem Licht darstellte als sie wirklich waren. Diese Taktik ging auf und es gab keine Unruhen mehr.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8870,7 +8870,7 @@ Unter Admeths Herrschaft erlebte der Dyrwald sieben produktive und profitable Ja
     </Entry>
     <Entry>
       <ID>1584</ID>
-      <DefaultText>Die Beseelung, die unter aedryanischer Herrschaft verboten worden war, war nach Hadrets Rebellion rechtlich gesehen kein Tabu mehr. Akademiker begannen im Jahr 2681 AI damit, sie intensiv zu studieren. Bis zum Jahr 2697 AI gab es fast 40 Akademiker, die aktiv in dieser Disziplin forschten, sowohl im Dyrwald als auch in den Vailianischen Republiken - obwohl es bis dahin noch keinerlei nennenswerte Ergebnisse gegeben hatte. Im Jahr 2704 AI kam es zu einem tragischen Durchbruch, wenn man das so sagen kann. Ein Beseeler in Baelreach zertrümmerte versehentlich die Seelen von etwa einem Dutzend Freiwilligen, die ihm geholfen hatten. Als Vergeltung für ihren Tod stürmten die Bewohner der Gegend das Haus des Beseelers und töteten ihn. Der Graf der Region wollte keine Ressourcen verschwenden und das Volk nicht noch weiter erzürnen. Er ließ nicht nach dem Anführer der Selbstjustiz übenden Menge suchen - ließ aber auch die Beseelung nicht verbieten. Um ihre Sicherheit zu gewährleisten, zogen die meisten Beseeler aus den ländlichen Gebieten, in denen sie ihre Forschungen unternahmen, nach Trutzbucht. Viele von ihnen wählten den aufstrebenden und wohlhabenden Distrikt Farnheim als ihre neue Heimat. 
+      <DefaultText>Die Beseelung, die unter aedyrischer Herrschaft verboten worden war, war nach Hadrets Rebellion rechtlich gesehen kein Tabu mehr. Akademiker begannen im Jahr 2681 AI damit, sie intensiv zu studieren. Bis zum Jahr 2697 AI gab es fast 40 Akademiker, die aktiv in dieser Disziplin forschten, sowohl im Dyrwald als auch in den Vailianischen Republiken - obwohl es bis dahin noch keinerlei nennenswerte Ergebnisse gegeben hatte. Im Jahr 2704 AI kam es zu einem tragischen Durchbruch, wenn man das so sagen kann. Ein Beseeler in Baelreach zertrümmerte versehentlich die Seelen von etwa einem Dutzend Freiwilligen, die ihm geholfen hatten. Als Vergeltung für ihren Tod stürmten die Bewohner der Gegend das Haus des Beseelers und töteten ihn. Der Graf der Region wollte keine Ressourcen verschwenden und das Volk nicht noch weiter erzürnen. Er ließ nicht nach dem Anführer der Selbstjustiz übenden Menge suchen - ließ aber auch die Beseelung nicht verbieten. Um ihre Sicherheit zu gewährleisten, zogen die meisten Beseeler aus den ländlichen Gebieten, in denen sie ihre Forschungen unternahmen, nach Trutzbucht. Viele von ihnen wählten den aufstrebenden und wohlhabenden Distrikt Farnheim als ihre neue Heimat. 
 
 In den nächsten 24&#160;Jahren wurde die Beseelung zwar weiter erforscht und es gab auch einige kleinere Durchbrüche, doch je mehr die Forscher lernten, desto teurer und komplizierter wurde ihre Arbeit. Die meisten Beseeler konnten ihre Forschungen nicht ohne Spenden von reichen Personen und Organisationen finanzieren. Im Jahr 2737 AI drangen einige Beseeler in die verbotenen Ruinen von Eir&#160;Glanfath an. Sie waren verzweifelt und sahen keinen anderen Weg, in ihrer Arbeit Fortschritte zu machen. Sie entdeckten, dass es in einigen Stätten seltsame Artefakte gab, die im Zusammenhang mit der Seelenessenz zu stehen schienen. Sie begannen, Experimente mit diesen Artefakten anzustellen. Trotz ihrer anhaltenden Bemühungen konnten sie nicht genau in Erfahrung, was sie da eigentlich entdeckt hatten. Schließlich wurden sie von den Glanfathanern entdeckt, die einige von ihnen gefangen nahmen und forderten, dass man sie für ihre Verbrechen bestrafe. Die Behörden des Dyrwalds hatten keine andere Wahl, wenn sie die Verträge einhalten und den Frieden wahren wollten - sie ließen zu, dass die Beseeler nach alter glanfathanischer Tradition hingerichtet wurden. Das veranlasste den Duc dazu, ein weiteres Dekret zu erlassen - die Erforschung und Ausübung der Beseelung an heiligen glanfathanischen Stätten - oder nur in ihrer Nähe - sollte fortan mit dem Tod bestraft werden.
 
@@ -8884,9 +8884,9 @@ Um das Verhältnis mit den Glanfathanern wieder zu stärken, gestattete die Regi
     </Entry>
     <Entry>
       <ID>1586</ID>
-      <DefaultText>Im Jahr 2807 AI kehrte der Krieg in den Dyrwald zurück. St. Waidwen, der plötzlich in eine lebende Inkarnation von Eothas verwandelt worden war, marschierte von Readceras aus auf den Dyrwald zu - es begann der Krieg des Heiligen. Der Dyrwald versammelte sich bei der Zitadelle von Halgot und trug den Kampf zu Waidwen nach Readceras, um zu verhindern, dass das eigene Land Schaden nahm. Obwohl die Truppen des Dyrwalds verheerende Verluste erlitten, konnten sie dank Hadrets militärischer Techniken in Kombination mit Galven Regds Strategien auch einige Siege erringen. Readceranische Truppen gelangten über die Weißmark in den Dyrwald - wobei sie von den Bewohnern von Kaltmorg unbehelligt blieben - und ließen das Gnadental verbrannt und zerstört zurück. Selbst lange nach Ende des Krieges verabscheuen die Dyrwäldler Kaltmorg noch wegen dieses Verrats.
+      <DefaultText>Im Jahr 2807 AI kehrte der Krieg in den Dyrwald zurück. St. Waidwen, der plötzlich in eine lebende Inkarnation von Eothas verwandelt worden war, marschierte von Readceras aus auf den Dyrwald zu - es begann der Krieg des Heiligen. Der Dyrwald versammelte sich bei der Zitadelle von Halgot und trug den Kampf zu Waidwen nach Readceras, um zu verhindern, dass das eigene Land Schaden nahm. Obwohl die Truppen des Dyrwalds verheerende Verluste erlitten, konnten sie dank Hadrets militärischer Techniken in Kombination mit Galven Regds Strategien auch einige Siege erringen. Readceranische Truppen gelangten über die Weißmark in den Dyrwald - wobei sie von den Bewohnern von Kaltmorg unbehelligt blieben - und ließen das Gnadental verbrannt und zerstört zurück. Selbst lange nach Ende des Krieges verabscheuen die Dyrwälder Kaltmorg noch wegen dieses Verrats.
 
-Um den Krieg zu beenden und St. Waidwen auszuschalten, wussten die magranischen Kleriker des Dyrwalds sich nicht anders zu helfen, als eine besondere Bombe zu bauen, die unter der Brücke bei der Zitadelle von Halgot versteckt wurde. Sie wollten Waidwen auf die Brücke locken und die Bombe dann zünden. Ihr Plan war erfolgreich und St. Waidwen wurde ausgelöscht, zusammen mit all seinen Truppen und der gesamten Brücke. Die zwölf Männer und Frauen aus dem Dyrwald, die sich freiwillig gemeldet hatten, um St. Waidwen auf der Brücke aufzuhalten, kamen ebenfalls ums Leben. Das Opfer, das diese Märtyrer erbracht haben, wurde in den kommenden Jahren im Dyrwald gefeiert. Die Bombe ging als "Götterhammer" in die Geschichte ein und die Zitadelle wurde kurz nach der Schlacht in "Götterhammerzitadelle" umbenannt. Nach St. Waidwens Tod konnten seine Truppen mühelos vertrieben werden und der Dyrwald begann mit dem Wiederaufbau nach dem ersten großen Konflikt in über einhundert Jahren. Als Vergeltung für St. Waidwens Taten im Namen Eothas' wurden viele Eothasianer aus den Gemeinden im Dyrwald verstoßen oder durch gesellschaftlichen Druck zum Wegzug gedrängt.
+Um den Krieg zu beenden und St. Waidwen auszuschalten, wussten die magranischen Kleriker des Dyrwalds sich nicht anders zu helfen, als eine besondere Bombe zu bauen, die unter der Brücke bei der Zitadelle von Halgot versteckt wurde. Sie wollten Waidwen auf die Brücke locken und die Bombe dann zünden. Ihr Plan war erfolgreich und St. Waidwen wurde ausgelöscht, zusammen mit all seinen Truppen und der gesamten Brücke. Die zwölf Männer und Frauen aus dem Dyrwald, die sich freiwillig gemeldet hatten, um St. Waidwen auf der Brücke aufzuhalten, kamen ebenfalls ums Leben. Das Opfer, das diese Märtyrer erbracht haben, wurde in den kommenden Jahren im Dyrwald gefeiert. Die Bombe ging als "Götterhammer" in die Geschichte ein und die Zitadelle wurde kurz nach der Schlacht in "Götterhammerzitadelle" umbenannt. Nach St. Waidwens Tod konnten seine Truppen mühelos vertrieben werden und der Dyrwald begann mit dem Wiederaufbau nach dem ersten großen Konflikt in über einhundert Jahren. Als Vergeltung für St. Waidwens Taten im Namen Eothas' wurden viele Eothasier aus den Gemeinden im Dyrwald verstoßen oder durch gesellschaftlichen Druck zum Wegzug gedrängt.
 
 Weniger als ein Jahr nach dem verheerenden Krieg des Heiligen kam es zu einer weiteren Tragödie. Im Jahr 2809 AI wurde von der ersten Hohlgeburt im Dyrwald berichtet. Viele dieser armen Geschöpfe starben wenige Wochen oder Monate nach ihrer Geburt. Die entsetzte Bevölkerung sehnt sich nach einem Schuldigen, der bestraft werden kann - seien es die Götter, die Mütter, die Regierung oder die Anhänger von Eothas. 
 
@@ -8903,7 +8903,7 @@ Zwei Jahre später, im Jahr 2664 AI, fand der Fercönyng Verbündete, die bereit
 
 Mit seinem neuen Wissen bewaffnet arbeitete Admeth mit Galven Medhra (der neuen Anführerin der Glanfathaner) und den ländlichen Gemeinden des Dyrwalds zusammen, um zu verhindern, dass die Agenten des Fercönyngs die Ruinen erneut betraten. Es entwickelte sich ein Tauziehen zwischen den beiden Gruppen, die beide durch politische, wirtschaftliche und militärische Manöver versuchten, die Oberhand zu gewinnen. Der Fercönyng war in diesem Spiel aber im Nachteil, da er seine Autorität lieber durchsetzen wollte, ohne einen Aufstand auszulösen.
 
-Schließlich hatte Admeth genug. Er überzeugte sieben der neun Grafen, sich ihm anzuschließen und ihren Treueschwur gegenüber dem Fercönyng zu brechen. Sie erklärten ihre Unabhängigkeit und verkündeten, dass sie sich selbst regieren würden, genau wie die Vailianischen Republiken es zwanzig Jahre zuvor getan hatten. Admeth sagte dem Volk, er habe genug von einer Politik, die den Adel reich machte, während sie das Volk des Dyrwalds in Gefahr brachte. Er erklärte sich zum Duc (erneut nach dem Vorbild der Vailianischen Republiken) und nannte den Dyrwald ein "freies" Palatinat. So begann im Jahr 2668 AI der Widerstandskrieg. Der Krieg dauerte vier Jahre und führte zu unzähligen Toten, darunter auch Admeth selbst. Die Dyrwäldler konnten aber gemeinsam mit ihren glanfathanischen Verbündeten den Sieg erringen. Glanfathanische Astrologen gingen zusammen mit den dyrwäldlischen Truppen und Mitgliedern der eilig einberufenen Miliz der Schmelztiegelritter als Sieger aus der Schlacht von Trutzbucht hervor - der letzten Schlacht des Krieges, die den Dyrwald von der Herrschaft des aedyranischen Reichs befreite. Sieben der neun Grafen des Dyrwalds überlebten und unterzeichneten Verträge mit dem Fercönyng von Aedyr. Der Krieg verlieh dem Dyrwald ein größeres Gefühl der Gemeinschaft zwischen seinen Bürgern und seinen glanfathanischen Verbündeten. Admeth Hadret wurde von beiden Gruppen verehrt und der Dyrwald erlebte zum ersten Mal eine landesweite Gemeinschaft der Unabhängigkeit, Hartnäckigkeit und Opferbereitschaft. Yenwald und Cwynsrun wurden aufgelöst und in die umliegenden Grafschaften integriert, womit derer sieben übrig blieben - Helstor, Der Griff, Tenferths, Norwaech, Kaltwasser, Aschfall und Baelreach. Neu-Dunryd wurde in Trutzbucht umbenannt und wurde zum Machtsitz des neuen Ducs in Baelreach. Die Herrschaft des neuen Ducs begann im Jahr 2672 AI.</DefaultText>
+Schließlich hatte Admeth genug. Er überzeugte sieben der neun Grafen, sich ihm anzuschließen und ihren Treueschwur gegenüber dem Fercönyng zu brechen. Sie erklärten ihre Unabhängigkeit und verkündeten, dass sie sich selbst regieren würden, genau wie die Vailianischen Republiken es zwanzig Jahre zuvor getan hatten. Admeth sagte dem Volk, er habe genug von einer Politik, die den Adel reich machte, während sie das Volk des Dyrwalds in Gefahr brachte. Er erklärte sich zum Duc (erneut nach dem Vorbild der Vailianischen Republiken) und nannte den Dyrwald ein "freies" Palatinat. So begann im Jahr 2668 AI der Widerstandskrieg. Der Krieg dauerte vier Jahre und führte zu unzähligen Toten, darunter auch Admeth selbst. Die Dyrwälder konnten aber gemeinsam mit ihren glanfathanischen Verbündeten den Sieg erringen. Glanfathanische Astrologen gingen zusammen mit den dyrwälderischen Truppen und Mitgliedern der eilig einberufenen Miliz der Schmelztiegelritter als Sieger aus der Schlacht von Trutzbucht hervor - der letzten Schlacht des Krieges, die den Dyrwald von der Herrschaft des aedyrischen Reichs befreite. Sieben der neun Grafen des Dyrwalds überlebten und unterzeichneten Verträge mit dem Fercönyng von Aedyr. Der Krieg verlieh dem Dyrwald ein größeres Gefühl der Gemeinschaft zwischen seinen Bürgern und seinen glanfathanischen Verbündeten. Admeth Hadret wurde von beiden Gruppen verehrt und der Dyrwald erlebte zum ersten Mal eine landesweite Gemeinschaft der Unabhängigkeit, Hartnäckigkeit und Opferbereitschaft. Yenwald und Cwynsrun wurden aufgelöst und in die umliegenden Grafschaften integriert, womit derer sieben übrig blieben - Helstor, Der Griff, Tenferths, Norwaech, Kaltwasser, Aschfall und Baelreach. Neu-Dunryd wurde in Trutzbucht umbenannt und wurde zum Machtsitz des neuen Ducs in Baelreach. Die Herrschaft des neuen Ducs begann im Jahr 2672 AI.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8933,13 +8933,13 @@ Schließlich hatte Admeth genug. Er überzeugte sieben der neun Grafen, sich ihm
     </Entry>
     <Entry>
       <ID>1593</ID>
-      <DefaultText>Im Jahr 2602 AI kehrten aedyranische Entdecker von jenseits des Ozeans zurück. Sie berichteten, dass sie dort Ruinen und Schätze vorgefunden hätten - und weitläufige Felder, die wie geschaffen für den Vorlas-Anbau waren. Die Entdecker warnten den Fercönyng, dass die Einheimischen Fremden gegenüber nicht freundlich gesinnt seien. Doch der Fercönyng sah nur die Gelegenheit, sein Reich zu vergrößern und Handel mit einem neuen Kontinent zu etablieren. Er sandte weitere Entdecker aus. In den nächsten zwanzig Jahren wurde das Gebiet, das später der Dyrwald wurde, erforscht, kartographiert und besiedelt. Im Jahr 2623 AI wurden die ersten dauerhaften aedyranischen Kolonialsiedlungen gegründet.
+      <DefaultText>Im Jahr 2602 AI kehrten aedyrische Entdecker von jenseits des Ozeans zurück. Sie berichteten, dass sie dort Ruinen und Schätze vorgefunden hätten - und weitläufige Felder, die wie geschaffen für den Vorlas-Anbau waren. Die Entdecker warnten den Fercönyng, dass die Einheimischen Fremden gegenüber nicht freundlich gesinnt seien. Doch der Fercönyng sah nur die Gelegenheit, sein Reich zu vergrößern und Handel mit einem neuen Kontinent zu etablieren. Er sandte weitere Entdecker aus. In den nächsten zwanzig Jahren wurde das Gebiet, das später der Dyrwald wurde, erforscht, kartographiert und besiedelt. Im Jahr 2623 AI wurden die ersten dauerhaften aedyrischen Kolonialsiedlungen gegründet.
 
-Vorlas-Felder wurden nördlich der Wälder des Dyrwalds angelegt, doch durch die Konflikte mit den Glanfathanern und den Krieg des Zerbrochenen Steins konnte die Kolonie nicht aufblühen. Erst 2643 AI bot sich eine neue Gelegenheit. Einige eothasianische Pilger, die der Verfolgung entgehen wollten, gründeten Siedlungen und Vorlas-Höfe im Gebiet von Readceras. Da Groß-Vailia vor dem Zusammenbruch stand, wollte der Fercönyng die Kontrolle über den Handel mit violetten Färbemitteln an sich reißen. Er förderte die Besiedlung und bezahlte sogar dafür, dass die Pilger sich in der neuen Welt niederlassen konnten.
+Vorlas-Felder wurden nördlich der Wälder des Dyrwalds angelegt, doch durch die Konflikte mit den Glanfathanern und den Krieg des Zerbrochenen Steins konnte die Kolonie nicht aufblühen. Erst 2643 AI bot sich eine neue Gelegenheit. Einige eothasische Pilger, die der Verfolgung entgehen wollten, gründeten Siedlungen und Vorlas-Höfe im Gebiet von Readceras. Da Groß-Vailia vor dem Zusammenbruch stand, wollte der Fercönyng die Kontrolle über den Handel mit violetten Färbemitteln an sich reißen. Er förderte die Besiedlung und bezahlte sogar dafür, dass die Pilger sich in der neuen Welt niederlassen konnten.
 
 Da der Fercönyng noch immer versuchte, sich einen Namen im Färbemittelhandel zu machen, konnte er nicht angemessen reagieren, als Admeth Hadret sein Ultimatum stellte. Um eine Rebellion zu vermeiden und sich Zeit zu verschaffen, die Vorlas-Höfe in Readceras zu überwachen, gab der Fercönyng nach und machte Admeth zum Gréf-Palatinen. Im Gegenzug investierte Admeth Zeit und Ressourcen in die Handels- und Transportwege des Dyrwalds, was dem Fercönyng ein höheres Einkommen einbrachte.
 
-Sieben Jahre lang versorgte der Dyrwald Aedyr mit regelmäßigen Einnahmen, so dass der Fercönyng Zeit hatte, sein Handelssystem in Readceras zu festigen. Da die Aufmerksamkeit des Fercönyngs auf andere Dinge gerichtet war, ging Admeth die Zehnjahresverträge ein, mit denen er die Sklaverei im Dyrwald beendete und eine der Einnahmequellen der dyrwäldlichen Entdecker dauerhaft zum Versiegen brachte - die Artefakte aus den Ruinen, die im ganzen Dyrwald zu finden sind. Zu dieser Zeit hatte das Wort des Fercönyngs für die Bewohner des Dyrwalds fast keinen Wert mehr. Admeth Hadret hatte ihn als ihren wahren Anführer ersetzt.
+Sieben Jahre lang versorgte der Dyrwald Aedyr mit regelmäßigen Einnahmen, so dass der Fercönyng Zeit hatte, sein Handelssystem in Readceras zu festigen. Da die Aufmerksamkeit des Fercönyngs auf andere Dinge gerichtet war, ging Admeth die Zehnjahresverträge ein, mit denen er die Sklaverei im Dyrwald beendete und eine der Einnahmequellen der dyrwälderischen Entdecker dauerhaft zum Versiegen brachte - die Artefakte aus den Ruinen, die im ganzen Dyrwald zu finden sind. Zu dieser Zeit hatte das Wort des Fercönyngs für die Bewohner des Dyrwalds fast keinen Wert mehr. Admeth Hadret hatte ihn als ihren wahren Anführer ersetzt.
 
 Um Admeths Stellung zu untergraben suchte der Fercönyng Verbündete, die bereit waren, entgegen den Bedingungen des Vertrages die Ruinen zu erforschen und Artefakte daraus zu plündern. Bald besaß Aedyr wieder eine Quelle für Artefakte, die es verkaufen konnte. Als seine Agenten schließlich geschnappt worden, distanzierte der Fercönyng sich von dem Geschehen - wohl wissend, dass es keine Beweise gab, die zu ihm zurückführten.
 
@@ -8953,13 +8953,13 @@ Der Gréf aber nutzte Mittel, die ihm seine glanfathanischen Verbündeten bereit
     </Entry>
     <Entry>
       <ID>1595</ID>
-      <DefaultText>Im Jahr 2652 AI begann alles zu zerfallen. Es wurde entdeckt, dass mehrere Ruinen geplündert worden waren. Alle Zeichen deuteten darauf hin, dass die Aedyraner den Vertrag gebrochen hatten. Die Glanfathaner hielten sich so lange sie nur konnten mit einem Urteil zurück, doch als die Beweise schließlich erdrückend wurden, schlugen sie mit all ihrer Macht zurück. Regd nahm wieder die Rolle des Anführers an und führte sein Volk in den Kampf gegen die Aedyraner. Anstatt wieder mit Edrang Hadret zu ringen, kreuzte Regd diesmal aber die Schwerter mit Edrangs Sohn Admeth Hadret. Admeth erwies sich also ebenso fähig - oder fähiger - wie sein Vater und setzte eine Taktik ein, mit der kein Glanfathaner gerechnet hatte. Um das Schlachtfeld zu räumen und dafür zu sorgen, dass der Feind sich nirgendwo verstecken konnte, ließ Admeth den gesamten Wald beim Fluss Isce Uar in Brand setzen und versperrte allen fliehenden Truppen mit seiner Armee den Weg. Einige überlebten das Gemetzel zwar, doch der Großteil der glanfathanischen Truppen kam um. Regd wurde in dem Chaos gefangen genommen und nach Neu-Heomar gebracht. Es kam zwar zu vielen weiteren Schlachten (in denen Admeth teilweise dieselbe Taktik einsetzte), doch die glanfathanischen Truppen hatten ihre Führung und ihre Entschlossenheit verloren. Sie wurden mühelos zerschlagen und noch vor Ende desselben Jahres war der Krieg der Schwarzen Bäume (wie er heute genannt wird) beendet.
+      <DefaultText>Im Jahr 2652 AI begann alles zu zerfallen. Es wurde entdeckt, dass mehrere Ruinen geplündert worden waren. Alle Zeichen deuteten darauf hin, dass die Aedyrer den Vertrag gebrochen hatten. Die Glanfathaner hielten sich so lange sie nur konnten mit einem Urteil zurück, doch als die Beweise schließlich erdrückend wurden, schlugen sie mit all ihrer Macht zurück. Regd nahm wieder die Rolle des Anführers an und führte sein Volk in den Kampf gegen die Aedyrer. Anstatt wieder mit Edrang Hadret zu ringen, kreuzte Regd diesmal aber die Schwerter mit Edrangs Sohn Admeth Hadret. Admeth erwies sich also ebenso fähig - oder fähiger - wie sein Vater und setzte eine Taktik ein, mit der kein Glanfathaner gerechnet hatte. Um das Schlachtfeld zu räumen und dafür zu sorgen, dass der Feind sich nirgendwo verstecken konnte, ließ Admeth den gesamten Wald beim Fluss Isce Uar in Brand setzen und versperrte allen fliehenden Truppen mit seiner Armee den Weg. Einige überlebten das Gemetzel zwar, doch der Großteil der glanfathanischen Truppen kam um. Regd wurde in dem Chaos gefangen genommen und nach Neu-Heomar gebracht. Es kam zwar zu vielen weiteren Schlachten (in denen Admeth teilweise dieselbe Taktik einsetzte), doch die glanfathanischen Truppen hatten ihre Führung und ihre Entschlossenheit verloren. Sie wurden mühelos zerschlagen und noch vor Ende desselben Jahres war der Krieg der Schwarzen Bäume (wie er heute genannt wird) beendet.
 
 Um das Verhältnis zwischen den beiden Gruppen zu verbessern, führte Admeth neue Gesetze ein, die das Rauben neuer Sklaven aus Eir&#160;Glanfath einschränkten. Die Gesetze gaben Glanfathanern außerdem die Möglichkeit, ihre Verwandten aus der Gefangenschaft freizukaufen. Die Glanfathaner waren zwar nicht vollständig glücklich darüber, ihre Landsleute - die bereits frei gewesen waren - kaufen zu müssen, doch sie betrachteten diese Geste des guten Willens als ebensolche und stellten die Feindseligkeiten wieder ein. Sieben Jahre vergingen, in denen der Dyrwald unter Admeths Herrschaft stand. Die Glanfathaner hatten zum ersten Mal das Gefühl, dass wieder wahrer Frieden in ihr Land zurückkehren könnte. Dieser Frieden führte zu den vermutlich bedeutendsten Friedensverhandlungen, die es zwischen Eir&#160;Glanfath und dem Dyrwald je gab. Admeth schuf die Zehnjahresverträge, deren Name sich dadurch erklärt, dass sie zehn Jahre nach dem Ende des Kriegs der Schwarzem Bäume entstanden. Es wurde ein Zeitplan für die Freilassung aller glanfathanischen Sklaven festgelegt. Die Bürger von Eir&#160;Glanfath betrachteten den Dyrwald mit einer vorsichtigen Hoffnung. Durch den erweiterten Frieden zwischen den zwei Völkern und durch die neuen Verträge hofften sie, dass der Konflikt tatsächlich überwunden war.
 
-Im Jahr 2665 brachte Galven Medhra, eine Elfenfrau, die das Amt von Regd übernommen hatte, Kunde zu Admeth. Einige Dyrwäldler waren ertappt worden, wie sie Artefakte aus einem Grab geraubt hatten. Während der Ermittlungen wurde festgestellt, dass auch weitere Stätten geplündert worden waren. Da es sich um Einzelfälle handelte, die frühzeitig aufgehalten werden konnten, wollte Medhra keinen neuen Krieg beginnen, nachdem so lange Frieden geherrscht hatte. Admeth war dankbar für diese Geste der Höflichkeit und ließ die Verantwortlichen sofort aufspüren. Medhra stellte Admeth ihre Brîshalgwin ("Verstandsjäger") zur Seite, mit deren Hilfe Beweise gefunden wurden, die direkt zum Fercönyng führten. Admeth und Medhra waren nun Verbündete gegen den aedyranischen Fercönyng. Sie nutzten alle Mittel, die ihnen zur Verfügung standen, um zu verhindern, dass die Agenten des Fercönyngs in die Ruinen gelangten.
+Im Jahr 2665 brachte Galven Medhra, eine Elfenfrau, die das Amt von Regd übernommen hatte, Kunde zu Admeth. Einige Dyrwälder waren ertappt worden, wie sie Artefakte aus einem Grab geraubt hatten. Während der Ermittlungen wurde festgestellt, dass auch weitere Stätten geplündert worden waren. Da es sich um Einzelfälle handelte, die frühzeitig aufgehalten werden konnten, wollte Medhra keinen neuen Krieg beginnen, nachdem so lange Frieden geherrscht hatte. Admeth war dankbar für diese Geste der Höflichkeit und ließ die Verantwortlichen sofort aufspüren. Medhra stellte Admeth ihre Brîshalgwin ("Verstandsjäger") zur Seite, mit deren Hilfe Beweise gefunden wurden, die direkt zum Fercönyng führten. Admeth und Medhra waren nun Verbündete gegen den aedyrischen Fercönyng. Sie nutzten alle Mittel, die ihnen zur Verfügung standen, um zu verhindern, dass die Agenten des Fercönyngs in die Ruinen gelangten.
 
-Im Jahr 2668 AI, als Admeth die Unabhängigkeit vom Reich Aedyr verkündete und damit das freie Palatinat des Dyrwalds schuf, standen die Glanfathaner hinter ihm und boten ihm ihre Unterstützung und Truppen an. Der Krieg wirkte sich zwar nicht unmittelbar auf das glanfathanische Volk aus, es gab aber doch Todesopfer. Letztlich erlangten die Dyrwäldler ihre Freiheit und die Verbindung zwischen den beiden Völkern wurde durch ihr geteiltes Leid gestärkt. Admeth</DefaultText>
+Im Jahr 2668 AI, als Admeth die Unabhängigkeit vom Reich Aedyr verkündete und damit das freie Palatinat des Dyrwalds schuf, standen die Glanfathaner hinter ihm und boten ihm ihre Unterstützung und Truppen an. Der Krieg wirkte sich zwar nicht unmittelbar auf das glanfathanische Volk aus, es gab aber doch Todesopfer. Letztlich erlangten die Dyrwälder ihre Freiheit und die Verbindung zwischen den beiden Völkern wurde durch ihr geteiltes Leid gestärkt. Admeth</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8995,13 +8995,13 @@ Es gibt keinen einzelnen Ritter, der der gesamten Organisation vorsteht. Diese V
       <ID>1599</ID>
       <DefaultText>In den fünf Jahren nach seinem Aufstieg zum Gréf bemühte Admeth sich, die Beziehungen zu den Glanfathanern zu verbessern und sein Land mit dem ihren zu vereinen. Er erließ Gesetze, die das Gefangennehmen neuer Sklaven einschränkten, erlaubte den Glanfathanern, ihre Landsleute aus der Gefangenschaft freizukaufen, und führte eine Steuer auf den Besitz von Sklaven ein, um die Verwendung bezahlter Arbeitskräfte zu fördern. Es gab zwar etwas Widerstand gegen die neuen Gesetze, doch die Aufmerksamkeit des Fercönyngs war auf Readceras gerichtet und Admeth war mächtig (und genoss die Unterstützung der Kolonisten) - die Grafen konnten kaum echten Widerstand leisten.
 
-Im Jahr 2662 AI, als sich der Krieg der Schwarzen Bäume zum zehnten Mal jährte, setzte Admeth der Sklaverei im Dyrwald ein Ende. Er handelte eine Reihe von Verträgen mit den Glanfathanern aus, durch die ein Zeitplan festgelegt wurde, wann die verbleibenden Sklaven freizulassen waren. Jeder Sklavenbesitzer sollte als Entschädigung Geld oder Land erhalten, abhängig von der Anzahl der freigelassenen Sklaven. Sollte ein Sklavenbesitzer sich weigern, so sollten die Sklaven zwangsweise freigelassen und ihr ehemaliger Herr mit einer empfindlichen Geldstrafe belegt werden. Die Glanfathaner öffneten im Gegenzug die Handelsrouten mit dem Dyrwald und erlaubten den Dyrwäldlern, in Gebieten zu leben, in denen ihre heiligen Ruinen stehen - wobei es weiterhin streng verboten blieb, die Ruinen zu betreten. Als letzten Akt des guten Willens ließ Admeth Galven Regd frei, da er genug für seine Taten gelitten habe.
+Im Jahr 2662 AI, als sich der Krieg der Schwarzen Bäume zum zehnten Mal jährte, setzte Admeth der Sklaverei im Dyrwald ein Ende. Er handelte eine Reihe von Verträgen mit den Glanfathanern aus, durch die ein Zeitplan festgelegt wurde, wann die verbleibenden Sklaven freizulassen waren. Jeder Sklavenbesitzer sollte als Entschädigung Geld oder Land erhalten, abhängig von der Anzahl der freigelassenen Sklaven. Sollte ein Sklavenbesitzer sich weigern, so sollten die Sklaven zwangsweise freigelassen und ihr ehemaliger Herr mit einer empfindlichen Geldstrafe belegt werden. Die Glanfathaner öffneten im Gegenzug die Handelsrouten mit dem Dyrwald und erlaubten den Dyrwäldern, in Gebieten zu leben, in denen ihre heiligen Ruinen stehen - wobei es weiterhin streng verboten blieb, die Ruinen zu betreten. Als letzten Akt des guten Willens ließ Admeth Galven Regd frei, da er genug für seine Taten gelitten habe.
 
 Der Fercönyng erkannte, dass er die Kontrolle über sein eigenes Palatinat verloren hatte. Er ersann einen Plan, um den Handel mit antiken Artefakten wieder zu beleben. Er sprach die Grafen an, die unter Admeths Herrschaft litten, und überzeugte sie, Agenten anzuheuern, um die Ruinen zu plündern. Anfänglich taten sie das im Geheimen, doch sie wurden schnell fahrlässig und wurden schließlich geschnappt. Dieser Verstoß gegen die Verträge provozierte die Glanfathaner wieder zu Gewaltakten, während Admeth Nachforschungen anstellte, wer dahinter steckte.
 
-Mit Hilfe der glanfathanischen Anführer fand Admeth Beweise, die zum Fercönyng als Drahtzieher der Plünderungen führten. Das war der Anfang vom Ende der aedyranischen Herrschaft im Dyrwald. In den nächsten sieben Jahren versuchten Admeth und der Fercönyng, durch politische, wirtschaftliche und militärische Manöver einen Vorteil über einander zu erlangen. Im Jahr 2668 AI erklärte Admeth, dass der Dyrwald genug hatte. Er verkündete, dass der Dyrwald die Autorität des Fercönyngs nicht mehr anerkannte, sondern nun ein freies Land sei, das sich selbst regieren würde. Das löste den Widerstandskrieg aus, der fünf Jahre andauerte.
+Mit Hilfe der glanfathanischen Anführer fand Admeth Beweise, die zum Fercönyng als Drahtzieher der Plünderungen führten. Das war der Anfang vom Ende der aedyrischen Herrschaft im Dyrwald. In den nächsten sieben Jahren versuchten Admeth und der Fercönyng, durch politische, wirtschaftliche und militärische Manöver einen Vorteil über einander zu erlangen. Im Jahr 2668 AI erklärte Admeth, dass der Dyrwald genug hatte. Er verkündete, dass der Dyrwald die Autorität des Fercönyngs nicht mehr anerkannte, sondern nun ein freies Land sei, das sich selbst regieren würde. Das löste den Widerstandskrieg aus, der fünf Jahre andauerte.
 
-Das Ergebnis des Kriegs war die Freiheit des Drywalds, und auch wenn Duc Hadret vor Kriegsende starb, so gilt er für die Dyrwäldler doch als Gründer ihres Landes.</DefaultText>
+Das Ergebnis des Kriegs war die Freiheit des Dyrwalds, und auch wenn Duc Hadret vor Kriegsende starb, so gilt er für die Dyrwälder doch als Gründer ihres Landes.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9022,7 +9022,7 @@ Und es schien tatsächlich, als wäre er das, bis zur Schlacht bei der Zitadelle
 
 Zwölf Männer und Frauen aus dem Dyrwald meldeten sich freiwillig für die Aufgabe, Waidwen aus dem Hinterhalt anzugreifen, damit er auf der Brücke feststeckte, bis die Bombe gezündet werden konnte. Die Schlacht war kurz, blutig und endgültig. "Das Dutzend" (wie man sie später nannte) konnte Waidwen auf der Brücke aufhalten. Die Bombe detonierte und tötete Waidwen, die vier Freiwilligen, die zu diesem Zeitpunkt noch am Leben waren und über fünfzig readceranische Soldaten, die an vorderster Front mit Waidwen marschierten.
 
-In diesem Augenblick endete der Krieg des Heiligen. Die verbleibenden readceranischen Truppen konnten mühelos zerschlagen werden. Sie hatten zwar mehr als genug Männer und Material, um die Belagerung zu Ende zu bringen, doch ihr Anführer, der bis vor kurzem noch als unbesiegbar galt, war soeben in einem Hagel aus Metall und Stein verschwunden. Panik brach aus und die Dyrwäldler hatten keine Mühe, sie in die Flucht zu schlagen.
+In diesem Augenblick endete der Krieg des Heiligen. Die verbleibenden readceranischen Truppen konnten mühelos zerschlagen werden. Sie hatten zwar mehr als genug Männer und Material, um die Belagerung zu Ende zu bringen, doch ihr Anführer, der bis vor kurzem noch als unbesiegbar galt, war soeben in einem Hagel aus Metall und Stein verschwunden. Panik brach aus und die Dyrwälder hatten keine Mühe, sie in die Flucht zu schlagen.
 
 Von diesem Punkt an war die Bombe nur noch als "Götterhammer" bekannt. Sie hielt sogar Einzug in den alltäglichen Sprachgebrauch. "So sicher, wie der Götterhammer den Krieg des Heiligen beendete" wurde zu einer festen Redewendung. Weniger sicher ist das Schicksal von Eothas, der seit der Explosion der Bombe nicht mehr zu seinen Anhängern gesprochen hat und für viele als tot gilt.
 
@@ -9031,7 +9031,7 @@ Bevor ein besorgter Bürger seiner Furcht Ausdruck verleiht oder ein erfindungsr
     </Entry>
     <Entry>
       <ID>1603</ID>
-      <DefaultText>Der Beherzte Dieb: Eine dyrwäldlerische Farce, Teil 2</DefaultText>
+      <DefaultText>Der Beherzte Dieb: Eine dyrwälderische Farce, Teil 2</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9195,7 +9195,7 @@ MÄNNLICH: Das Urteil ist endgültig. Die Entscheidung ist gefallen. (Er wendet 
       <ID>1619</ID>
       <DefaultText>Die Anordnung ist durch Zeit und Salz ganz steif geworden.
 
-"Aedyranische Verstärkung ist auf dem Vormarsch. Ondras Geschenk ist auf Befehl von Duc Hadret sofort zu evakuieren."</DefaultText>
+"Aedyrische Verstärkung ist auf dem Vormarsch. Ondras Geschenk ist auf Befehl von Duc Hadret sofort zu evakuieren."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9211,7 +9211,7 @@ MÄNNLICH: Das Urteil ist endgültig. Die Entscheidung ist gefallen. (Er wendet 
 
 12. Fonauton 2672 - Schwerer Regen. 2 Fischerboot auf See verloren. 164 Tage seit Sichtung der Roter Traum.
 
-1. Tarauton 2672 - Dunkle Wolken. Aedyranische Schiffe am Horizont. 173 Tage seit Sichtung der Roter Traum."</DefaultText>
+1. Tarauton 2672 - Dunkle Wolken. Aedyrische Schiffe am Horizont. 173 Tage seit Sichtung der Roter Traum."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9316,7 +9316,7 @@ MÄNNLICH: Das Urteil ist endgültig. Die Entscheidung ist gefallen. (Er wendet 
     </Entry>
     <Entry>
       <ID>1642</ID>
-      <DefaultText>Dieser Leinensack enthält den Kopf des berüchtigten aedyranischen Sklaventreibers Galen Dalgard.</DefaultText>
+      <DefaultText>Dieser Leinensack enthält den Kopf des berüchtigten aedyrischen Sklaventreibers Galen Dalgard.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9356,7 +9356,7 @@ MÄNNLICH: Das Urteil ist endgültig. Die Entscheidung ist gefallen. (Er wendet 
     </Entry>
     <Entry>
       <ID>1650</ID>
-      <DefaultText>Dieser Leinensack enthält den Kopf des eothasianischen Priesters Thorfen.</DefaultText>
+      <DefaultText>Dieser Leinensack enthält den Kopf des eothasischen Priesters Thorfen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9386,7 +9386,7 @@ MÄNNLICH: Das Urteil ist endgültig. Die Entscheidung ist gefallen. (Er wendet 
     </Entry>
     <Entry>
       <ID>1656</ID>
-      <DefaultText>Ich hätte nie erwartet, in meinem Leben einmal ein Massaker von solchen Ausmaßen zu sehen. Ich war in meinem Schreibzimmer, um wichtige Dokumente für die Evakuierung einpacken. Ich ahnte nicht, dass die Aedyraner so drastisch vorgehen würden. Es war meine Frau, Ne'iloc, die zuerst hörte, wie die Dämme brachen. Wir stiegen auf das Dach, als das Wasser den Treppenabsatz erreichte. Meine drei Kinder Nathe, Leibelsa und Kyrre hielten wir in den Armen. Das Wasser erreichte unsere Brust. Wir klammerten uns an den gerade erst reparierten Schornstein. So konnten wir verhindern, dass die Fluten uns wegrissen. Andere Familien hatten weniger Glück.
+      <DefaultText>Ich hätte nie erwartet, in meinem Leben einmal ein Massaker von solchen Ausmaßen zu sehen. Ich war in meinem Schreibzimmer, um wichtige Dokumente für die Evakuierung einpacken. Ich ahnte nicht, dass die Aedyrer so drastisch vorgehen würden. Es war meine Frau, Ne'iloc, die zuerst hörte, wie die Dämme brachen. Wir stiegen auf das Dach, als das Wasser den Treppenabsatz erreichte. Meine drei Kinder Nathe, Leibelsa und Kyrre hielten wir in den Armen. Das Wasser erreichte unsere Brust. Wir klammerten uns an den gerade erst reparierten Schornstein. So konnten wir verhindern, dass die Fluten uns wegrissen. Andere Familien hatten weniger Glück.
 
 Als das Wasser schließlich zurückging, waren die Straßen voller Schutt, Schlamm und stinkender Fische. Der halbe Bezirk war vom Meer verschluckt worden. Leichen schwammen im Wasser, zusammen mit allem, was bei der Evakuierung zurückgelassen worden war. Wir verbrannten die Bürger, die wir fanden. Die armen Seelen haben sonst niemanden, der sich an sie erinnert, daher dokumentiere ich sie hier. Ich weiß nicht, ob sie Angehörige hatten, welche die Flut überlebt haben, aber es ist besser, ihre Namen niederzuschreiben, damit diese grauenhafte Flut sie nicht einfach wegspült ... wie so vieles andere.
 
@@ -9689,7 +9689,7 @@ Retsim Namotatop</DefaultText>
     </Entry>
     <Entry>
       <ID>1701</ID>
-      <DefaultText>Der süße und dicke Met ist eines der Lieblingsgetränke der Aedyraner und hält die alte Tradition aufrecht, launige Abende mit qualvollen Morgen zu vereinen.</DefaultText>
+      <DefaultText>Der süße und dicke Met ist eines der Lieblingsgetränke der Aedyrer und hält die alte Tradition aufrecht, launige Abende mit qualvollen Morgen zu vereinen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -9807,7 +9807,7 @@ Wenn Woedica ihren Thron zurückerobert, wird meine Familie verstehen, dass ich 
 
 Eothas hat nicht mit uns gesprochen, seit er als der Heilige Waidwen erschienen ist. Ich hatte gehofft, dass Eothas mich als seine nächste Hülle erwählen würde, doch ... das Kind des Lichts bleibt stumm. Jeden Tag vollführe ich das Ritual, die Schatten der Ungläubigen zu verbannen ... und jeden Tag bestelle ich einsam meine Felder, ohne ein Anzeichen von Eothas' Rückkehr. Er möge dir Licht bringen, wenn du in der Dunkelheit lebst, doch wie lange muss ich noch in dieser langen Nacht des Verlassenseins darben?
 
-Ist das meine Strafe dafür, dass ich meinen Glauben geheim gehalten habe? Versteckt Eothas sich vor mir, bis ich für alle hörbar herausschreie, wie ich ihn verehre? Gewiss weiß er, dass die Dyrwäldler ihn und seine Anhänger nun hassen ... meine Landsmänner geben die Schuld für alle Übel des Kriegs des Heiligen uns weiterhin treuen Anhängern von Eothas. Sollten sie nicht zornig auf die readceranischen Soldaten sein? Erkennen die Dyrwäldler nicht, dass sie alle Hoffnung auf Heilung verhindern, indem sie den Gott der Wiedergeburt und Erlösung verstoßen?
+Ist das meine Strafe dafür, dass ich meinen Glauben geheim gehalten habe? Versteckt Eothas sich vor mir, bis ich für alle hörbar herausschreie, wie ich ihn verehre? Gewiss weiß er, dass die Dyrwälder ihn und seine Anhänger nun hassen ... meine Landsmänner geben die Schuld für alle Übel des Kriegs des Heiligen uns weiterhin treuen Anhängern von Eothas. Sollten sie nicht zornig auf die readceranischen Soldaten sein? Erkennen die Dyrwälder nicht, dass sie alle Hoffnung auf Heilung verhindern, indem sie den Gott der Wiedergeburt und Erlösung verstoßen?
 
 Während ich diese Worte schreibe, weiß ich, dass ich weiterhin das Farbblatt anbauen muss. Ich werde jeden Tag mit neuer Hoffnung erwachen: Wenn du in der Dunkelheit lebst, wird er mir Licht bringen. Jeden Tag bete ich, dass die Dämmerungssterne mich besuchen, genau, wie sie den Heiligen Waidwen in seinem Vorlasfeld besuchten. Werden sie mir erscheinen, wie sie dem Heiligen Waidwen erschienen sind? Als ein Mann und zwei Frauen, strahlend und makellos? Man sagt mir, sie kommen, um neue Zeiten anzukündigen ... Man sagt mir viele Dinge, und ich versuche, den Glauben in mir zu finden, sie alle zu glauben.
 
@@ -9940,7 +9940,7 @@ Ich fürchte, meine Schülerin wird auf Waels Besuch zurückblicken und sich bet
       <ID>1733</ID>
       <DefaultText>Deine Soldaten sind nicht voll bewaffnet, nicht einmal anständig gekleidet, wenn sie nicht zumindest die Grundlagen der glanfathanischen Sprache beherrschen. Wenn deine Späher nicht lauschen können, wenn deine gefangenen Soldaten die Worte ihrer Wachen nicht erkennen, wenn unsere Offiziere nicht auf Friedensangebote antworten können - scheitern wir. Selbst wenige Wörter der Gesichtsbemalten zu kennen kann den Unterschied zwischen Sieg oder Niederlage bedeuten.
 
-Die glanfathanische Schrift ist - wie die aedyranische - eine Abwandlung des alten vailianischen Alphabets, das vor langer Zeit von den Aedyranern über das Meer getragen wurde. Die Glanfathaner veränderten dieses Alphabet etwas, so dass es einige auffällige Unterschiede gibt, welche für Uninformierte verwirrend sein können.
+Die glanfathanische Schrift ist - wie die aedyrische - eine Abwandlung des alten vailianischen Alphabets, das vor langer Zeit von den Aedyrern über das Meer getragen wurde. Die Glanfathaner veränderten dieses Alphabet etwas, so dass es einige auffällige Unterschiede gibt, welche für Uninformierte verwirrend sein können.
 
 A und â ist der Unterschied zwischen "Ball" und "fahl".
 E und ê ist der Unterschied zwischen "wenn" und "wen".
@@ -9948,7 +9948,7 @@ I und î ist der Unterschied zwischen "Knick" und "Krieg".
 O und ô ist der Unterschied zwischen "flott" und "rot".
 W und ŵ ist der Unterschied zwischen "Schutt" und "Mut".
 
-Man beachte den letzten Teil - in Eir&#160;Glanfath dient der Buchstabe w als unser Buchstabe u. Ihn als Konsonanten "www" auszusprechen ist die schnellste Art, einen Glanfathaner wissen zu lassen, dass man ein Dyrwäldler ist, der Schwierigkeiten hat, die Sprache zu erlernen. Siehe "Estramor" im untenstehenden Glossar.
+Man beachte den letzten Teil - in Eir&#160;Glanfath dient der Buchstabe w als unser Buchstabe u. Ihn als Konsonanten "www" auszusprechen ist die schnellste Art, einen Glanfathaner wissen zu lassen, dass man ein Dyrwälder ist, der Schwierigkeiten hat, die Sprache zu erlernen. Siehe "Estramor" im untenstehenden Glossar.
 
 Und man behalte diese kniffligen Unterschiede im Hinterkopf:
 
@@ -9983,22 +9983,22 @@ Weretha - die Gesamtheit unserer Welt (Aussprache "u-retha" mit stimmlosem denta
     </Entry>
     <Entry>
       <ID>1734</ID>
-      <DefaultText>Aedyranische Dialekte</DefaultText>
+      <DefaultText>Aedyrische Dialekte</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1735</ID>
-      <DefaultText>Die Sonne über der aedyranischen Sprache geht niemals unter. Wir, die wir diese stolze Sprache oder eine Abwandlung davon sprechen, bevölkern jeden Winkel von Eora.
+      <DefaultText>Die Sonne über der aedyrischen Sprache geht niemals unter. Wir, die wir diese stolze Sprache oder eine Abwandlung davon sprechen, bevölkern jeden Winkel von Eora.
 
-Die meisten von uns, die diese wunderbare Sprache sprechen, kennen sie als Aedyranisch. Gelehrte aber und penibel auf Korrektheit bedachte Personen qualifizieren sie oft als "modernes" oder "zeitgenössisches" Aedyranisch. Dies dient als Abgrenzung zum Alt-Aedyranischen - der alten Elfensprache, die im aedyranischen Reich gesprochen wurde, bevor die ersten Siedler des Dyrwalds ihre Langschiffe bauten.
+Die meisten von uns, die diese wunderbare Sprache sprechen, kennen sie als Aedyrisch. Gelehrte aber und penibel auf Korrektheit bedachte Personen qualifizieren sie oft als "modernes" oder "zeitgenössisches" Aedyrisch. Dies dient als Abgrenzung zum Alt-Aedyrischen - der alten Elfensprache, die im aedyrischen Reich gesprochen wurde, bevor die ersten Siedler des Dyrwalds ihre Langschiffe bauten.
 
-Wenn Alt-Aedyranisch als die Mutter des lebendigen Aedyranisch gelten könnte, so könnte man die Sprache Hylisch als den Vetter des Aedyranischen betrachten. Hylisch ist immer weniger verbreitet, doch viele Elfen (besonders ältere) im aedyranischen Landesinneren sprechen diesen Dialekt noch.
+Wenn Alt-Aedyrisch als die Mutter des lebendigen Aedyrisch gelten könnte, so könnte man die Sprache Hylisch als den Vetter des Aedyrischen betrachten. Hylisch ist immer weniger verbreitet, doch viele Elfen (besonders ältere) im aedyrischen Landesinneren sprechen diesen Dialekt noch.
 
-Ob es dem Leser bewusst ist oder nicht - wer diese Worte lesen kann, der versteht auch Hylisch. Es ist nahezu identisch mit dem Aedyranischen, besitzt jedoch ein großes Vokabular an archaischen Wörtern, die im heutigen Aedyranisch sehr selten geworden sind. Wenn man Barden lauscht, die alte aedyranische Gedichte vortragen, hört man oft Refrains, die wie melodischer Unsinn klingen - meist sind dies Wörter, die in unserer gemeinsamen Sprache ausgestorben sind, im Hylischen aber noch verwendet werden.
+Ob es dem Leser bewusst ist oder nicht - wer diese Worte lesen kann, der versteht auch Hylisch. Es ist nahezu identisch mit dem Aedyrischen, besitzt jedoch ein großes Vokabular an archaischen Wörtern, die im heutigen Aedyrisch sehr selten geworden sind. Wenn man Barden lauscht, die alte aedyrische Gedichte vortragen, hört man oft Refrains, die wie melodischer Unsinn klingen - meist sind dies Wörter, die in unserer gemeinsamen Sprache ausgestorben sind, im Hylischen aber noch verwendet werden.
 
-Während Hylisch jenen, die das so genannte "moderne" Aedyranisch sprechen, vertraut ist, gilt das nicht für den Vorläufer unserer Sprache. Alt-Aedyranisch ist eine tote Sprache, von Akademikern gesprochen, aber in keiner größeren Gemeinschaft noch aktiv verwendet. Alt-Aedyranische Wörter sind Aedyranischsprechenden oft vertraut, doch die Wörter verwenden eine veraltete Rechtschreibung voller unbekannter Akzentzeichen.
+Während Hylisch jenen, die das so genannte "moderne" Aedyrisch sprechen, vertraut ist, gilt das nicht für den Vorläufer unserer Sprache. Alt-Aedyrisch ist eine tote Sprache, von Akademikern gesprochen, aber in keiner größeren Gemeinschaft noch aktiv verwendet. Alt-Aedyrische Wörter sind Aedyrisch Sprechenden oft vertraut, doch die Wörter verwenden eine veraltete Rechtschreibung voller unbekannter Akzentzeichen.
 
-Das Alt-Aedyranische verwendet beispielsweise einige Doppellaute, die im modernen Aedyranisch nicht existieren, sowie einige knifflige Konsonantenhäufungen:
+Das Alt-Aedyrische verwendet beispielsweise einige Doppellaute, die im modernen Aedyrisch nicht existieren, sowie einige knifflige Konsonantenhäufungen:
 
 Ea erzeugt einen "eh-ja"-Klang, ähnlich dem Kinderreim "Eia-popeia".
 Eo klingt wie "eh-jo" - dieser Klang wird im modernen Wort "Eora" noch verwendet.
@@ -10009,7 +10009,7 @@ Gj klingt wie "j" in "Jugend".
 Sc klingt wie "sch" - Sciff spricht sich also "Schiff".
 Cg klingt wie "dsch" in "Dschungel".
 
-Die Vornamen von Aedyranern, Dyrwäldlern und Readceranern stammen oft aus dem Alt-Aedyranischen. Einige Beispiele:
+Die Vornamen von Aedyrern, Dyrwäldern und Readceranern stammen oft aus dem Alt-Aedyrischen. Einige Beispiele:
 
 Aldwyn wird "ALD-wihn" gesprochen, wegen des langen Vokalklangs des "y".
 Durnisc wird "DUR-nisch" gesprochen, da das "sc" am Ende wie "sch" klingt.
@@ -10671,12 +10671,12 @@ Ich breche am Morgen nach Cilant Lîs auf. Dann muss ich nur noch das Relief fin
     </Entry>
     <Entry>
       <ID>1865</ID>
-      <DefaultText>Da sich Aedyr in der Nähe von Eoras Äquator befindet, bevorzugen die Aedyraner leicht, lockere und bequeme Kleidung. Ihre Gewänder bestehen meistens aus Leinen, wobei aus der Naturfarbe der Faser und bunten Farben kräftige, einfache Muster entstehen.</DefaultText>
+      <DefaultText>Da sich Aedyr in der Nähe von Eoras Äquator befindet, bevorzugen die Aedyrer leicht, lockere und bequeme Kleidung. Ihre Gewänder bestehen meistens aus Leinen, wobei aus der Naturfarbe der Faser und bunten Farben kräftige, einfache Muster entstehen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1866</ID>
-      <DefaultText>Obwohl die meisten Dyrwäldler aus dem Aedyr-Reich stammen, hat sich die dyrwäldlerischer Kleidung seit den ersten Kolonisierungswellen stark verändert. Dyrwäldler bevorzugen grobe Kleidung, die oft aus Wolle und Hirschleder gefertigt wird. Aufgrund des instabilen Wetter des Östlichen Abschnitts trägt man im Alltag des Dyrwalds gerne Westen und andere Überbekleidungen.</DefaultText>
+      <DefaultText>Obwohl die meisten Dyrwälder aus dem Aedyr-Reich stammen, hat sich die dyrwälderischer Kleidung seit den ersten Kolonisierungswellen stark verändert. Dyrwälder bevorzugen grobe Kleidung, die oft aus Wolle und Hirschleder gefertigt wird. Aufgrund des instabilen Wetter des Östlichen Abschnitts trägt man im Alltag des Dyrwalds gerne Westen und andere Überbekleidungen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -10774,7 +10774,7 @@ Trotz seiner Dicke und seines Gewichts ist dieser Gürtel optisch nicht sonderli
 
 Als Aedwyn einen unbemerkten Tod starb, ging die Klinge in den Besitz seiner jungen Nichte über, Cadend Grundmef. Letztere fand, dass die Waffe über die Eigenheiten ihres Onkels verfügte: sie war gut, um in unpassenden Momenten zu unterbrechen und jedem, mit dem sie in Kontakt kam, das Leben zu entziehen ... und schuf eine generell lästige Präsenz. Aedwyn selbst gab dem Degen den Spitznamen "Moskito" und setzte ihn regelmäßig in Hofduellen ein.
 
-Nach ihrem Tod wurde die Waffe an Aedwyns Enkel im Dyrwald weitergegeben. Als Thayn von Cwynsrun fiel er bei einem glanfathanischen Überfall, und Moskito ging mit ihm verloren. Da er keine Nachkommen hatte und keiner der Grundmeths von Aedyr den Degen beansprucht haben, war er seitdem im Besitz verschiedener anonymer Glanfathaner und Dyrwäldler.</DefaultText>
+Nach ihrem Tod wurde die Waffe an Aedwyns Enkel im Dyrwald weitergegeben. Als Thayn von Cwynsrun fiel er bei einem glanfathanischen Überfall, und Moskito ging mit ihm verloren. Da er keine Nachkommen hatte und keiner der Grundmeths von Aedyr den Degen beansprucht haben, war er seitdem im Besitz verschiedener anonymer Glanfathaner und Dyrwälder.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -10811,7 +10811,7 @@ Nach ihrem Tod wurde die Waffe an Aedwyns Enkel im Dyrwald weitergegeben. Als Th
     </Entry>
     <Entry>
       <ID>1889</ID>
-      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwäldlerischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
+      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwälderischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/items.stringtable
+++ b/text/game/items.stringtable
@@ -9326,7 +9326,7 @@ MÄNNLICH: Das Urteil ist endgültig. Die Entscheidung ist gefallen. (Er wendet 
     </Entry>
     <Entry>
       <ID>1644</ID>
-      <DefaultText>Dieser Leinensack enthält den Kopf von Devŵen, einer monströsen Menpwgra.</DefaultText>
+      <DefaultText>Dieser Leinensack enthält den Kopf von Devŵen, einer monströsen Mênpŵgra.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/maps.stringtable
+++ b/text/game/maps.stringtable
@@ -596,7 +596,7 @@
     </Entry>
     <Entry>
       <ID>118</ID>
-      <DefaultText>Tempel von Eothaas</DefaultText>
+      <DefaultText>Tempel von Eothas</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/stronghold.stringtable
+++ b/text/game/stronghold.stringtable
@@ -261,7 +261,7 @@
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>{0}, im Dienste des aedyranischen Hofes, ist in der Festung eingetroffen.</DefaultText>
+      <DefaultText>{0}, im Dienste des aedyrischen Hofes, ist in der Festung eingetroffen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -391,7 +391,7 @@
     </Entry>
     <Entry>
       <ID>78</ID>
-      <DefaultText>Naedle ist eine Agentin des Bleiernen Schlüssels, die mich in der Sturmwallschlucht überfallen wollte. Nachdem ihre Gefährten sich nicht trauten zu kämpfen, änderte sie ihre Meinung und ergab sich.</DefaultText>
+      <DefaultText>Naelde ist eine Agentin des Bleiernen Schlüssels, die mich in der Sturmwallschlucht überfallen wollte. Nachdem ihre Gefährten sich nicht trauten zu kämpfen, änderte sie ihre Meinung und ergab sich.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/01_defiance_bay_coppleane/01_tsk_rogue_knight.stringtable
+++ b/text/quests/01_defiance_bay_coppleane/01_tsk_rogue_knight.stringtable
@@ -75,7 +75,7 @@ Osric hat mich gebeten, einen Brustharnisch von Penhelm wiederzubeschaffen. Er g
       <ID>10010</ID>
       <DefaultText>Penhelm scheint nicht gewillt zu sein, Osrics Rüstung herauszugeben, die er selbst am Körper trägt. Ich brauche ein stärkeres Druckmittel.
 
-Osric glaubt, dass Penhelms eidesstattliche Versicherung, dass seine Seele frei von aedyranischen Einflüssen ist, eine Fälschung sein könnte. Er sagte, ich würde sie irgendwo auf Burg Schmelztiegel in Urfeuer finden.</DefaultText>
+Osric glaubt, dass Penhelms eidesstattliche Versicherung, dass seine Seele frei von aedyrischen Einflüssen ist, eine Fälschung sein könnte. Er sagte, ich würde sie irgendwo auf Burg Schmelztiegel in Urfeuer finden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/04_defiance_bay_brackenbury/04_qst_final_act.stringtable
+++ b/text/quests/04_defiance_bay_brackenbury/04_qst_final_act.stringtable
@@ -56,7 +56,7 @@
     </Entry>
     <Entry>
       <ID>10002</ID>
-      <DefaultText>Die Beweise führen zu einer Frau namens Lumdara und einer Theatergruppe namens Sternenfest. In Kupferweg gibt es ein Amphitheater. Vielleicht finde ich sie dort.</DefaultText>
+      <DefaultText>Die Beweise führen zu einer Frau namens Lumdala und einer Theatergruppe namens Sternenfest. In Kupferweg gibt es ein Amphitheater. Vielleicht finde ich sie dort.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/06_stronghold/06_tsk_boss_menpwgra.stringtable
+++ b/text/quests/06_stronghold/06_tsk_boss_menpwgra.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Töte die Menpwgra namens Devŵen und nimm ihren Kopf an dich.</DefaultText>
+      <DefaultText>Töte die Mênpŵgra namens Devŵen und nimm ihren Kopf an dich.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -21,12 +21,12 @@
     </Entry>
     <Entry>
       <ID>10000</ID>
-      <DefaultText>Ein seltsamer, mörderischer Kult von Druiden hat sich um eine Menpwgra namens Devŵen gebildet. Die Gruppe nutzt eine Höhle in der Nordlandschaft als ihr Hauptquartier.</DefaultText>
+      <DefaultText>Ein seltsamer, mörderischer Kult von Druiden hat sich um eine Mênpŵgra namens Devŵen gebildet. Die Gruppe nutzt eine Höhle in der Nordlandschaft als ihr Hauptquartier.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>10001</ID>
-      <DefaultText>In der Nordlandschaft hat sich ein Druidenkult um eine Menpwgra herum gebildet. Ich muss die Höhle des Kults finden und dort Devŵen töten, die Anführerin. Ihr Kopf wird als Beweis ihres Ablebens dienen. Ohne Devŵen wird der Kult auseinanderfallen.
+      <DefaultText>In der Nordlandschaft hat sich ein Druidenkult um eine Mênpŵgra herum gebildet. Ich muss die Höhle des Kults finden und dort Devŵen töten, die Anführerin. Ihr Kopf wird als Beweis ihres Ablebens dienen. Ohne Devŵen wird der Kult auseinanderfallen.
 
 
 Der Druidenkult von Devŵen haust in der Nordlandschaft-Höhle. Ich muss Devŵen töten und ihren Kopf als Beweis an mich nehmen.</DefaultText>
@@ -39,7 +39,7 @@ Der Druidenkult von Devŵen haust in der Nordlandschaft-Höhle. Ich muss Devŵen
     </Entry>
     <Entry>
       <ID>30000</ID>
-      <DefaultText>Ich habe das Kopfgeld für die Menpwgra namens Devŵen eingefordert.</DefaultText>
+      <DefaultText>Ich habe das Kopfgeld für die Mênpŵgra namens Devŵen eingefordert.</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/quests/06_stronghold/06_tsk_boss_paladin.stringtable
+++ b/text/quests/06_stronghold/06_tsk_boss_paladin.stringtable
@@ -21,12 +21,12 @@
     </Entry>
     <Entry>
       <ID>10000</ID>
-      <DefaultText>Der aedyranische Sklaventreiber Galen Dalgard wurde bei der Madhamr-Brücke gesehen. Es wurde ein Kopfgeld auf ihn ausgesetzt.</DefaultText>
+      <DefaultText>Der aedyrische Sklaventreiber Galen Dalgard wurde bei der Madhmr-Brücke gesehen. Es wurde ein Kopfgeld auf ihn ausgesetzt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>10001</ID>
-      <DefaultText>Es wurde ein Kopfgeld auf den berüchtigten Sklaventreiber Galen Dalgard ausgesetzt. Fyrgen sagte, man könne ihn vielleicht bei der Madhamr-Brücke finden. Ich muss ihn töten und seinen Kopf als Beweis mitbringen, um das Kopfgeld zu erhalten.</DefaultText>
+      <DefaultText>Es wurde ein Kopfgeld auf den berüchtigten Sklaventreiber Galen Dalgard ausgesetzt. Fyrgen sagte, man könne ihn vielleicht bei der Madhmr-Brücke finden. Ich muss ihn töten und seinen Kopf als Beweis mitbringen, um das Kopfgeld zu erhalten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/06_stronghold/06_tsk_boss_priest.stringtable
+++ b/text/quests/06_stronghold/06_tsk_boss_priest.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>10000</ID>
-      <DefaultText>Der eothasianische Priester Thorfen sorgt im Esternwald für Ärger - weshalb ein Kopfgeld auf ihn ausgesetzt ist.</DefaultText>
+      <DefaultText>Der eothasische Priester Thorfen sorgt im Esternwald für Ärger - weshalb ein Kopfgeld auf ihn ausgesetzt ist.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/07_gilded_vale/07_qst_buried_secrets.stringtable
+++ b/text/quests/07_gilded_vale/07_qst_buried_secrets.stringtable
@@ -61,7 +61,7 @@
     </Entry>
     <Entry>
       <ID>20003</ID>
-      <DefaultText>Innerhalb des Tempels habe ich eine Art Geist gesehen - oder zumindest eine Erinnerung. In dieser Erinnerung erlebte ich ein eothasianisches Ritual, bei dem auch Glocken geläutet wurden. Das erste und letzte Läuten scheint von der 'Rechten Hand' zu stammen, die einen auffälligen, verzerrten Klang hat.</DefaultText>
+      <DefaultText>Innerhalb des Tempels habe ich eine Art Geist gesehen - oder zumindest eine Erinnerung. In dieser Erinnerung erlebte ich ein eothasisches Ritual, bei dem auch Glocken geläutet wurden. Das erste und letzte Läuten scheint von der 'Rechten Hand' zu stammen, die einen auffälligen, verzerrten Klang hat.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/10_od_nua/10_qst_master_below.stringtable
+++ b/text/quests/10_od_nua/10_qst_master_below.stringtable
@@ -68,7 +68,7 @@
       <ID>10000</ID>
       <DefaultText>Meine neue Burgvogtin hat mich darüber informiert, dass vor langer Zeit ein mächtiger Engwithaner ein labyrinthartiges Verlies unter Caed Nua angelegt hat, das jetzt als die Endlosen Pfade von Od Nua bekannt ist. 
 
-Od Nua wurde von den Leuten seiner Zeit für seine Taten umgebracht, aber die Burgvogtin schwört, dass es unterhalb der Ruinen immer noch eine starke Macht gibt. Jedes Mal, wenn jemand versucht, Caed Nua für sich zu beanspruchen, erwacht dieser 'Meister in der Tiefe' und schickt eine Horde Monster los, um dem entgegen zu wirken. Wenn ich mich nicht um diese böse Präsenz kümmere, könnte ich schließlich das Schicksal der Aedyraner erleiden, die versuchten, dieses Land vor langer Zeit zu beanspruchen.</DefaultText>
+Od Nua wurde von den Leuten seiner Zeit für seine Taten umgebracht, aber die Burgvogtin schwört, dass es unterhalb der Ruinen immer noch eine starke Macht gibt. Jedes Mal, wenn jemand versucht, Caed Nua für sich zu beanspruchen, erwacht dieser 'Meister in der Tiefe' und schickt eine Horde Monster los, um dem entgegen zu wirken. Wenn ich mich nicht um diese böse Präsenz kümmere, könnte ich schließlich das Schicksal der Aedyrer erleiden, die versuchten, dieses Land vor langer Zeit zu beanspruchen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -144,7 +144,7 @@ Dann wurde ich vom Geist Od Nuas konfrontiert, der sich aber nicht als der Meist
     </Entry>
     <Entry>
       <ID>20003</ID>
-      <DefaultText>Während ich die mit Trollen verseuchten Höhlen der vierten Ebene erkundete, fand ich das Tagebuch eines aedyranischen Abenteurers, in dem dieser die Entdeckung eines uralten engwithanischen Siegels beschrieb. Anscheinend gehörte dieses Siegel einem engwithanischen Aufseher in Diensten eines 'großen Meisters'. Bei diesem 'Meister' könnte es sich um Od Nua handeln, den Architekten, den meine Burgvogtin erwähnte.</DefaultText>
+      <DefaultText>Während ich die mit Trollen verseuchten Höhlen der vierten Ebene erkundete, fand ich das Tagebuch eines aedyrischen Abenteurers, in dem dieser die Entdeckung eines uralten engwithanischen Siegels beschrieb. Anscheinend gehörte dieses Siegel einem engwithanischen Aufseher in Diensten eines 'großen Meisters'. Bei diesem 'Meister' könnte es sich um Od Nua handeln, den Architekten, den meine Burgvogtin erwähnte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -164,7 +164,7 @@ Dann wurde ich vom Geist Od Nuas konfrontiert, der sich aber nicht als der Meist
     </Entry>
     <Entry>
       <ID>20007</ID>
-      <DefaultText>Als ich ein Xaurip-Lager erkundete, entdeckte ich eine rituelle Opferkammer. Darin fand ich eine verunstaltete aedyranische Statue, die zur Darstellung eines gesichtslosen Idols umfunktioniert und neu dekoriert worden war. Vielleicht ist diese mysteriöse Gottheit der Meister in der Tiefe, der von den Xaurips verehrt wird.</DefaultText>
+      <DefaultText>Als ich ein Xaurip-Lager erkundete, entdeckte ich eine rituelle Opferkammer. Darin fand ich eine verunstaltete aedyrische Statue, die zur Darstellung eines gesichtslosen Idols umfunktioniert und neu dekoriert worden war. Vielleicht ist diese mysteriöse Gottheit der Meister in der Tiefe, der von den Xaurips verehrt wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/10_od_nua/10_tsk_blade_paths.stringtable
+++ b/text/quests/10_od_nua/10_tsk_blade_paths.stringtable
@@ -61,7 +61,7 @@
     </Entry>
     <Entry>
       <ID>20003</ID>
-      <DefaultText>Ich habe das prunkvolle Heft eines Schwerts gefunden. Die Verzierungen scheinen aedyranischen Ursprungs und eindeutig wertvoll zu sein.</DefaultText>
+      <DefaultText>Ich habe das prunkvolle Heft eines Schwerts gefunden. Die Verzierungen scheinen aedyrischen Ursprungs und eindeutig wertvoll zu sein.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/11_twin_elms_hearthsong/11_qst_downwind_dyrwood.stringtable
+++ b/text/quests/11_twin_elms_hearthsong/11_qst_downwind_dyrwood.stringtable
@@ -16,17 +16,17 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Finde die dyrwäldliche Expedition beim Pilgerlager in der Wildnis der Nordlandschaft.</DefaultText>
+      <DefaultText>Finde die dyrwälderische Expedition beim Pilgerlager in der Wildnis der Nordlandschaft.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>Verfolge die dyrwäldliche Expedition bis zum östlichen Rand der Wildnis der Nordlandschaft.</DefaultText>
+      <DefaultText>Verfolge die dyrwälderische Expedition bis zum östlichen Rand der Wildnis der Nordlandschaft.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>Löse die Pattsituation zwischen der dyrwäldlichen Expedition und den Reißzähnen.</DefaultText>
+      <DefaultText>Löse die Pattsituation zwischen der dyrwälderischen Expedition und den Reißzähnen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -68,7 +68,7 @@
       <ID>10004</ID>
       <DefaultText>Ich habe die Expedition im Osten der Nordlandschaft entdeckt. Sie haben sich bei den Überresten eines alten engwithanischen Turms verschanzt, über der engen Schlucht des Waldes.
 
-Unzählige glanfathanische Reißzähne haben die Dyrwäldler umzingelt und warten auf den richtigen Augenblick für den Angriff.</DefaultText>
+Unzählige glanfathanische Reißzähne haben die Dyrwälder umzingelt und warten auf den richtigen Augenblick für den Angriff.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -78,7 +78,7 @@ Unzählige glanfathanische Reißzähne haben die Dyrwäldler umzingelt und warte
     </Entry>
     <Entry>
       <ID>10006</ID>
-      <DefaultText>Ich habe den Reißzähnen geholfen. Esmar, der Anführer der Expedition aus dyrwäldlichen Söldnern, ist nicht länger. Die Reißzähne warten in der Nordlandschaft auf meinen Bericht - südlich von der Stelle, an der ich mich um die Söldner gekümmert habe.</DefaultText>
+      <DefaultText>Ich habe den Reißzähnen geholfen. Esmar, der Anführer der Expedition aus dyrwälderischen Söldnern, ist nicht länger. Die Reißzähne warten in der Nordlandschaft auf meinen Bericht - südlich von der Stelle, an der ich mich um die Söldner gekümmert habe.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -88,17 +88,17 @@ Unzählige glanfathanische Reißzähne haben die Dyrwäldler umzingelt und warte
     </Entry>
     <Entry>
       <ID>20000</ID>
-      <DefaultText>Ich habe den Hauptmann der Expedition getroffen, Esmar, der sich in einer alten Ruine vor den Glanfathanern versteckt hat. Im Süden warten die Reißzähne, im Norden ein Rudel Stelgaer - die Dyrwäldler stecken in der Klemme. Würde man eines dieser Hindernisse entfernen, könnte die Expedition fliehen.</DefaultText>
+      <DefaultText>Ich habe den Hauptmann der Expedition getroffen, Esmar, der sich in einer alten Ruine vor den Glanfathanern versteckt hat. Im Süden warten die Reißzähne, im Norden ein Rudel Stelgaer - die Dyrwälder stecken in der Klemme. Würde man eines dieser Hindernisse entfernen, könnte die Expedition fliehen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>20001</ID>
-      <DefaultText>Ich bin einer Elfe begegnet, einer Jägerin der Reißzähne, Anführerin der Glanfathaner, die Cwineths Expedition verfolgen. Sie will, dass ich mich um die Dyrwäldler kümmere - als Beweis, dass ich ein Freund Eir Glanfaths bin, nicht einfach nur ein weiterer Plünderer aus dem Dyrwald.</DefaultText>
+      <DefaultText>Ich bin einer Elfe begegnet, einer Jägerin der Reißzähne, Anführerin der Glanfathaner, die Cwineths Expedition verfolgen. Sie will, dass ich mich um die Dyrwälder kümmere - als Beweis, dass ich ein Freund Eir Glanfaths bin, nicht einfach nur ein weiterer Plünderer aus dem Dyrwald.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>20002</ID>
-      <DefaultText>Ich habe die Reißzähne überzeugt, die Expedition gehen zu lassen - allerdings unter strengen Bedingungen. Esmar, Anführer der dyrwäldlichen Söldner, muss mit seinem Leben oder seiner Freiheit bezahlen, um seinen Gefährten sicheres Geleit aus glanfathanischen Landen zu verschaffen.</DefaultText>
+      <DefaultText>Ich habe die Reißzähne überzeugt, die Expedition gehen zu lassen - allerdings unter strengen Bedingungen. Esmar, Anführer der dyrwälderischen Söldner, muss mit seinem Leben oder seiner Freiheit bezahlen, um seinen Gefährten sicheres Geleit aus glanfathanischen Landen zu verschaffen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -113,7 +113,7 @@ Unzählige glanfathanische Reißzähne haben die Dyrwäldler umzingelt und warte
     </Entry>
     <Entry>
       <ID>30001</ID>
-      <DefaultText>Ich bin mit der Kunde über das Schicksal der dyrwäldlichen Expedition zu der Anführerin der Reißzähne zurückgekehrt. Ich habe das dumpfe Gefühl, sie hätte sich der Söldner lieber selbst entledigt, doch durch meine Dienste habe ich dennoch ihre Gunst gewonnen.</DefaultText>
+      <DefaultText>Ich bin mit der Kunde über das Schicksal der dyrwälderischen Expedition zu der Anführerin der Reißzähne zurückgekehrt. Ich habe das dumpfe Gefühl, sie hätte sich der Söldner lieber selbst entledigt, doch durch meine Dienste habe ich dennoch ihre Gunst gewonnen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/11_twin_elms_hearthsong/11_qst_hard_bargain.stringtable
+++ b/text/quests/11_twin_elms_hearthsong/11_qst_hard_bargain.stringtable
@@ -98,12 +98,12 @@ Die Glanfathaner sind aber auf anhaltenden Handel angewiesen und wollen eine dir
     </Entry>
     <Entry>
       <ID>30001</ID>
-      <DefaultText>Ich habe beschlossen, Alarhi dabei zu helfen, Rinatto loszuwerden - und habe den vailianischen Kaufmann konfrontiert. Er ist unter dem Druck zusammengebrochen und hat die glanfathanische Stadt überstürzt verlassen.</DefaultText>
+      <DefaultText>Ich habe beschlossen, Alarhî dabei zu helfen, Rinatto loszuwerden - und habe den vailianischen Kaufmann konfrontiert. Er ist unter dem Druck zusammengebrochen und hat die glanfathanische Stadt überstürzt verlassen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>30002</ID>
-      <DefaultText>Ich habe beschlossen, Alarhi zu helfen - und habe den vailianischen Kaufmann konfrontiert. Rinatto ist tot, er wird den Glanfathanern keinen Ärger mehr machen.</DefaultText>
+      <DefaultText>Ich habe beschlossen, Alarhî zu helfen - und habe den vailianischen Kaufmann konfrontiert. Rinatto ist tot, er wird den Glanfathanern keinen Ärger mehr machen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/companions/companion_qst_eder.stringtable
+++ b/text/quests/companions/companion_qst_eder.stringtable
@@ -66,7 +66,7 @@
     </Entry>
     <Entry>
       <ID>20000</ID>
-      <DefaultText>Der Archivar weigerte sich, uns die Aufzeichnungen vom Krieg des Heiligen zu zeigen, was er mit Bedenken über rachsüchtige Dyrwäldler begründete, die Jagd auf readceranische Flüchtlinge machen. Er sagte, dass es sich anders verhalten würde, wenn ich in der Stadt einen besseren Ruf hätte.</DefaultText>
+      <DefaultText>Der Archivar weigerte sich, uns die Aufzeichnungen vom Krieg des Heiligen zu zeigen, was er mit Bedenken über rachsüchtige Dyrwälder begründete, die Jagd auf readceranische Flüchtlinge machen. Er sagte, dass es sich anders verhalten würde, wenn ich in der Stadt einen besseren Ruf hätte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/critical_path/act_4/cp_qst_confront_lka.stringtable
+++ b/text/quests/critical_path/act_4/cp_qst_confront_lka.stringtable
@@ -38,7 +38,7 @@ Gleich, ob das geschieht oder nicht - wir scheinen noch eine Rechnung offen zu h
     </Entry>
     <Entry>
       <ID>30000</ID>
-      <DefaultText>Ich habe die engwithanische Maschine erreicht, die ich in meinen Träumen gesehen habe. Tausende von dyrwäldischen Seelen wurden in sie gezogen. Thaos kann nicht weit sein.</DefaultText>
+      <DefaultText>Ich habe die engwithanische Maschine erreicht, die ich in meinen Träumen gesehen habe. Tausende von dyrwälderischen Seelen wurden in sie gezogen. Thaos kann nicht weit sein.</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/quests/critical_path/act_4/cp_qst_enter_breith_eaman.stringtable
+++ b/text/quests/critical_path/act_4/cp_qst_enter_breith_eaman.stringtable
@@ -50,7 +50,7 @@ Meine halluzinierten Erinnerungen werden nun immer häufiger. Ich kann sie kaum 
     </Entry>
     <Entry>
       <ID>20000</ID>
-      <DefaultText>Dorvahl, Wächter und Fährmann von Altlied, hat mir gesagt, dass die Grabinsel sich von allen anderen Bezirken von Zwillingsulmen unterscheidet. Die Insel ist ein Friedhof für die Anamfaths der Sechs Stämme - und ein gefährlicher Ort.</DefaultText>
+      <DefaultText>Dorvhal, Wächter und Fährmann von Altlied, hat mir gesagt, dass die Grabinsel sich von allen anderen Bezirken von Zwillingsulmen unterscheidet. Die Insel ist ein Friedhof für die Anamfaths der Sechs Stämme - und ein gefährlicher Ort.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Und _boom_ - da hätten wir:
- (Eir) Glanfath
  - Glanfathaner
  - glanfathanisch

Glanfathen wurde im Forum auch erwähnt... ich würds erstmal bei Glanfathaner belassen; nicht weils besser klingt, sondern weil so weniger geändert werden muss.
- Dyrwald
  - Dyrwälder
  - dyrwälderisch
- Aedyr
  - Aedyrer
  - aedyrisch
- Eothas
  - Eothasier
  - eothasisch

Außerdem:
- Vereinheitlichte Schreibweise von vielen anderen Charakter- und Ortsbezeichnung (Mehrzahl gewinnt), bzw. Beseitigung von Typos
