### PR TITLE
fixing word joiner

### DIFF
--- a/text/game/cyclopedia.stringtable
+++ b/text/game/cyclopedia.stringtable
@@ -273,7 +273,7 @@ Lauerer sind dafür berüchtigt, sich in voller Sicht zu verstecken. Oft warten 
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwälderischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
+      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#x2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwälderischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -483,7 +483,7 @@ Xaurips verehren Drachen als Gottheiten und errichten ihre Gemeinden um die Nest
     </Entry>
     <Entry>
       <ID>84</ID>
-      <DefaultText>Die Genauigkeit spielt bei fast jedem Angriff eine Rolle. Sie beeinflusst, wie wahrscheinlich es ist, dass der Angriff eine Wirkung auf das Ziel hat. Genauigkeit wird hauptsächlich durch die Klasse und die Stufe eines Charakters festgelegt, wird aber auch durch Talente und andere aktive Effekte wie Zauber oder Gegenstände beeinflusst. Wird ein Angriff unternommen, wird die Genauigkeit mit der jeweiligen Verteidigung des Ziels verglichen, um festzustellen, wie der Angriffswurf modifiziert wird. Liegt die Genauigkeit über der Verteidigung des Ziels, erhöht sich die Wahrscheinlichkeit von T&#2060;reffer&#2060;n oder Kritischen Treffer&#2060;n und die Wahrscheinlichkeit von Leichten Treffer&#2060;n oder Fehlschläge&#2060;n sinkt.
+      <DefaultText>Die Genauigkeit spielt bei fast jedem Angriff eine Rolle. Sie beeinflusst, wie wahrscheinlich es ist, dass der Angriff eine Wirkung auf das Ziel hat. Genauigkeit wird hauptsächlich durch die Klasse und die Stufe eines Charakters festgelegt, wird aber auch durch Talente und andere aktive Effekte wie Zauber oder Gegenstände beeinflusst. Wird ein Angriff unternommen, wird die Genauigkeit mit der jeweiligen Verteidigung des Ziels verglichen, um festzustellen, wie der Angriffswurf modifiziert wird. Liegt die Genauigkeit über der Verteidigung des Ziels, erhöht sich die Wahrscheinlichkeit von T&#x2060;reffer&#x2060;n oder Kritischen Treffer&#x2060;n und die Wahrscheinlichkeit von Leichten Treffer&#x2060;n oder Fehlschläge&#x2060;n sinkt.
 Fähigkeiten oder Talente, die keine Waffen als Teil des Angriffs einsetzen, werden mit einem kleinen Genauigkeitsbonus verstärkt, der auf der Stufe des Charakters basiert.</DefaultText>
       <FemaleText />
     </Entry>
@@ -525,7 +525,7 @@ Fähigkeiten oder Talente, die keine Waffen als Teil des Angriffs einsetzen, wer
     </Entry>
     <Entry>
       <ID>92</ID>
-      <DefaultText>Mit seinem Wille&#2060;n widersetzt sich ein Charakter mentalen Angriffen (z.B. einem Zauber, der das Ziel mental lähmt). Er wird durch die Klasse des Charakters, seine Stufe, seinen Intellekt und seine Entschlossenheit definiert, kann aber auch durch andere Effekte beeinflusst werden.</DefaultText>
+      <DefaultText>Mit seinem Wille&#x2060;n widersetzt sich ein Charakter mentalen Angriffen (z.B. einem Zauber, der das Ziel mental lähmt). Er wird durch die Klasse des Charakters, seine Stufe, seinen Intellekt und seine Entschlossenheit definiert, kann aber auch durch andere Effekte beeinflusst werden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -705,7 +705,7 @@ Fähigkeiten oder Talente, die keine Waffen als Teil des Angriffs einsetzen, wer
     </Entry>
     <Entry>
       <ID>128</ID>
-      <DefaultText>Gehirnerschütterungen belegen den Intellekt sowie den Wille&#2060;n des Charakters mit einem Malus.</DefaultText>
+      <DefaultText>Gehirnerschütterungen belegen den Intellekt sowie den Wille&#x2060;n des Charakters mit einem Malus.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -780,7 +780,7 @@ Fähigkeiten oder Talente, die keine Waffen als Teil des Angriffs einsetzen, wer
     </Entry>
     <Entry>
       <ID>143</ID>
-      <DefaultText>T&#2060;reffer</DefaultText>
+      <DefaultText>T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -847,7 +847,7 @@ Einige Kreaturen können manchen Wirkungen gegenüber immun sein. In diesem Fall
       <ID>154</ID>
       <DefaultText>Alle Angriffe in Pillars of Eternity vergleichen den Genauigkeitswert des Angreifers mit einer von vier Verteidigungen des Ziels: Abwehr (direkte Nah- und Fernkampfangriffe), Tapferkeit (Angriffe gegen das Immunsystem wie Gift oder Krankheit), Reflexe (Wirkungsbereichangriffe) und Wille (mentale Angriffe). 
 
-Es wird eine Zahl zwischen 1 und 100 generiert und zu der Differenz zwischen Genauigkeit und Verteidigung addiert, um das Ergebnis des Angriffs zu berechnen. Bis 15 = Fehlschläge, 16 - 50 = Leichte Treffer, 51-100 = T&#2060;reffer, ab 100 = Kritische Treffer. 
+Es wird eine Zahl zwischen 1 und 100 generiert und zu der Differenz zwischen Genauigkeit und Verteidigung addiert, um das Ergebnis des Angriffs zu berechnen. Bis 15 = Fehlschläge, 16 - 50 = Leichte Treffer, 51-100 = T&#x2060;reffer, ab 100 = Kritische Treffer. 
 
 In einem ausgeglichenen Angriff-/Verteidigung-Szenario werden die meisten Angriffe Treffer oder Leichte Treffer sein. Wenn die Genauigkeit über der Verteidigung liegt, ist die Wahrscheinlichkeit von Kritischen Treffern höher. Wenn die Verteidigung über der Genauigkeit liegt, ist die Wahrscheinlichkeit von Fehlschlägen höher.</DefaultText>
       <FemaleText />
@@ -1362,7 +1362,7 @@ Das bedeutet, dass alle Statistiken der Waffen weiter gelten, insbesondere der S
     </Entry>
     <Entry>
       <ID>250</ID>
-      <DefaultText>Eine Handelsmacht und die ehemalige Kolonie einer größeren, älteren Nation, Alt-Vailia. Die Republiken liegen südlich des Dyrwalds und Eir&#160;Glanfath&#2060;s und werden von einem Duc regiert, der vom "Consuagli Asegia" gewählt wird, einem Rat aus 14 Ducs, darunter auch die fünf mächtigsten, die "Ducs Bels".</DefaultText>
+      <DefaultText>Eine Handelsmacht und die ehemalige Kolonie einer größeren, älteren Nation, Alt-Vailia. Die Republiken liegen südlich des Dyrwalds und Eir&#160;Glanfath&#x2060;s und werden von einem Duc regiert, der vom "Consuagli Asegia" gewählt wird, einem Rat aus 14 Ducs, darunter auch die fünf mächtigsten, die "Ducs Bels".</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/gui.stringtable
+++ b/text/game/gui.stringtable
@@ -621,7 +621,7 @@
     </Entry>
     <Entry>
       <ID>123</ID>
-      <DefaultText>{2} fügt {0} {1}&#2060;schaden zu.</DefaultText>
+      <DefaultText>{2} fügt {0} {1}&#x2060;schaden zu.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1651,7 +1651,7 @@
     </Entry>
     <Entry>
       <ID>330</ID>
-      <DefaultText>T&#2060;reffer</DefaultText>
+      <DefaultText>T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2475,7 +2475,7 @@ Silberflut - In jeder Begegnung generieren Mond-Gottähnliche, wenn sie auf unte
       <ID>492</ID>
       <DefaultText>Sesshafte Orlaner sind in Readceras und in den Vailianischen Republiken oftmals Sklaven. Eine der Vertragsbedingungen zwischen dem Dyrwald und dem Volk aus Eir&#160;Glanfath war die Befreiung der orlanischen Sklaven, und obwohl diese eingehalten wurde, leben im Dyrwald noch immer viele sesshafte Orlaner als Schuldknechte.
 
-Geringe Bedrohung - Greift ein sesshafter Orlaner ein Ziel an, das von einem Gruppenmitglied ebenfalls als Ziel ausgewählt worden ist, verwandelt der sesshafte Orlaner einen Teil seiner T&#2060;reffer in Kritische Treffer.</DefaultText>
+Geringe Bedrohung - Greift ein sesshafter Orlaner ein Ziel an, das von einem Gruppenmitglied ebenfalls als Ziel ausgewählt worden ist, verwandelt der sesshafte Orlaner einen Teil seiner T&#x2060;reffer in Kritische Treffer.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3640,7 +3640,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>717</ID>
-      <DefaultText>Meiste T&#2060;reffer</DefaultText>
+      <DefaultText>Meiste T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -3885,7 +3885,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>766</ID>
-      <DefaultText>T&#2060;reffer</DefaultText>
+      <DefaultText>T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -4120,7 +4120,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>813</ID>
-      <DefaultText>T&#2060;reffer</DefaultText>
+      <DefaultText>T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5170,7 +5170,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1025</ID>
-      <DefaultText>Verursacht bei T&#2060;reffer {0}.</DefaultText>
+      <DefaultText>Verursacht bei T&#x2060;reffer {0}.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5575,12 +5575,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1106</ID>
-      <DefaultText>{0} Nahkampf&#2060;genauigkeit</DefaultText>
+      <DefaultText>{0} Nahkampf&#x2060;genauigkeit</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1107</ID>
-      <DefaultText>{0} Fernkampf&#2060;genauigkeit</DefaultText>
+      <DefaultText>{0} Fernkampf&#x2060;genauigkeit</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5620,7 +5620,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1115</ID>
-      <DefaultText>{0} {1}&#2060;schaden</DefaultText>
+      <DefaultText>{0} {1}&#x2060;schaden</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5680,7 +5680,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1127</ID>
-      <DefaultText>{0} {1}&#2060;schaden</DefaultText>
+      <DefaultText>{0} {1}&#x2060;schaden</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5710,12 +5710,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1133</ID>
-      <DefaultText>{0} {1}&#2060;schaden pro Wunde</DefaultText>
+      <DefaultText>{0} {1}&#x2060;schaden pro Wunde</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1134</ID>
-      <DefaultText>{0} Rüstungs&#2060;schadensreduktion</DefaultText>
+      <DefaultText>{0} Rüstungs&#x2060;schadensreduktion</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5725,7 +5725,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1136</ID>
-      <DefaultText>{0} Chance auf Betäubung bei T&#2060;reffer</DefaultText>
+      <DefaultText>{0} Chance auf Betäubung bei T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5735,7 +5735,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1138</ID>
-      <DefaultText>{0} Chance auf Verkrüppelung bei T&#2060;reffer</DefaultText>
+      <DefaultText>{0} Chance auf Verkrüppelung bei T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5750,7 +5750,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1141</ID>
-      <DefaultText>{0} Nahkampf&#2060;schaden</DefaultText>
+      <DefaultText>{0} Nahkampf&#x2060;schaden</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5770,7 +5770,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1145</ID>
-      <DefaultText>{0} Konzentration bei T&#2060;reffer</DefaultText>
+      <DefaultText>{0} Konzentration bei T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5900,7 +5900,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1171</ID>
-      <DefaultText>{0} T&#2060;reffer umgewandelt in Kritische Treffer, wenn das gleiche Ziel eines Verbündeten angegriffen wird</DefaultText>
+      <DefaultText>{0} T&#x2060;reffer umgewandelt in Kritische Treffer, wenn das gleiche Ziel eines Verbündeten angegriffen wird</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5910,7 +5910,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1173</ID>
-      <DefaultText>{0} erlittene Kritische Treffer umgewandelt in T&#2060;reffer</DefaultText>
+      <DefaultText>{0} erlittene Kritische Treffer umgewandelt in T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -5920,12 +5920,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1175</ID>
-      <DefaultText>{0} erlittener T&#2060;reffer umgewandelt in Leichte Treffer (nur Abwehr und Reflexe)</DefaultText>
+      <DefaultText>{0} erlittener T&#x2060;reffer umgewandelt in Leichte Treffer (nur Abwehr und Reflexe)</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1176</ID>
-      <DefaultText>{0} erlittener T&#2060;reffer umgewandelt in Leichte Treffer (nur Tapferkeit und Wille)</DefaultText>
+      <DefaultText>{0} erlittener T&#x2060;reffer umgewandelt in Leichte Treffer (nur Tapferkeit und Wille)</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6050,7 +6050,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1201</ID>
-      <DefaultText>{0} Leichte Treffer umgewandelt in T&#2060;reffer</DefaultText>
+      <DefaultText>{0} Leichte Treffer umgewandelt in T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6065,7 +6065,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1204</ID>
-      <DefaultText>{0} Kritische Treffer umgewandelt in T&#2060;reffer</DefaultText>
+      <DefaultText>{0} Kritische Treffer umgewandelt in T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6075,12 +6075,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1206</ID>
-      <DefaultText>{0} T&#2060;reffer umgewandelt in Kritische Treffer</DefaultText>
+      <DefaultText>{0} T&#x2060;reffer umgewandelt in Kritische Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1207</ID>
-      <DefaultText>{0} T&#2060;reffer umgewandelt in Leichte Treffer</DefaultText>
+      <DefaultText>{0} T&#x2060;reffer umgewandelt in Leichte Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6095,12 +6095,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1210</ID>
-      <DefaultText>{0} Nahkampf&#2060;schaden</DefaultText>
+      <DefaultText>{0} Nahkampf&#x2060;schaden</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1211</ID>
-      <DefaultText>{0} Fernkampf&#2060;schaden</DefaultText>
+      <DefaultText>{0} Fernkampf&#x2060;schaden</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6135,7 +6135,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1218</ID>
-      <DefaultText>{0} {1}-Zeitschaden bei T&#2060;reffer</DefaultText>
+      <DefaultText>{0} {1}-Zeitschaden bei T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6225,7 +6225,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1236</ID>
-      <DefaultText>{0} Schaden gegen Niedergeschlagen&#2060;e, Betäubt&#2060;e, Flankiert&#2060;e Feinde</DefaultText>
+      <DefaultText>{0} Schaden gegen Niedergeschlagen&#x2060;e, Betäubt&#x2060;e, Flankiert&#x2060;e Feinde</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6240,7 +6240,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1239</ID>
-      <DefaultText>{0} erlittener T&#2060;reffer umgewandelt in Leichte Treffer</DefaultText>
+      <DefaultText>{0} erlittener T&#x2060;reffer umgewandelt in Leichte Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6255,7 +6255,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1242</ID>
-      <DefaultText>{0} Rüstungs&#2060;schadensreduktion wenn unter 25% Gesundheit</DefaultText>
+      <DefaultText>{0} Rüstungs&#x2060;schadensreduktion wenn unter 25% Gesundheit</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6360,12 +6360,12 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1263</ID>
-      <DefaultText>{0} Frequenz für Gift&#2060;auswirkungen</DefaultText>
+      <DefaultText>{0} Frequenz für Gift&#x2060;auswirkungen</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1264</ID>
-      <DefaultText>{0} Frequenz für Krankheit&#2060;sauswirkungen</DefaultText>
+      <DefaultText>{0} Frequenz für Krankheit&#x2060;sauswirkungen</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6690,7 +6690,7 @@ Beschwörungen - Mächtige magische Effekte, die Sänger auslösen können, wenn
     </Entry>
     <Entry>
       <ID>1329</ID>
-      <DefaultText>{0}&#2060;schaden</DefaultText>
+      <DefaultText>{0}&#x2060;schaden</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7697,7 +7697,7 @@ Trotz dieser Vorteile ist die Beziehung aber auch mit Risiken behaftet. Waldläu
     </Entry>
     <Entry>
       <ID>1532</ID>
-      <DefaultText>Entzieht {0} {1}&#2060;schaden als Ausdauer</DefaultText>
+      <DefaultText>Entzieht {0} {1}&#x2060;schaden als Ausdauer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7747,7 +7747,7 @@ Trotz dieser Vorteile ist die Beziehung aber auch mit Risiken behaftet. Waldläu
     </Entry>
     <Entry>
       <ID>1542</ID>
-      <DefaultText>Erholung&#2060;sgeschwindigkeit: {0}</DefaultText>
+      <DefaultText>Erholung&#x2060;sgeschwindigkeit: {0}</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -7957,7 +7957,7 @@ Trotz dieser Vorteile ist die Beziehung aber auch mit Risiken behaftet. Waldläu
     </Entry>
     <Entry>
       <ID>1584</ID>
-      <DefaultText>{0} {1}&#2060;schaden erlitten</DefaultText>
+      <DefaultText>{0} {1}&#x2060;schaden erlitten</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8177,12 +8177,12 @@ Trotz dieser Vorteile ist die Beziehung aber auch mit Risiken behaftet. Waldläu
     </Entry>
     <Entry>
       <ID>1628</ID>
-      <DefaultText>{0} Schild&#2060;abwehr</DefaultText>
+      <DefaultText>{0} Schild&#x2060;abwehr</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>1629</ID>
-      <DefaultText>Schild&#2060;abwehr-Bonus gilt auch für Reflexe.</DefaultText>
+      <DefaultText>Schild&#x2060;abwehr-Bonus gilt auch für Reflexe.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8400,7 +8400,7 @@ Stufe {1} Schlösser knacken,
     </Entry>
     <Entry>
       <ID>1673</ID>
-      <DefaultText>{0} {1}&#2060;schaden an selbst beim Angriff mit Werkzeugen</DefaultText>
+      <DefaultText>{0} {1}&#x2060;schaden an selbst beim Angriff mit Werkzeugen</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8410,7 +8410,7 @@ Stufe {1} Schlösser knacken,
     </Entry>
     <Entry>
       <ID>1675</ID>
-      <DefaultText>{0} Leichte Treffer mit Einhand-Nahkampfwaffen umgewandelt in T&#2060;reffer</DefaultText>
+      <DefaultText>{0} Leichte Treffer mit Einhand-Nahkampfwaffen umgewandelt in T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8425,7 +8425,7 @@ Stufe {1} Schlösser knacken,
     </Entry>
     <Entry>
       <ID>1678</ID>
-      <DefaultText>{0} Unterbrechung&#2060;schance</DefaultText>
+      <DefaultText>{0} Unterbrechung&#x2060;schance</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -8500,7 +8500,7 @@ Stufe {1} Schlösser knacken,
     </Entry>
     <Entry>
       <ID>1693</ID>
-      <DefaultText>{0} T&#2060;reffer gegen Ziele mit niedriger Ausdauer umgewandelt in Kritische Treffer</DefaultText>
+      <DefaultText>{0} T&#x2060;reffer gegen Ziele mit niedriger Ausdauer umgewandelt in Kritische Treffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/itemmods.stringtable
+++ b/text/game/itemmods.stringtable
@@ -66,17 +66,17 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>des Intellekt&#2060;s +1</DefaultText>
+      <DefaultText>des Intellekt&#x2060;s +1</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>13</ID>
-      <DefaultText>des Intellekt&#2060;s +2</DefaultText>
+      <DefaultText>des Intellekt&#x2060;s +2</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>14</ID>
-      <DefaultText>des Intellekt&#2060;s +3</DefaultText>
+      <DefaultText>des Intellekt&#x2060;s +3</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1056,7 +1056,7 @@
     </Entry>
     <Entry>
       <ID>210</ID>
-      <DefaultText>des Intellekt&#2060;s -1</DefaultText>
+      <DefaultText>des Intellekt&#x2060;s -1</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1141,17 +1141,17 @@
     </Entry>
     <Entry>
       <ID>227</ID>
-      <DefaultText>des Wille&#2060;ns +5</DefaultText>
+      <DefaultText>des Wille&#x2060;ns +5</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>228</ID>
-      <DefaultText>des Wille&#2060;ns +10</DefaultText>
+      <DefaultText>des Wille&#x2060;ns +10</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>229</ID>
-      <DefaultText>des Wille&#2060;ns +15</DefaultText>
+      <DefaultText>des Wille&#x2060;ns +15</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1181,7 +1181,7 @@
     </Entry>
     <Entry>
       <ID>235</ID>
-      <DefaultText>Umwandlung Leichte Treffer zu T&#2060;reffer</DefaultText>
+      <DefaultText>Umwandlung Leichte Treffer zu T&#x2060;reffer</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1211,7 +1211,7 @@
     </Entry>
     <Entry>
       <ID>241</ID>
-      <DefaultText>des Wille&#2060;ns -3</DefaultText>
+      <DefaultText>des Wille&#x2060;ns -3</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/items.stringtable
+++ b/text/game/items.stringtable
@@ -8118,7 +8118,7 @@ Bis er auf Edrang Hadret traf.</DefaultText>
 
 Das Fest der Ahnen
 
-Das Fest der Ahnen findet während des Frühlingserwachens statt und wird zu Ehren der Besiedelung Eir&#160;Glanfath&#2060;s durch die Glanfathaner gefeiert. Es ist eine einfache, drei Tage andauernde Zeremonie, die vor allem aus Festmahlen besteht. Diese Festmahle werden in den Ruinen abgehalten, die in ganz Eir&#160;Glanfath zu finden sind. Kränze aus Zweigen und Blumen werden in den Ruinen niedergelegt und die Glanfathaner beten zu den Göttern und danken ihnen für ihre Gesundheit und ihren Wohlstand.
+Das Fest der Ahnen findet während des Frühlingserwachens statt und wird zu Ehren der Besiedelung Eir&#160;Glanfath&#x2060;s durch die Glanfathaner gefeiert. Es ist eine einfache, drei Tage andauernde Zeremonie, die vor allem aus Festmahlen besteht. Diese Festmahle werden in den Ruinen abgehalten, die in ganz Eir&#160;Glanfath zu finden sind. Kränze aus Zweigen und Blumen werden in den Ruinen niedergelegt und die Glanfathaner beten zu den Göttern und danken ihnen für ihre Gesundheit und ihren Wohlstand.
 
 Die Säuberung
 
@@ -8542,7 +8542,7 @@ Seltsamerweise scheinen die Regeln innerhalb der Grenzen von Zwillingsulmen nich
 
 Wie dem auch sei, die Glanfathaner nahmen ihre Rolle als Wächter ernst. Sie verehrten die Stätten und entwickelten Rituale, um die Ruinen zu bewachen und zu beschützen. Mit der Zeit wurden diese Rituale für einige zu bloßer Gewohnheit, zu Formalitäten. Nicht mehr wert als andere überlieferte Legenden. Das soll nicht heißen, dass die Glanfathaner ihre Bemühungen einstellten, ihren Eid aufrechtzuhalten (siehe den Abschnitt über die Zehnjahresverträge in meinem Buch über Admeth Hadret), doch die bedingungslose Hingabe an den Eid schwankte von Stamm zu Stamm und von Clan zu Clan. Nicht so allerdings bei den Reißzähnen. Die Reißzähne sind eine Gruppe, die nicht durch Verwandschaft oder Gemeinschaft verbunden sind, sondern durch ihren Glauben. Von allen Gruppen in Eir&#160;Glanfath scheinen die Reißzähne sich der Einhaltung des Versprechens, das ihre Ahnen den Engwithanern machten, am stärksten verschrieben zu haben.
 
-Die Tatsache, dass ihr Fanatismus und Eifer nicht so allumfassend sind, wie manche glauben, macht sie nicht weniger gefährlich. Die Reißzähne sind nicht dafür bekannt zu verhandeln, wenn sie sich im Recht fühlen. Wenn sie der Meinung sind, man habe eine heilige Stätte entweiht, so erfolgen ihr Urteil und ihre Strafe schnell und hart. Berichte über die Angriffe der Reißzähne sind bereits in Unterlagen aus der Zeit der ersten Erkundungen Eir&#160;Glanfath&#2060;s zu finden. Selbst der kleinste Verstoß rechtfertigt in ihren Augen eine Hinrichtung.
+Die Tatsache, dass ihr Fanatismus und Eifer nicht so allumfassend sind, wie manche glauben, macht sie nicht weniger gefährlich. Die Reißzähne sind nicht dafür bekannt zu verhandeln, wenn sie sich im Recht fühlen. Wenn sie der Meinung sind, man habe eine heilige Stätte entweiht, so erfolgen ihr Urteil und ihre Strafe schnell und hart. Berichte über die Angriffe der Reißzähne sind bereits in Unterlagen aus der Zeit der ersten Erkundungen Eir&#160;Glanfath&#x2060;s zu finden. Selbst der kleinste Verstoß rechtfertigt in ihren Augen eine Hinrichtung.
 
 Der Orden selbst scheint vor allem aus Jägern zu bestehen. Ob sie als fähige Jäger rekrutiert oder dazu ausgebildet werden, wenn sie in den Orden aufgenommen wurden, ist nicht bekannt. Der Autor ist der Auffassung, dass Ersteres zutrifft. Denn wenn sie den Reißzähnen erst einmal beigetreten sind, so rückt allen Quellen zufolge die Jagd nach Wild in den Hintergrund und ihre Hauptaufgabe besteht darin, Eir&#160;Glanfath zu patrouillieren und die Ruinen zu beschützen.</DefaultText>
       <FemaleText />
@@ -10811,7 +10811,7 @@ Nach ihrem Tod wurde die Waffe an Aedwyns Enkel im Dyrwald weitergegeben. Als Th
     </Entry>
     <Entry>
       <ID>1889</ID>
-      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwälderischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
+      <DefaultText>Einst wurden Löwen in den Ebenen östlich und südlich von Eir&#160;Glanfath&#x2060;s ausgedehnten Wäldern oft gesichtet, aber die Kolonisierung im Östlichen Abschnitt hat die Großkatzen in die relative Sicherheit des Territoriums zwischen den glanfathanischen und dyrwälderischen Siedlungen zurückgedrängt. Zusätzlich zu ihrer enormen Kraft sind Löwen für ihr Gebrüll bekannt, einem furchterregenden Geräusch, das selbst dem tapfersten Gestandenen die Angst ins Herz treiben kann.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/loadingtips.stringtable
+++ b/text/game/loadingtips.stringtable
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>Wenn ein Angriff einen T&#2060;reffer verursacht, richtet dieser T&#2060;reffer normalen Schaden an und hat eine normale Dauer. Leichte Treffer verringern Schaden und Dauer um 50%. Kritische Treffer erhöhen Schaden und Dauer um 50%.</DefaultText>
+      <DefaultText>Wenn ein Angriff einen T&#x2060;reffer verursacht, richtet dieser T&#x2060;reffer normalen Schaden an und hat eine normale Dauer. Leichte Treffer verringern Schaden und Dauer um 50%. Kritische Treffer erhöhen Schaden und Dauer um 50%.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -216,7 +216,7 @@
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>Durch die Fähigkeit Schleichangriff besitzen Schurken den höchsten Waffenschaden aller Klassen. Trifft ein Schurke einen Feind, der an einem Gebrechen leidet, das einen Schleichangriff ermöglicht, verursacht der T&#2060;reffer automatisch zusätzlichen Schaden.</DefaultText>
+      <DefaultText>Durch die Fähigkeit Schleichangriff besitzen Schurken den höchsten Waffenschaden aller Klassen. Trifft ein Schurke einen Feind, der an einem Gebrechen leidet, das einen Schleichangriff ermöglicht, verursacht der T&#x2060;reffer automatisch zusätzlichen Schaden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -261,7 +261,7 @@
     </Entry>
     <Entry>
       <ID>57</ID>
-      <DefaultText>Das Führen von zwei Nahkampfwaffen gleichzeitig bietet zwar die schnellste Angriffsrate, nicht aber den Pro-T&#2060;reffer-Schaden von Zweihandwaffen, die Genauigkeit einer einzelnen Einhandwaffe oder den Abwehrbonus eines Schilds.</DefaultText>
+      <DefaultText>Das Führen von zwei Nahkampfwaffen gleichzeitig bietet zwar die schnellste Angriffsrate, nicht aber den Pro-T&#x2060;reffer-Schaden von Zweihandwaffen, die Genauigkeit einer einzelnen Einhandwaffe oder den Abwehrbonus eines Schilds.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -271,7 +271,7 @@
     </Entry>
     <Entry>
       <ID>59</ID>
-      <DefaultText>Zweihändige Nahkampfwaffen richten den größten Pro-T&#2060;reffer-Schaden an und können auch hohe Schadensreduktionen durchbrechen.</DefaultText>
+      <DefaultText>Zweihändige Nahkampfwaffen richten den größten Pro-T&#x2060;reffer-Schaden an und können auch hohe Schadensreduktionen durchbrechen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/tutorial.stringtable
+++ b/text/game/tutorial.stringtable
@@ -71,17 +71,17 @@
     </Entry>
     <Entry>
       <ID>13</ID>
-      <DefaultText>Manchmal sind eine Waffe oder ein Zauber einfach nicht geeignet, um die Schadensreduktion eines Feindes zu durchdringen. Wenn der Angriff ein T&#2060;reffer ist, hebt die SR den gesamten theoretisch erlittenen Schaden bis auf einen kleinen Prozentsatz auf. Du hörst, wie deine Charaktere sich beschweren, wenn das passiert. Halte die Ohren offen, achte darauf, welche Schadensart abgeblockt wurde, und versuche es mit einer anderen Waffe oder einem anderen Zauber noch einmal.</DefaultText>
+      <DefaultText>Manchmal sind eine Waffe oder ein Zauber einfach nicht geeignet, um die Schadensreduktion eines Feindes zu durchdringen. Wenn der Angriff ein T&#x2060;reffer ist, hebt die SR den gesamten theoretisch erlittenen Schaden bis auf einen kleinen Prozentsatz auf. Du hörst, wie deine Charaktere sich beschweren, wenn das passiert. Halte die Ohren offen, achte darauf, welche Schadensart abgeblockt wurde, und versuche es mit einer anderen Waffe oder einem anderen Zauber noch einmal.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>14</ID>
-      <DefaultText>Du hast einen Kritischen Treffer gelandet! Ein Kritischer Treffer ist ein besseres Ergebnis als ein T&#2060;reffer. Die Wahrscheinlichkeit, dass du einen Kritischen Treffer landest, ist höher, wenn die Genauigkeit des Angriffs über der Verteidigung des Ziels liegt. Angriffe, die Schaden anrichten, richten höheren Schaden an, wenn sie als Kritischer Treffer landen. Angriffe, die Statuseffekte oder Wirkungen auslösen, haben eine längere Dauer, wenn sie als Kritischer Treffer landen. Leichte Treffer sind schwächer als T&#2060;reffer - ihr Schaden ist niedriger, Effekte und Wirkungen halten weniger lang an.</DefaultText>
+      <DefaultText>Du hast einen Kritischen Treffer gelandet! Ein Kritischer Treffer ist ein besseres Ergebnis als ein T&#x2060;reffer. Die Wahrscheinlichkeit, dass du einen Kritischen Treffer landest, ist höher, wenn die Genauigkeit des Angriffs über der Verteidigung des Ziels liegt. Angriffe, die Schaden anrichten, richten höheren Schaden an, wenn sie als Kritischer Treffer landen. Angriffe, die Statuseffekte oder Wirkungen auslösen, haben eine längere Dauer, wenn sie als Kritischer Treffer landen. Leichte Treffer sind schwächer als T&#x2060;reffer - ihr Schaden ist niedriger, Effekte und Wirkungen halten weniger lang an.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>15</ID>
-      <DefaultText>Du greifst gerade einen Feind mit mindestens einer Verteidigung (Abwehr, Tapferkeit, Reflexe, Wille) an, die deutlich über der Genauigkeit des angreifenden Charakters liegt. Wenn die Verteidigung deutlich über der Genauigkeit liegt, kann es sehr schwer sein, einen T&#2060;reffer zu landen - und unmöglich, einen Kritischen Treffer zu landen. Versuche, die Genauigkeit des Angreifers zu erhöhen, oder verwende Zauber oder Fähigkeiten, die eine andere Verteidigung angreifen.</DefaultText>
+      <DefaultText>Du greifst gerade einen Feind mit mindestens einer Verteidigung (Abwehr, Tapferkeit, Reflexe, Wille) an, die deutlich über der Genauigkeit des angreifenden Charakters liegt. Wenn die Verteidigung deutlich über der Genauigkeit liegt, kann es sehr schwer sein, einen T&#x2060;reffer zu landen - und unmöglich, einen Kritischen Treffer zu landen. Versuche, die Genauigkeit des Angreifers zu erhöhen, oder verwende Zauber oder Fähigkeiten, die eine andere Verteidigung angreifen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Falschen Code für die Wordjoiner benutzt (siehe #154): `&#2060;` (dec) anstelle von `&#x2060;` (hex) bzw. `&#8288;` (dec).

Erfolgreich getestet unter Windows (hatte aber auch davor seltsamerweise funktioniert)... Mac hab ich leider keinen rumstehen.
