### PR TITLE
map upd.

### DIFF
--- a/text/conversations/01_defiance_bay_copperlane/01_cv_merchant_peregund.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_merchant_peregund.stringtable
@@ -48,7 +48,7 @@
     </Entry>
     <Entry>
       <ID>39</ID>
-      <DefaultText>Die Orlanerin springt auf und ab, als du dich näherst. "Kennst du mich noch? Wir sind uns bei der Madhmr-Brücke begegnet."
+      <DefaultText>Die Orlanerin springt auf und ab, als du dich näherst. "Kennst du mich noch? Wir sind uns bei der Madhmrbrücke begegnet."
 
 Sie schlägt dir freundschaftlich auf die Schulter. "Danke, dass du mir damals geholfen hast. Wie versprochen mache ich dir die besten Preise in der Stadt. Ohne dich wäre ich immer noch pleite!"</DefaultText>
       <FemaleText />

--- a/text/conversations/06_stronghold/06_cv_warden.stringtable
+++ b/text/conversations/06_stronghold/06_cv_warden.stringtable
@@ -140,7 +140,7 @@
     </Entry>
     <Entry>
       <ID>27</ID>
-      <DefaultText>"Das hier wird nicht leicht. Galen Dalgard, der Sklaventreiber. Er wurde mit seinen Freunden bei der Madhmr-Brücke gesehen. Die örtlichen Behörden weigern sich, gegen ihn vorzugehen, weil er mächtige Freunde in Aedyr hat. Aber irgendeine namenlose Seele, ist bereit, Geld dafür zu bezahlen, dass Galen seinen letzten Atemzug tut. Es ist offenbar etwas Persönliches."</DefaultText>
+      <DefaultText>"Das hier wird nicht leicht. Galen Dalgard, der Sklaventreiber. Er wurde mit seinen Freunden bei der Madhmrbrücke gesehen. Die örtlichen Behörden weigern sich, gegen ihn vorzugehen, weil er mächtige Freunde in Aedyr hat. Aber irgendeine namenlose Seele, ist bereit, Geld dafür zu bezahlen, dass Galen seinen letzten Atemzug tut. Es ist offenbar etwas Persönliches."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_cv_warden.stringtable
+++ b/text/conversations/06_stronghold/06_cv_warden.stringtable
@@ -172,7 +172,7 @@
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>"Nun, einer ihrer Exarchen, dieser Sserkal, ist mit einigen seiner Verwandten am Perlholz-Steilufer aufgetaucht. Dieses Angebot ist nicht unterschrieben - aber irgendjemand will ihn offenbar nicht dort haben."</DefaultText>
+      <DefaultText>"Nun, einer ihrer Exarchen, dieser Sserkal, ist mit einigen seiner Verwandten an der Perlholzklippe aufgetaucht. Dieses Angebot ist nicht unterschrieben - aber irgendjemand will ihn offenbar nicht dort haben."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_calisca_background.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_calisca_background.stringtable
@@ -825,7 +825,7 @@ Mit einem unbehaglichen Zittern in der Stimme fügt sie hinzu: "Ich muss meine S
     </Entry>
     <Entry>
       <ID>162</ID>
-      <DefaultText>"Ich hatte eine Affäre mit einer Schüler, und dann wurde ich von dem Schüler UND meinem Ehemann sitzengelassen."</DefaultText>
+      <DefaultText>"Ich hatte eine Affäre mit einem Schüler, und dann wurde ich von dem Schüler UND meinem Ehemann sitzengelassen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_peregund.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_peregund.stringtable
@@ -13,7 +13,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Solltest du darauf warten, dass die Madhmr-Brücke repariert wird, wirst du eine sehr lange Zeit hier verbringen. Ein Übergang ist hier nicht möglich."</DefaultText>
+      <DefaultText>"Solltest du darauf warten, dass die Madhmrbrücke repariert wird, wirst du eine sehr lange Zeit hier verbringen. Ein Übergang ist hier nicht möglich."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -25,7 +25,7 @@ Die Orlanerin verschränkt die Arme, während sich ein Stirnrunzeln auf ihrem Ge
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>"Die Madhmr-Brücke war die direkteste Route von Goldtal nach Trutzbucht. Händler und Reisende müssen jetzt mit Booten übersetzen oder einen mehrtägigen Umweg um die Bucht herum einplanen."</DefaultText>
+      <DefaultText>"Die Madhmrbrücke war die direkteste Route von Goldtal nach Trutzbucht. Händler und Reisende müssen jetzt mit Booten übersetzen oder einen mehrtägigen Umweg um die Bucht herum einplanen."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/08_wilderness/08_cv_foelmar.stringtable
+++ b/text/conversations/08_wilderness/08_cv_foelmar.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>"Du brauchst nicht zufällig Vorräte? Ich wollte eigentlich zur Madhmr-Brücke, aber vielleicht ist es besser, ich gehe zurück in die Stadt und versammle noch einige Leute."</DefaultText>
+      <DefaultText>"Du brauchst nicht zufällig Vorräte? Ich wollte eigentlich zur Madhmrbrücke, aber vielleicht ist es besser, ich gehe zurück in die Stadt und versammle noch einige Leute."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/12_oldsong/12_cv_casfath_onwen.stringtable
+++ b/text/conversations/12_oldsong/12_cv_casfath_onwen.stringtable
@@ -168,7 +168,7 @@ Sie tritt einen Schritt zurück und mustert dich eingehend. "Ehrlich gesagt hatt
     </Entry>
     <Entry>
       <ID>38</ID>
-      <DefaultText>Sie grinst spöttisch. "Und wenn er dir sagte, du könntest von der Madhmr-Brücke springen und dir würden Flügel wachsen, würdest du das auch glauben?"
+      <DefaultText>Sie grinst spöttisch. "Und wenn er dir sagte, du könntest von der Madhmrbrücke springen und dir würden Flügel wachsen, würdest du das auch glauben?"
 
 "Es ist ein törichter Aberglaube, mehr nicht. Die Königin der Vögel segnet uns mit ihren Begleitern, damit wir ihrem Gesang lauschen, nicht, damit wir ihr Fleisch essen."</DefaultText>
       <FemaleText />

--- a/text/conversations/prototype_2/p2_cv_hendyna.stringtable
+++ b/text/conversations/prototype_2/p2_cv_hendyna.stringtable
@@ -60,7 +60,7 @@ Sie grinst schmerzhaft. "Gerade erst angekommen? Ich wollte gerade einen Teil me
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>Als der Rest der Geschichte aus ihr herausgesprudelt kommt, zuckt Hendyna zusammen. "Ich hatte ein Jungdrachennest östlich der Ortschaft beobachtet, bei der Dyrfurt-Flusskreuzung. Das Biest blieb gerade lange genug, um einen Haufen Eier zu legen, und zog dann weiter. Der Himmelsmutter sei Dank, dass es kein ausgewachsener Drache war."</DefaultText>
+      <DefaultText>Als der Rest der Geschichte aus ihr herausgesprudelt kommt, zuckt Hendyna zusammen. "Ich hatte ein Jungdrachennest östlich der Ortschaft beobachtet, bei der Dyrfurter Flusskreuzung. Das Biest blieb gerade lange genug, um einen Haufen Eier zu legen, und zog dann weiter. Der Himmelsmutter sei Dank, dass es kein ausgewachsener Drache war."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -194,7 +194,7 @@ Sie beugt sich näher zu dir heran. "Und komm immer bei mir vorbei, wenn du Trä
     </Entry>
     <Entry>
       <ID>65</ID>
-      <DefaultText>"Ich hatte ein Jungdrachennest östlich der Ortschaft beobachtet, bei der Dyrfurt-Flusskreuzung. Das Biest blieb gerade lange genug, um einen Haufen Eier zu legen, und zog dann weiter. Der Himmelsmutter sei Dank, dass es kein ausgewachsener Drache war."</DefaultText>
+      <DefaultText>"Ich hatte ein Jungdrachennest östlich der Ortschaft beobachtet, bei der Dyrfurter Flusskreuzung. Das Biest blieb gerade lange genug, um einen Haufen Eier zu legen, und zog dann weiter. Der Himmelsmutter sei Dank, dass es kein ausgewachsener Drache war."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -340,7 +340,7 @@ Sie beugt sich näher zu dir heran. "Und komm immer bei mir vorbei, wenn du Trä
     </Entry>
     <Entry>
       <ID>97</ID>
-      <DefaultText>"Es befindet sich in einem Nest auf einer Klippe am östlichen Ende der Dyrfurt-Flusskreuzung. In der Wildnis ein Stück östlich hier. Es gibt sicher anderswo noch mehr, aber das bei der Dyrfurt-Flusskreuzung ist genau im richtigen Alter."
+      <DefaultText>"Es befindet sich in einem Nest auf einer Klippe am östlichen Ende der Dyrfurter Flusskreuzung. In der Wildnis ein Stück östlich hier. Es gibt sicher anderswo noch mehr, aber das bei der Dyrfurter Flusskreuzung ist genau im richtigen Alter."
 
 "Wenn du hingehst, sei vorsichtig. Als ich das letzte Mal dort war, wimmelte es von Lindwürmern, und ich nehme an, dass sie noch dort sind."</DefaultText>
       <FemaleText />

--- a/text/game/gui.stringtable
+++ b/text/game/gui.stringtable
@@ -5135,7 +5135,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1018</ID>
-      <DefaultText>Madhmr-Brücke</DefaultText>
+      <DefaultText>Madhmrbrücke</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7115,7 +7115,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1416</ID>
-      <DefaultText>Madhmr-Brücke</DefaultText>
+      <DefaultText>Madhmrbrücke</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/items.stringtable
+++ b/text/game/items.stringtable
@@ -9366,7 +9366,7 @@ MÄNNLICH: Das Urteil ist endgültig. Die Entscheidung ist gefallen. (Er wendet 
     </Entry>
     <Entry>
       <ID>1652</ID>
-      <DefaultText>Dieser Leinensack enthält den Kopf von Sserkal, dem Vithrack, den du am Perlholz-Steilufer besiegt hast.</DefaultText>
+      <DefaultText>Dieser Leinensack enthält den Kopf von Sserkal, dem Vithrack, den du an der Perlholzklippe besiegt hast.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/maps.stringtable
+++ b/text/game/maps.stringtable
@@ -16,7 +16,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Dyrfurt-Flusskreuzung</DefaultText>
+      <DefaultText>Dyrfurter Flusskreuzung</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -156,12 +156,12 @@
     </Entry>
     <Entry>
       <ID>30</ID>
-      <DefaultText>Waldend-Ebenen</DefaultText>
+      <DefaultText>Waldend Ebenen</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>31</ID>
-      <DefaultText>Perlholz-Steilufer</DefaultText>
+      <DefaultText>Perlholz Steilufer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -176,7 +176,7 @@
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>Madhmrbrücke</DefaultText>
+      <DefaultText>Madhmr Brücke</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/maps.stringtable
+++ b/text/game/maps.stringtable
@@ -156,12 +156,12 @@
     </Entry>
     <Entry>
       <ID>30</ID>
-      <DefaultText>Waldend Ebenen</DefaultText>
+      <DefaultText>Waldend-Ebenen</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>31</ID>
-      <DefaultText>Perlholz Steilufer</DefaultText>
+      <DefaultText>Perlholz-Steilufer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -176,7 +176,7 @@
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>Madhmr Brücke</DefaultText>
+      <DefaultText>Madhmrbrücke</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -191,7 +191,7 @@
     </Entry>
     <Entry>
       <ID>37</ID>
-      <DefaultText>Aedelwan Brücke</DefaultText>
+      <DefaultText>Aedelwan-brücke</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/maps.stringtable
+++ b/text/game/maps.stringtable
@@ -161,7 +161,7 @@
     </Entry>
     <Entry>
       <ID>31</ID>
-      <DefaultText>Perlholz-Steilufer</DefaultText>
+      <DefaultText>Perlholzklippe</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/maps.stringtable
+++ b/text/game/maps.stringtable
@@ -191,7 +191,7 @@
     </Entry>
     <Entry>
       <ID>37</ID>
-      <DefaultText>Aedelwanbrücke</DefaultText>
+      <DefaultText>Aedelwan Brücke</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/00_dyrford_hendyna.stringtable
+++ b/text/quests/00_dyrford_hendyna.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Beschaffe ein Drachenei von der Dyrfurt-Flusskreuzung.</DefaultText>
+      <DefaultText>Beschaffe ein Drachenei von der Dyrfurter Flusskreuzung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/02_defiance_bay_first_fires/02_qst_vailan_embassy.stringtable
+++ b/text/quests/02_defiance_bay_first_fires/02_qst_vailan_embassy.stringtable
@@ -11,12 +11,12 @@
     </Entry>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Geh zur Aedelwan-Brücke.</DefaultText>
+      <DefaultText>Geh zur Aedelwanbrücke.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Gib dich an der Aedelwan-Brücke als Mestre Barcozzis Käufer aus.</DefaultText>
+      <DefaultText>Gib dich an der Aedelwanbrücke als Mestre Barcozzis Käufer aus.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>10001</ID>
-      <DefaultText>Die Vergessenen warten an der Aedelwan-Brücke auf Mestre Barcozzis Käufer. Agosti will, dass ich mich als der Käufer ausgebe, um Einzelheiten darüber zu erfahren, wie die Vergessenen engwithanische Relikte schmuggeln.</DefaultText>
+      <DefaultText>Die Vergessenen warten an der Aedelwanbrücke auf Mestre Barcozzis Käufer. Agosti will, dass ich mich als der Käufer ausgebe, um Einzelheiten darüber zu erfahren, wie die Vergessenen engwithanische Relikte schmuggeln.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -46,7 +46,7 @@
     </Entry>
     <Entry>
       <ID>10003</ID>
-      <DefaultText>Die Vergessenen werden nicht zulassen, dass ich die Aedelwan-Brücke lebend verlasse. Ich muss sie alle töten, bevor sie mich töten.</DefaultText>
+      <DefaultText>Die Vergessenen werden nicht zulassen, dass ich die Aedelwanbrücke lebend verlasse. Ich muss sie alle töten, bevor sie mich töten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/06_stronghold/06_tsk_boss_paladin.stringtable
+++ b/text/quests/06_stronghold/06_tsk_boss_paladin.stringtable
@@ -21,12 +21,12 @@
     </Entry>
     <Entry>
       <ID>10000</ID>
-      <DefaultText>Der aedyrische Sklaventreiber Galen Dalgard wurde bei der Madhmr-Brücke gesehen. Es wurde ein Kopfgeld auf ihn ausgesetzt.</DefaultText>
+      <DefaultText>Der aedyrische Sklaventreiber Galen Dalgard wurde bei der Madhmrbrücke gesehen. Es wurde ein Kopfgeld auf ihn ausgesetzt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>10001</ID>
-      <DefaultText>Es wurde ein Kopfgeld auf den berüchtigten Sklaventreiber Galen Dalgard ausgesetzt. Fyrgen sagte, man könne ihn vielleicht bei der Madhmr-Brücke finden. Ich muss ihn töten und seinen Kopf als Beweis mitbringen, um das Kopfgeld zu erhalten.</DefaultText>
+      <DefaultText>Es wurde ein Kopfgeld auf den berüchtigten Sklaventreiber Galen Dalgard ausgesetzt. Fyrgen sagte, man könne ihn vielleicht bei der Madhmrbrücke finden. Ich muss ihn töten und seinen Kopf als Beweis mitbringen, um das Kopfgeld zu erhalten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/06_stronghold/06_tsk_boss_vithrack.stringtable
+++ b/text/quests/06_stronghold/06_tsk_boss_vithrack.stringtable
@@ -21,12 +21,12 @@
     </Entry>
     <Entry>
       <ID>10000</ID>
-      <DefaultText>Ein Vithrack-Exarch wurde beim Perlholz-Steilufer gesehen - und es ist ein Kopfgeld auf ihn ausgesetzt.</DefaultText>
+      <DefaultText>Ein Vithrack-Exarch wurde bei der Perlholzklippe gesehen - und es ist ein Kopfgeld auf ihn ausgesetzt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>10001</ID>
-      <DefaultText>Sserkal ist ein mächtiger Vithrack-Exarch, der mit seinen Verwandten beim Perlholz-Steilufer gesehen wurde. Ihre Anwesenheit macht die Einheimischen nervös, weshalb sie ein Kopfgeld auf ihn ausgesetzt haben. Ich muss seinen Kopf bringen, um die Belohnung zu erhalten.</DefaultText>
+      <DefaultText>Sserkal ist ein mächtiger Vithrack-Exarch, der mit seinen Verwandten bei der Perlholzklippe gesehen wurde. Ihre Anwesenheit macht die Einheimischen nervös, weshalb sie ein Kopfgeld auf ihn ausgesetzt haben. Ich muss seinen Kopf bringen, um die Belohnung zu erhalten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/07_gilded_vale/07_tsk_ferry_flotsam.stringtable
+++ b/text/quests/07_gilded_vale/07_tsk_ferry_flotsam.stringtable
@@ -21,14 +21,14 @@
     </Entry>
     <Entry>
       <ID>10000</ID>
-      <DefaultText>Nicht weit entfernt von der ruinierten Madhmr-Brücke traf ich eine Händlerin namens Peregund. Sie besaß eine Fähre, mit der sie den Fluss überquerte, aber das Schiff wurde von einem Sturm zerschmettert.
+      <DefaultText>Nicht weit entfernt von der ruinierten Madhmrbrücke traf ich eine Händlerin namens Peregund. Sie besaß eine Fähre, mit der sie den Fluss überquerte, aber das Schiff wurde von einem Sturm zerschmettert.
 
 Peregund möchte, dass ich ihr bei der Bergung ihrer Güter aus dem Wrack der Fähre helfe. Plünderer versuchen, die Ladung für sich selbst zu beanspruchen, und die unbewaffnete Peregund kann sich ihre Vorräte nicht alleine zurückholen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>10001</ID>
-      <DefaultText>Ich sollte die Gegend direkt flussabwärts von der Madhmr-Brücke untersuchen und nach dem Wrack der Fähre suchen.</DefaultText>
+      <DefaultText>Ich sollte die Gegend direkt flussabwärts von der Madhmrbrücke untersuchen und nach dem Wrack der Fähre suchen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/quests/companions/companion_qst_sagani.stringtable
+++ b/text/quests/companions/companion_qst_sagani.stringtable
@@ -40,7 +40,7 @@ Wenn Sagani mit mir unterwegs ist, ermöglichen mir meine einzigartigen Fähigke
     </Entry>
     <Entry>
       <ID>10002</ID>
-      <DefaultText>Als wir das Perlholz-Steilufer erreichten, war Persoq bereits aufgebrochen, aber ich sah eine andere Vision ... und dieses Mal befand er sich tief im Wald und rannte auf einen Adra-Bogen zu.</DefaultText>
+      <DefaultText>Als wir die Perlholzklippe erreichten, war Persoq bereits aufgebrochen, aber ich sah eine andere Vision ... und dieses Mal befand er sich tief im Wald und rannte auf einen Adra-Bogen zu.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -100,7 +100,7 @@ Wenn Sagani mit mir unterwegs ist, ermöglichen mir meine einzigartigen Fähigke
     </Entry>
     <Entry>
       <ID>20010</ID>
-      <DefaultText>Ich bin zum Perlholz-Steilufer gekommen, was mich an die Vision erinnert, die ich von Persoq hatte. Ich werde meine Augen nach Spuren von ihm offenhalten.</DefaultText>
+      <DefaultText>Ich bin zur Perlholzklippe gekommen, was mich an die Vision erinnert, die ich von Persoq hatte. Ich werde meine Augen nach Spuren von ihm offenhalten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
[siehe Forum](http://forums.obsidian.net/topic/71899-translation-errors-missing-translations-german/page-38#entry1689598)

Ich schätze mal das der Fehler mit dem abgehacktem Wort erst seit 1.05 auftaucht, vorher gab es dahingehend ja keine Beschwerden und die Änderungen sind seit dem 4. April drin (#47)
