### PR TITLE
rolling back to typewriter apostrophe

### DIFF
--- a/text/conversations/00_dyrwood/00_cv_aelys.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_aelys.stringtable
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>95</ID>
-      <DefaultText>Aelys’ Starren ist finster und abwesend. Die rachsüchtige Essenz der Skaeniten schwärmt über ihre Seele aus wie Ameisen über eine sterbende Motte.</DefaultText>
+      <DefaultText>Aelys' Starren ist finster und abwesend. Die rachsüchtige Essenz der Skaeniten schwärmt über ihre Seele aus wie Ameisen über eine sterbende Motte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/00_dyrwood/00_cv_korgrak.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_korgrak.stringtable
@@ -175,7 +175,7 @@ Der Oger schnaubt und festigt den Griff um seine Keule. „Ich habe zurückgezog
     </Entry>
     <Entry>
       <ID>47</ID>
-      <DefaultText>Er hämmert seine Keule in den Boden. „Ich hab’s doch schon gesagt! Den Gestandenen auf der Straße hungert es heutzutage nach allem, was sie essen oder verkaufen können. Im Freien würde ich keine Woche überstehen. Nicht alleine.“</DefaultText>
+      <DefaultText>Er hämmert seine Keule in den Boden. „Ich hab's doch schon gesagt! Den Gestandenen auf der Straße hungert es heutzutage nach allem, was sie essen oder verkaufen können. Im Freien würde ich keine Woche überstehen. Nicht alleine.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -254,7 +254,7 @@ Hiravias zuckt mit den Achseln und lächelt Korgrak an. „Den Druiden wird es w
     </Entry>
     <Entry>
       <ID>67</ID>
-      <DefaultText>Er äugt dich misstrauisch an. „Ich werde für’s Erste dem Fluss folgen. Wenigstens verspricht dieser Weg eine gute Jagd.“</DefaultText>
+      <DefaultText>Er äugt dich misstrauisch an. „Ich werde fürs Erste dem Fluss folgen. Wenigstens verspricht dieser Weg eine gute Jagd.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/00_dyrwood/00_cv_lord_harond.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_lord_harond.stringtable
@@ -266,7 +266,7 @@ Er bemerkt dich und zeigt ein zuckendes Grinsen. „Es ist an der Zeit, dass Ael
     </Entry>
     <Entry>
       <ID>211</ID>
-      <DefaultText>„Ich fürchte, Lady Harond ist nicht reisefähig. Leider hat Aelys nur wenig nahe Verwandte. Meine Schwester und ihr Ehemann, Aelys’ Tante und Onkel natürlich, haben Aedyr in den letzten Monaten besucht.“ Er reibt seine Fingerknöchel. „Und was Geschwister angeht&#160;… Aelys hat keine. Meine Frau hat nur Hohlgeburten erlitten. Das heißt seit Aelys.“</DefaultText>
+      <DefaultText>„Ich fürchte, Lady Harond ist nicht reisefähig. Leider hat Aelys nur wenig nahe Verwandte. Meine Schwester und ihr Ehemann, Aelys' Tante und Onkel natürlich, haben Aedyr in den letzten Monaten besucht.“ Er reibt seine Fingerknöchel. „Und was Geschwister angeht&#160;… Aelys hat keine. Meine Frau hat nur Hohlgeburten erlitten. Das heißt seit Aelys.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/00_dyrwood/00_cv_nyfre_new.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_nyfre_new.stringtable
@@ -150,7 +150,7 @@ Sie folgt den vermummten Gestalten zur Treppe und wirft dir, als sie durch die T
     </Entry>
     <Entry>
       <ID>27</ID>
-      <DefaultText>Sie atmet schwer, schnappt nach Luft und streckt eine Hand aus, um sich zu beruhigen. „Ich&#160;… oh Götter, ich bin frei.“ Sie schaut zur Tür. „Für’s Erste. Ich muss aufbrechen, solange ich einen Vorsprung habe. Und etwas Gewicht muss ich auch noch loswerden. Hier, für dich.“ Sie greift unter ihre Lederrüstung und gibt dir einige gefaltete Lederstücke. „Wenn ich schnell unterwegs bin, werde ich das nicht mehr benötigen. Pass auf dich auf.“
+      <DefaultText>Sie atmet schwer, schnappt nach Luft und streckt eine Hand aus, um sich zu beruhigen. „Ich&#160;… oh Götter, ich bin frei.“ Sie schaut zur Tür. „Fürs Erste. Ich muss aufbrechen, solange ich einen Vorsprung habe. Und etwas Gewicht muss ich auch noch loswerden. Hier, für dich.“ Sie greift unter ihre Lederrüstung und gibt dir einige gefaltete Lederstücke. „Wenn ich schnell unterwegs bin, werde ich das nicht mehr benötigen. Pass auf dich auf.“
 
 Sie und der Rest ihrer Gefährten eilen die Treppe hinunter.</DefaultText>
       <FemaleText />

--- a/text/conversations/00_dyrwood/00_cv_sevis.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_sevis.stringtable
@@ -175,7 +175,7 @@ Er sieht sich zu dir um. „Das Wichtigste zuerst.“</DefaultText>
     </Entry>
     <Entry>
       <ID>44</ID>
-      <DefaultText>Er zuckt mit den Achseln und hebt seine Klinge hoch. „Einen Versuch war’s wert.“</DefaultText>
+      <DefaultText>Er zuckt mit den Achseln und hebt seine Klinge hoch. „Einen Versuch war's wert.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/00_dyrwood/00_cv_wymund.stringtable
+++ b/text/conversations/00_dyrwood/00_cv_wymund.stringtable
@@ -163,7 +163,7 @@ Die Kapuze verschiebt sich, als er seinen Kopf neigt. „Gehe ich richtig der An
     </Entry>
     <Entry>
       <ID>89</ID>
-      <DefaultText>Er nickt. „Kehre vor allen Dingen nach Dyrfurt zurück und sorge dafür, dass Harond mit ihr weiterreist. Keiner von uns soll Aelys’ Rache zu Gesicht bekommen, aber wenn alles so läuft wie geplant, wird der ganze Dyrwald davon erfahren.“ Er schubst die junge Frau nach vorne.</DefaultText>
+      <DefaultText>Er nickt. „Kehre vor allen Dingen nach Dyrfurt zurück und sorge dafür, dass Harond mit ihr weiterreist. Keiner von uns soll Aelys' Rache zu Gesicht bekommen, aber wenn alles so läuft wie geplant, wird der ganze Dyrwald davon erfahren.“ Er schubst die junge Frau nach vorne.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -227,7 +227,7 @@ Mit einem Seufzen wendet er sich wieder dem Mädchen zu und bricht ihr Genick.</
     </Entry>
     <Entry>
       <ID>106</ID>
-      <DefaultText>„Haronds Ehefrau gebar nichts als Hohlgeburten. Jetzt hat er also keinen Erben und Aelys, das Kind seiner Schwester, erreicht das heiratsfähige Alter. Ohne eigene Nachkommen würde Haronds Erbe auf Aelys’ leibliche Nachkommen übertragen werden.“
+      <DefaultText>„Haronds Ehefrau gebar nichts als Hohlgeburten. Jetzt hat er also keinen Erben und Aelys, das Kind seiner Schwester, erreicht das heiratsfähige Alter. Ohne eigene Nachkommen würde Haronds Erbe auf Aelys' leibliche Nachkommen übertragen werden.“
 
 „Er fand also einen Weg, um seine eigene adlige Blutlinie fortzusetzen&#160;… und schwängerte dieses Mädchen, seine eigene Nichte.“</DefaultText>
       <FemaleText />

--- a/text/conversations/01_defiance_bay_copperlane/01_bs_tavern_patron_male_02.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_bs_tavern_patron_male_02.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>„Ich sag’s ungern, aber das Vermächtnis ist gut fürs Geschäft.“</DefaultText>
+      <DefaultText>„Ich sag's ungern, aber das Vermächtnis ist gut fürs Geschäft.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/01_defiance_bay_copperlane/01_cv_gareth.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_gareth.stringtable
@@ -76,7 +76,7 @@
     </Entry>
     <Entry>
       <ID>31</ID>
-      <DefaultText>„Ja, das war’s. Und jetzt verschwinde, bevor&#160;–“</DefaultText>
+      <DefaultText>„Ja, das war's. Und jetzt verschwinde, bevor&#160;–“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/01_defiance_bay_copperlane/01_cv_langden.stringtable
+++ b/text/conversations/01_defiance_bay_copperlane/01_cv_langden.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>„Die Mauer hinauf und in das Fenster hinein. Den Edelstein für den hübschen kleinen Fürsten schnappen. Wir haben’s verstanden.“</DefaultText>
+      <DefaultText>„Die Mauer hinauf und in das Fenster hinein. Den Edelstein für den hübschen kleinen Fürsten schnappen. Wir haben's verstanden.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/02_defiance_bay_first_fires/02_cv_woedica_mercenary.stringtable
+++ b/text/conversations/02_defiance_bay_first_fires/02_cv_woedica_mercenary.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>Er denkt vorsichtig nach, dann nickt er. „Na gut, geh’ rein und melde dich bei der Akolythin. Sie wird dir dann eine Aufgabe zuweisen. Sie müssten gerade mit ihrem Treffen im großen Raum fertig geworden sein.“</DefaultText>
+      <DefaultText>Er denkt vorsichtig nach, dann nickt er. „Na gut, geh' rein und melde dich bei der Akolythin. Sie wird dir dann eine Aufgabe zuweisen. Sie müssten gerade mit ihrem Treffen im großen Raum fertig geworden sein.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_llines.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_llines.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Sie lehnt sich auf den Tresen und klopft mit ihren schwarz lackierten Nägeln auf das Holz. „Was darf’s sein?“</DefaultText>
+      <DefaultText>Sie lehnt sich auf den Tresen und klopft mit ihren schwarz lackierten Nägeln auf das Holz. „Was darf's sein?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_serel.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_serel.stringtable
@@ -86,7 +86,7 @@
     </Entry>
     <Entry>
       <ID>23</ID>
-      <DefaultText>Ihre Schultern entspannen sich und ihr kokettes Lächeln kehrt zurück. „So ist’s recht.“</DefaultText>
+      <DefaultText>Ihre Schultern entspannen sich und ihr kokettes Lächeln kehrt zurück. „So ist's recht.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/04_defiance_bay_brackenbury/04_cv_bellasege.stringtable
+++ b/text/conversations/04_defiance_bay_brackenbury/04_cv_bellasege.stringtable
@@ -267,21 +267,21 @@ Sein Kiefer verkrampft sich und seine Augen zucken unter seinen Lidern.</Default
       <ID>52</ID>
       <DefaultText>Aloth reißt die Augen auf, aber der Ausdruck in ihnen ist nicht der seine.
 
-„Und was is’ mit den Röteln, die du im Zwischenraum zwischen deinen Ohren siehst? Sind die dir real genug?“</DefaultText>
+„Und was is' mit den Röteln, die du im Zwischenraum zwischen deinen Ohren siehst? Sind die dir real genug?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>53</ID>
       <DefaultText>Aloth reißt die Augen auf, aber der Ausdruck in ihnen ist nicht der seine.
 
-„Nie is’ er sicher, wenn ich da bin.“</DefaultText>
+„Nie is' er sicher, wenn ich da bin.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>54</ID>
       <DefaultText>Aloth reißt die Augen auf, aber der Ausdruck in ihnen ist nicht der seine.
 
-„Jetzt hast’n vertrieben. Was ’n welkes Gänseblümchen.“</DefaultText>
+„Jetzt hast'n vertrieben. Was 'n welkes Gänseblümchen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -501,7 +501,7 @@ Er hält einen Finger an seine Lippen, seine Augen weit und flehend. „Bitte. I
     </Entry>
     <Entry>
       <ID>96</ID>
-      <DefaultText>Er legt die Papiere wieder auf den Schreibtisch und blickt dich kläglich an. „Ich werd dir nich’ helfen, das zu erklären.“</DefaultText>
+      <DefaultText>Er legt die Papiere wieder auf den Schreibtisch und blickt dich kläglich an. „Ich werd dir nich' helfen, das zu erklären.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/05_defiance_bay_heritage_hill/05_cv_saeda_valas.stringtable
+++ b/text/conversations/05_defiance_bay_heritage_hill/05_cv_saeda_valas.stringtable
@@ -208,7 +208,7 @@
     </Entry>
     <Entry>
       <ID>134</ID>
-      <DefaultText>Sagani steht stocksteif da und blickt auf das Mädchen wie auf einen verwundeten Hasen. „Aurochs’ Schatten. Sie muss wochenlang auf sich allein gestellt gewesen sein.“</DefaultText>
+      <DefaultText>Sagani steht stocksteif da und blickt auf das Mädchen wie auf einen verwundeten Hasen. „Aurochs' Schatten. Sie muss wochenlang auf sich allein gestellt gewesen sein.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_bs_calisca_camp_banter.stringtable
+++ b/text/conversations/07_gilded_vale/07_bs_calisca_camp_banter.stringtable
@@ -16,7 +16,7 @@
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>„Das war’s.“</DefaultText>
+      <DefaultText>„Das war's.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_bs_smith_customer.stringtable
+++ b/text/conversations/07_gilded_vale/07_bs_smith_customer.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>„In letzter Zeit kamen nicht so viele von denen, wenn man sich’s recht bedenkt.“</DefaultText>
+      <DefaultText>„In letzter Zeit kamen nicht so viele von denen, wenn man sich's recht bedenkt.“</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/07_gilded_vale/07_cv_odema.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_odema.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>„Die ganze Gegend wimmelt nur so von diesen Hüttenbewohnern, die euch für euer Eindringen nur zu gerne mit ’ner Axt begrüßen würden. Passt also auf, dass ihr keinen Dreck auf ihren heiligen glühenden Felsen hinterlasst.“</DefaultText>
+      <DefaultText>„Die ganze Gegend wimmelt nur so von diesen Hüttenbewohnern, die euch für euer Eindringen nur zu gerne mit 'ner Axt begrüßen würden. Passt also auf, dass ihr keinen Dreck auf ihren heiligen glühenden Felsen hinterlasst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -23,12 +23,12 @@ Schließlich wendet sich der Karawanenmeister dir zu und legt die Stirn in Falte
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>„Leichte Grollfäule, vielleicht. Gibt ’n Stechkäfer in der Gegend, der das überträgt. Erstmal durch die Eingeweide durch, dann geht’s wieder. Es sei denn, du trinkst kein Wasser&#160;… in dem Fall bist du in ’nem Tag tot.“</DefaultText>
+      <DefaultText>„Leichte Grollfäule, vielleicht. Gibt 'n Stechkäfer in der Gegend, der das überträgt. Erstmal durch die Eingeweide durch, dann geht's wieder. Es sei denn, du trinkst kein Wasser&#160;… in dem Fall bist du in 'nem Tag tot.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>„Da gibts ’ne Beere in der Region, klein und rosa. Nennt sich Frühlingsbeere. Ungefähr so groß wie ein Fingernagel. Verursacht höllische Magenkrämpfe, wenn man sie isst, aber die Grenzbewohner machen Tee draus, der die Innereien beruhigt. Sollte dich über die Nacht bringen. Sieh dich mal um, ob du welche finden kannst. Währenddessen sorg ich dafür, dass wir etwas Wasser für dich auftreiben.“</DefaultText>
+      <DefaultText>„Da gibts 'ne Beere in der Region, klein und rosa. Nennt sich Frühlingsbeere. Ungefähr so groß wie ein Fingernagel. Verursacht höllische Magenkrämpfe, wenn man sie isst, aber die Grenzbewohner machen Tee draus, der die Innereien beruhigt. Sollte dich über die Nacht bringen. Sieh dich mal um, ob du welche finden kannst. Währenddessen sorg ich dafür, dass wir etwas Wasser für dich auftreiben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -87,7 +87,7 @@ Er wirft ihr einen Seitenblick zu. „Und überhaupt: Ich zahle viel zu gut.“<
 
 „Und nun geh. Heodan sollte Vorräte haben. Rüste dich aus, bevor du losziehst. Wir befinden uns in einem rauen Land.“
 
-„Hol dir ’ne Hand voll Beeren und komm sofort wieder zurück. Und wenn auch nur das Geringste sein sollte, lässt du alles stehen und liegen und nimmst die Beine in die Hand. Irgendwas liegt in der Luft heut Nacht. Wenns ein Bîaŵac ist, suchen wir Deckung in den Ruinen. Scheiß auf die Hüttenbewohner.“</DefaultText>
+„Hol dir 'ne Hand voll Beeren und komm sofort wieder zurück. Und wenn auch nur das Geringste sein sollte, lässt du alles stehen und liegen und nimmst die Beine in die Hand. Irgendwas liegt in der Luft heut Nacht. Wenns ein Bîaŵac ist, suchen wir Deckung in den Ruinen. Scheiß auf die Hüttenbewohner.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -117,12 +117,12 @@ Er wirft ihr einen Seitenblick zu. „Und überhaupt: Ich zahle viel zu gut.“<
     </Entry>
     <Entry>
       <ID>20</ID>
-      <DefaultText>„Die gleichen wie auf der Hälfte aller Hügel hier in Eir Glanfath. Der Schnickschnack dadrin bringt in Trutzbucht viel Geld, wenn es dir nichts ausmacht, dir hier und da ’nen Glanfathaner-Pfeil einzufangen. Die haben das Zeug hier zwar nicht erbaut, aber wenn sie nicht wie eine Bärenmutter darauf aufpassen, bin ich das Bildnis.“</DefaultText>
+      <DefaultText>„Die gleichen wie auf der Hälfte aller Hügel hier in Eir Glanfath. Der Schnickschnack dadrin bringt in Trutzbucht viel Geld, wenn es dir nichts ausmacht, dir hier und da 'nen Glanfathaner-Pfeil einzufangen. Die haben das Zeug hier zwar nicht erbaut, aber wenn sie nicht wie eine Bärenmutter darauf aufpassen, bin ich das Bildnis.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>21</ID>
-      <DefaultText>„Die in der Gegend sind natürlich schon zigmal geplündert worden. Nichts übrig, was auch nur ’nen halben Pand wert wäre.“
+      <DefaultText>„Die in der Gegend sind natürlich schon zigmal geplündert worden. Nichts übrig, was auch nur 'nen halben Pand wert wäre.“
 
 Zwinkernd fügt er hinzu: „Hab ich zumindest gehört.“</DefaultText>
       <FemaleText />
@@ -156,7 +156,7 @@ Zwinkernd fügt er hinzu: „Hab ich zumindest gehört.“</DefaultText>
     </Entry>
     <Entry>
       <ID>27</ID>
-      <DefaultText>„Zu dieser Jahreszeit? Regen, hauptsächlich&#160;… und Wind. Gibt hier draußen aber noch ’ne andere Art von Wind, von Zeit zu Zeit. Die Einheimischen nennen ihn Bîaŵac, ‚geboren aus dem Äther‘&#160;– dem Weg der Geister. Hab ich nie erlebt, will ich auch nich.“</DefaultText>
+      <DefaultText>„Zu dieser Jahreszeit? Regen, hauptsächlich&#160;… und Wind. Gibt hier draußen aber noch 'ne andere Art von Wind, von Zeit zu Zeit. Die Einheimischen nennen ihn Bîaŵac, ‚geboren aus dem Äther‘&#160;– dem Weg der Geister. Hab ich nie erlebt, will ich auch nich.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_sweynur.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_sweynur.stringtable
@@ -46,7 +46,7 @@
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>„Na, da hat aber jemand eine blühende Phantasie, was? Um was geht’s denn hier? Darum, dass sich Trumbel für den Dorfkönig hält, nur weil ihm die Mühle gehört.“</DefaultText>
+      <DefaultText>„Na, da hat aber jemand eine blühende Phantasie, was? Um was geht's denn hier? Darum, dass sich Trumbel für den Dorfkönig hält, nur weil ihm die Mühle gehört.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -221,7 +221,7 @@
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>„Na, da hat aber jemand eine blühende Phantasie, was? Um was geht’s denn hier? Darum, dass sich Trumbel für den Dorfkönig hält, nur weil ihm die Mühle gehört.“</DefaultText>
+      <DefaultText>„Na, da hat aber jemand eine blühende Phantasie, was? Um was geht's denn hier? Darum, dass sich Trumbel für den Dorfkönig hält, nur weil ihm die Mühle gehört.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_trumbel.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_trumbel.stringtable
@@ -298,7 +298,7 @@
     </Entry>
     <Entry>
       <ID>103</ID>
-      <DefaultText>Stattdessen hebt Trumbel nur noch weiter hoch. „Ich mein’s ernst! Ich werde mich nicht in meiner eigenen Mühle von Sweynur und seinen Lakaien bedrohen lassen!“</DefaultText>
+      <DefaultText>Stattdessen hebt Trumbel nur noch weiter hoch. „Ich mein's ernst! Ich werde mich nicht in meiner eigenen Mühle von Sweynur und seinen Lakaien bedrohen lassen!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_wirtan.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_wirtan.stringtable
@@ -76,7 +76,7 @@
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>„Er schickte seine Wachen los, um die Priester dem Schwerte zuzuführen, den Tempel einzureißen und einige der Bücher zu verbrennen. Das war’s dann.“ Er schaut weg.</DefaultText>
+      <DefaultText>„Er schickte seine Wachen los, um die Priester dem Schwerte zuzuführen, den Tempel einzureißen und einige der Bücher zu verbrennen. Das war's dann.“ Er schaut weg.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/10_od_nua/1012_cv_scouts.stringtable
+++ b/text/conversations/10_od_nua/1012_cv_scouts.stringtable
@@ -121,7 +121,7 @@
     </Entry>
     <Entry>
       <ID>28</ID>
-      <DefaultText>In deinem Verstand kannst du ein dumpfes Lachen hören. „Was kümmern Tcharek solche Dinge? Sstravek’narith, allein darauf kommt es an. Unser Volk. Ich werde ihm unsere Zukunft bringen. Ich werde meine Verbrechen danebenlegen, und sie werden gering wirken. Ich werde endlich nach Hause kommen.“ Die Vithrack stößt ein scharfes Pfeifgeräusch aus, worauf ihre Gefährtinnen nach vorne stürmen. „Aber der Eindringling&#160;… es hat keine Zukunft.“</DefaultText>
+      <DefaultText>In deinem Verstand kannst du ein dumpfes Lachen hören. „Was kümmern Tcharek solche Dinge? Sstravek'narith, allein darauf kommt es an. Unser Volk. Ich werde ihm unsere Zukunft bringen. Ich werde meine Verbrechen danebenlegen, und sie werden gering wirken. Ich werde endlich nach Hause kommen.“ Die Vithrack stößt ein scharfes Pfeifgeräusch aus, worauf ihre Gefährtinnen nach vorne stürmen. „Aber der Eindringling&#160;… es hat keine Zukunft.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/10_od_nua/1012_cv_vith_explorer.stringtable
+++ b/text/conversations/10_od_nua/1012_cv_vith_explorer.stringtable
@@ -106,7 +106,7 @@
     </Entry>
     <Entry>
       <ID>23</ID>
-      <DefaultText>Die Vithrack hebt einen klauenbewehrten Finger, um leicht an einer der Adra-Formationen zu kratzen, die entlang der Wand wachsen. „Studiert Essk’arevar. Adra. Wie wachsen, Form geben, gebrauchen. In Sstravek’narith wächst kein Adra. Krivi wird Geheimnis lernen.“</DefaultText>
+      <DefaultText>Die Vithrack hebt einen klauenbewehrten Finger, um leicht an einer der Adra-Formationen zu kratzen, die entlang der Wand wachsen. „Studiert Essk'arevar. Adra. Wie wachsen, Form geben, gebrauchen. In Sstravek'narith wächst kein Adra. Krivi wird Geheimnis lernen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/10_od_nua/1012_cv_vithrack_leader.stringtable
+++ b/text/conversations/10_od_nua/1012_cv_vithrack_leader.stringtable
@@ -66,7 +66,7 @@
     </Entry>
     <Entry>
       <ID>17</ID>
-      <DefaultText>„Wir werden studieren, was der Freund der Kolonie gebracht hat. Werden bald Antworten finden, sie nach Hause bringen. Auch die Jungen. Wenn wir Sstravek’narith erreichen werden sie&#160;… groß sein.“ Die Vithrack macht ein dumpfes, rasselndes Geräusch. Du vermutest, dass das ein Lachen gewesen sein könnte. „Tcharek wird alt sein.“</DefaultText>
+      <DefaultText>„Wir werden studieren, was der Freund der Kolonie gebracht hat. Werden bald Antworten finden, sie nach Hause bringen. Auch die Jungen. Wenn wir Sstravek'narith erreichen werden sie&#160;… groß sein.“ Die Vithrack macht ein dumpfes, rasselndes Geräusch. Du vermutest, dass das ein Lachen gewesen sein könnte. „Tcharek wird alt sein.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -351,7 +351,7 @@
     </Entry>
     <Entry>
       <ID>86</ID>
-      <DefaultText>„Vithrack sprechen ohne Stimmen, und mit vielen. Hunderte Seelen in großer Stadt. Sstravek’narith&#160;– ist Kolonie. Eine große Reise. Tier würde lange laufen, um sie zu erreichen.“</DefaultText>
+      <DefaultText>„Vithrack sprechen ohne Stimmen, und mit vielen. Hunderte Seelen in großer Stadt. Sstravek'narith&#160;– ist Kolonie. Eine große Reise. Tier würde lange laufen, um sie zu erreichen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -376,7 +376,7 @@
     </Entry>
     <Entry>
       <ID>94</ID>
-      <DefaultText>Du spürst in deinem Schädel abermals ein kurzes Jucken, und dann ein wogendes Echo der Freude. „Dann stehen Vithrack in großer Schuld. Damit studieren wir, lernen Geheimnisse des Meisters. Wir machen Statuen, größer als von altem, toten Meister in hohlem Ort. Sstravek’narith wird wie das Meer erstrahlen.“</DefaultText>
+      <DefaultText>Du spürst in deinem Schädel abermals ein kurzes Jucken, und dann ein wogendes Echo der Freude. „Dann stehen Vithrack in großer Schuld. Damit studieren wir, lernen Geheimnisse des Meisters. Wir machen Statuen, größer als von altem, toten Meister in hohlem Ort. Sstravek'narith wird wie das Meer erstrahlen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -416,7 +416,7 @@
     </Entry>
     <Entry>
       <ID>104</ID>
-      <DefaultText>„Vithrack&#160;… suchen. Suchen Wissen für Heimat. Für Kolonie, Sstravek’narith. Weit weg. Lange Zeit, wir haben gesucht. Wir wurden krank vor&#160;… Erinnerung. Von der Heimat. Bauten Nester. Schufen neue Heimat. Und fanden, was wir suchen.“</DefaultText>
+      <DefaultText>„Vithrack&#160;… suchen. Suchen Wissen für Heimat. Für Kolonie, Sstravek'narith. Weit weg. Lange Zeit, wir haben gesucht. Wir wurden krank vor&#160;… Erinnerung. Von der Heimat. Bauten Nester. Schufen neue Heimat. Und fanden, was wir suchen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/11_hearthsong/11_cv_anamfath_leader.stringtable
+++ b/text/conversations/11_hearthsong/11_cv_anamfath_leader.stringtable
@@ -536,7 +536,7 @@ Die Anamenfath fährt fort. „Diese Wahrheit zu erfahren, stimmt uns traurig, a
     </Entry>
     <Entry>
       <ID>130</ID>
-      <DefaultText>Arthwn drückt sein Kreuz durch und hebt sein stoppeliges Kinn. „Da hast du’s. Dieser Sieg ist mein!“ Er schaut sich in der Halle um. „So eine Heldentat hättet ihr von einem Zweifach Gespaltenen Pfeil nicht erwartet, was?“</DefaultText>
+      <DefaultText>Arthwn drückt sein Kreuz durch und hebt sein stoppeliges Kinn. „Da hast du's. Dieser Sieg ist mein!“ Er schaut sich in der Halle um. „So eine Heldentat hättet ihr von einem Zweifach Gespaltenen Pfeil nicht erwartet, was?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/12_oldsong/12_cv_einden.stringtable
+++ b/text/conversations/12_oldsong/12_cv_einden.stringtable
@@ -82,7 +82,7 @@
     </Entry>
     <Entry>
       <ID>19</ID>
-      <DefaultText>[Angreifen] „Versuch’s doch.“</DefaultText>
+      <DefaultText>[Angreifen] „Versuch's doch.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_berath.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_berath.stringtable
@@ -485,7 +485,7 @@ Die schwarzen Untiefen ihrer Augen drohen, dich zu verschlingen. „Du musst ihn
     </Entry>
     <Entry>
       <ID>122</ID>
-      <DefaultText>„Warum braucht Woedica überhaupt Thaos’ Hilfe? Und warum brauchst du die meine?“</DefaultText>
+      <DefaultText>„Warum braucht Woedica überhaupt Thaos' Hilfe? Und warum brauchst du die meine?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -747,7 +747,7 @@ Er klopft dir mit einer schmutzigen Pranke auf die Seite und lächelt. „Thaos 
     </Entry>
     <Entry>
       <ID>175</ID>
-      <DefaultText>Die Spitze von Durance’ Stab geht in Flammen auf. „Beantworte lieber deine eigene Frage, Ritter. Es würde dir nicht gefallen, wenn ich dir die Antwort entlocken muss.“</DefaultText>
+      <DefaultText>Die Spitze von Durance' Stab geht in Flammen auf. „Beantworte lieber deine eigene Frage, Ritter. Es würde dir nicht gefallen, wenn ich dir die Antwort entlocken muss.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_galawain_coalition.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_galawain_coalition.stringtable
@@ -290,7 +290,7 @@ Du stehst still. Du bist dir dem Kreis von Raubtieren, der dich umgibt, wohl bew
       <ID>64</ID>
       <DefaultText>„Endlich bricht die Hure ihr Schweigen! Hast du mich vermisst, Magran? Du hast vielleicht andere Liebhaber gefunden, aber gewiss war mir keiner ebenbürtig.“
 
-Magran antwortet nicht. Sie blickt nicht einmal in Durance’ Richtung. Ein unbewusster Tick lässt die überschüssige Haut unter Durance’ Augen erzittern. Er sagt nichts mehr. Seine Haut ist erbleicht.</DefaultText>
+Magran antwortet nicht. Sie blickt nicht einmal in Durance' Richtung. Ein unbewusster Tick lässt die überschüssige Haut unter Durance' Augen erzittern. Er sagt nichts mehr. Seine Haut ist erbleicht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -625,7 +625,7 @@ Der Orlaner fällt auf ein Knie. Seine Hände eilen in seine Taschen und ergreif
     </Entry>
     <Entry>
       <ID>133</ID>
-      <DefaultText>Durance’ Augen sind weit geöffnet. Sein Bart ist schweißnass.
+      <DefaultText>Durance' Augen sind weit geöffnet. Sein Bart ist schweißnass.
 
 „War das nicht, was du befohlen hattest? Wir wollten nur deinen Stolz nähren, indem wir deine Vision Wirklichkeit werden lassen.“
 
@@ -726,7 +726,7 @@ Hiravias löst seinen Blick von dem Klugen Hund, seine Stimme senkt sich zu eine
     </Entry>
     <Entry>
       <ID>152</ID>
-      <DefaultText>Durance’ Gesicht ist ernst. „Hüte dich vor den Versprechen eines Gottes, Wächter. Sie sind bindend, aber nur in eine Richtung.“</DefaultText>
+      <DefaultText>Durance' Gesicht ist ernst. „Hüte dich vor den Versprechen eines Gottes, Wächter. Sie sind bindend, aber nur in eine Richtung.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_naca.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_naca.stringtable
@@ -129,7 +129,7 @@ Sie breitet die Arme in einer ausladenden Geste aus. „Schreite durch Blutiger 
       <ID>32</ID>
       <DefaultText>Naca lächelt. „Ich weiß, dass er eine Furcht erregende Kreatur ist, die Galawain geschickt hat, um zu urteilen&#160;– und zu vollstrecken. Wen die Bestie für unwürdig befindet und tötet, der verliert für immer seine Seele.“
 
-Hiravias’ Augen weiten sich, während sie spricht, und bevor er unterbrechen kann, fügt sie an: „Ich sage dir nur, was die Sagenmeister vor mir gesagt haben.“</DefaultText>
+Hiravias' Augen weiten sich, während sie spricht, und bevor er unterbrechen kann, fügt sie an: „Ich sage dir nur, was die Sagenmeister vor mir gesagt haben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_sidha.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_sidha.stringtable
@@ -85,8 +85,8 @@ Sîdha wendet sich wieder dir zu.</DefaultText>
     </Entry>
     <Entry>
       <ID>15</ID>
-      <DefaultText>„Die Antwort lautet, ja, Alter, wir haben Thaos’ Weg vor nicht allzu langer Zeit gekreuzt, und wir können dir sagen, wohin er gegangen ist. Aber ich finde es seltsam, dass jemand ihn suchen sollte. Verdächtig, sogar. Wenn wir dir helfen sollen, ihn zu finden, müssen wir den Grund wissen.“</DefaultText>
-      <FemaleText>„Die Antwort lautet, ja, Alte, wir haben Thaos’ Weg vor nicht allzu langer Zeit gekreuzt, und wir können dir sagen, wohin er gegangen ist. Aber ich finde es seltsam, dass jemand ihn suchen sollte. Verdächtig, sogar. Wenn wir dir helfen sollen, ihn zu finden, müssen wir den Grund wissen.“</FemaleText>
+      <DefaultText>„Die Antwort lautet, ja, Alter, wir haben Thaos' Weg vor nicht allzu langer Zeit gekreuzt, und wir können dir sagen, wohin er gegangen ist. Aber ich finde es seltsam, dass jemand ihn suchen sollte. Verdächtig, sogar. Wenn wir dir helfen sollen, ihn zu finden, müssen wir den Grund wissen.“</DefaultText>
+      <FemaleText>„Die Antwort lautet, ja, Alte, wir haben Thaos' Weg vor nicht allzu langer Zeit gekreuzt, und wir können dir sagen, wohin er gegangen ist. Aber ich finde es seltsam, dass jemand ihn suchen sollte. Verdächtig, sogar. Wenn wir dir helfen sollen, ihn zu finden, müssen wir den Grund wissen.“</FemaleText>
     </Entry>
     <Entry>
       <ID>16</ID>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_simoc.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_simoc.stringtable
@@ -540,7 +540,7 @@ Hiravias verschränkt die Arme und zuckt mit den Schultern. „Er hat allen Grun
     </Entry>
     <Entry>
       <ID>112</ID>
-      <DefaultText>„Schön wäre es!“, ruft Hiravias. „Dieses junge Fischerkranich-Mädchen ist ein großartiges Geschenk&#160;– du solltest dankbar sein!“ Hiravias’ Stimme wird zu einem leisen Flüstern. „Vor allem angesichts der&#160;… Schwäche in deiner Familie.“</DefaultText>
+      <DefaultText>„Schön wäre es!“, ruft Hiravias. „Dieses junge Fischerkranich-Mädchen ist ein großartiges Geschenk&#160;– du solltest dankbar sein!“ Hiravias' Stimme wird zu einem leisen Flüstern. „Vor allem angesichts der&#160;… Schwäche in deiner Familie.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -560,7 +560,7 @@ Hiravias verschränkt die Arme und zuckt mit den Schultern. „Er hat allen Grun
     </Entry>
     <Entry>
       <ID>116</ID>
-      <DefaultText>Hiravias’ Augen weiten sich angesichts dieser Bemerkung. „Niemand verspottet die Fischerkraniche außer mir“, murmelt er leise und streckt seine Finger zu Krallen aus. „Aber ich gestehe ein, dass mein Stamm&#160;… klug genug ist&#160;… auf die sinnlosen Taktiken eines gerechten Kampfs zu verzichten.“</DefaultText>
+      <DefaultText>Hiravias' Augen weiten sich angesichts dieser Bemerkung. „Niemand verspottet die Fischerkraniche außer mir“, murmelt er leise und streckt seine Finger zu Krallen aus. „Aber ich gestehe ein, dass mein Stamm&#160;… klug genug ist&#160;… auf die sinnlosen Taktiken eines gerechten Kampfs zu verzichten.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/13_twin_elms_elms_reach/13_cv_tamrwn.stringtable
+++ b/text/conversations/13_twin_elms_elms_reach/13_cv_tamrwn.stringtable
@@ -23,7 +23,7 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>Hiravias’ Augen weiten sich überrascht und sein eines gesundes Ohr stellt sich auf. „Wie in Eora wusstest du–?“</DefaultText>
+      <DefaultText>Hiravias' Augen weiten sich überrascht und sein eines gesundes Ohr stellt sich auf. „Wie in Eora wusstest du–?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/14_burial_isle/14_cv_iovara.stringtable
+++ b/text/conversations/14_burial_isle/14_cv_iovara.stringtable
@@ -168,7 +168,7 @@ Sie schüttelt besorgt den Kopf. „Oder habe ich lediglich ein zweites Mal vers
     </Entry>
     <Entry>
       <ID>42</ID>
-      <DefaultText>„Sie wurden von Engwith geschaffen, einer Gesellschaft des hohen Geistes und der vielfältigen Interessen. Thaos’ Volk.“
+      <DefaultText>„Sie wurden von Engwith geschaffen, einer Gesellschaft des hohen Geistes und der vielfältigen Interessen. Thaos' Volk.“
 
 „In ihrer Zeit verehrte jedes Volk seine eigenen Götter. Manchmal zogen sie darüber in den Krieg. Nachdem sie selbst einige Kriege ausgetragen hatten, wollten die Engwithaner dem allen ein Ende setzen. Sie verwendeten all ihre Energie darauf, die wahren Schöpfer zu finden.“</DefaultText>
       <FemaleText />
@@ -278,7 +278,7 @@ Sein Gesicht wird selbstgefällig und er spuckt auf den Boden. „In einer Sache
     </Entry>
     <Entry>
       <ID>84</ID>
-      <DefaultText>Durance’ Mund zittert, sein Gesicht ist zornesrot. „Magran hat mir einen Weg gezeigt. Sie ist wankelmütig und grausam, aber so lehrt sie nun einmal. Du weißt nichts von den Feuern, die mich geformt haben.“</DefaultText>
+      <DefaultText>Durance' Mund zittert, sein Gesicht ist zornesrot. „Magran hat mir einen Weg gezeigt. Sie ist wankelmütig und grausam, aber so lehrt sie nun einmal. Du weißt nichts von den Feuern, die mich geformt haben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -359,7 +359,7 @@ Hiravias grinst ein breites Lächeln und errötet plötzlich. Er neigt schnell s
       <ID>103</ID>
       <DefaultText>„Und was, wenn auch die Feuer Lügen waren? Lügen, die du dir selbst eingeredet hast, um die Lücke zwischen Erfahrung und Wahrheit zu überbrücken?“
 
-Schweißperlen sammeln sich auf Durance’ Stirn und strömen sein Gesicht hinab, als wäre er ein Eisblock, der vor einem großen Scheiterhaufen steht.</DefaultText>
+Schweißperlen sammeln sich auf Durance' Stirn und strömen sein Gesicht hinab, als wäre er ein Eisblock, der vor einem großen Scheiterhaufen steht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -796,7 +796,7 @@ Kana sieht weg. „Wir suchen nach einfachen Antworten, doch die gibt es nicht.�
       <ID>356</ID>
       <DefaultText>„Du sprichst von ihren Täuschungen, aber was ist mit den deinen? Waren es ihre Worte, die dich auf deinen Weg geführt haben, oder war es die Abwesenheit ihrer Worte, eine Lücke, die du mit deinen eigenen zerbrochenen Gedanken gefüllt hast?“
 
-Schweißperlen sammeln sich auf Durance’ Stirn und strömen sein Gesicht hinab, als wäre er ein Eisblock, der vor einem großen Scheiterhaufen steht.</DefaultText>
+Schweißperlen sammeln sich auf Durance' Stirn und strömen sein Gesicht hinab, als wäre er ein Eisblock, der vor einem großen Scheiterhaufen steht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/14_burial_isle/14_cv_thaos.stringtable
+++ b/text/conversations/14_burial_isle/14_cv_thaos.stringtable
@@ -130,7 +130,7 @@ Edér runzelt verärgert die Stirn.</DefaultText>
     </Entry>
     <Entry>
       <ID>30</ID>
-      <DefaultText>Als er Aloth sieht, zuckt Thaos’ Mund verächtlich. „Nenne mir deinen Namen und dein Ansinnen, junger Akolyth.“</DefaultText>
+      <DefaultText>Als er Aloth sieht, zuckt Thaos' Mund verächtlich. „Nenne mir deinen Namen und dein Ansinnen, junger Akolyth.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -207,7 +207,7 @@ Edér runzelt verärgert die Stirn.</DefaultText>
     </Entry>
     <Entry>
       <ID>45</ID>
-      <DefaultText>Thaos’ plötzliche Aufmerksamkeit lässt Pallegina ihr Gefieder aufplustern. „Wie ich höre, haben deine Ducs Bels dir eine Mission aufgetragen.“</DefaultText>
+      <DefaultText>Thaos' plötzliche Aufmerksamkeit lässt Pallegina ihr Gefieder aufplustern. „Wie ich höre, haben deine Ducs Bels dir eine Mission aufgetragen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -249,7 +249,7 @@ Edér runzelt verärgert die Stirn.</DefaultText>
     </Entry>
     <Entry>
       <ID>53</ID>
-      <DefaultText>„Ächtung? Nennt man so den Genitalausschlag, den ich von deiner Mutter habe?“ Hiravias gutes Auge starrt Thaos’ Hals an und der Ohrstummel des Orlaners zuckt.
+      <DefaultText>„Ächtung? Nennt man so den Genitalausschlag, den ich von deiner Mutter habe?“ Hiravias gutes Auge starrt Thaos' Hals an und der Ohrstummel des Orlaners zuckt.
 
 „Mach dir nichts vor, alter Mann, du weißt nichts über mich.“</DefaultText>
       <FemaleText />
@@ -487,7 +487,7 @@ Er richtet seinen Blick auf dich.</DefaultText>
     </Entry>
     <Entry>
       <ID>103</ID>
-      <DefaultText>Thaos’ Augen blitzen vor plötzlicher Entrüstung auf. „Diese Frau hat in ihrem Leid mehr getan, als die meisten mit ihrem klaren, unwissenden Verstand je erreichen. Wenn sie nur gehorcht hätte. Welch eine Verschwendung von seltenem Talent und Intellekt.“</DefaultText>
+      <DefaultText>Thaos' Augen blitzen vor plötzlicher Entrüstung auf. „Diese Frau hat in ihrem Leid mehr getan, als die meisten mit ihrem klaren, unwissenden Verstand je erreichen. Wenn sie nur gehorcht hätte. Welch eine Verschwendung von seltenem Talent und Intellekt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/14_burial_isle/14_cv_thaos_2.stringtable
+++ b/text/conversations/14_burial_isle/14_cv_thaos_2.stringtable
@@ -13,12 +13,12 @@ Seine Seele bleibt einen Augenblick lang still, wehrlos, ihre Energie in der Nie
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>[Thaos’ Seele erkunden.]</DefaultText>
+      <DefaultText>[Thaos' Seele erkunden.]</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>Du atmest tief durch und tauchst in Thaos’ Seele ein. War sie in Farnheim noch ein Labyrinth aus engen Gängen und Sackgassen, ist sie nun weitläufig und grenzenlos. Ihre Mauern zerfallen zu Schutt wie die Ruinen von Engwith, als du sie durchquerst.
+      <DefaultText>Du atmest tief durch und tauchst in Thaos' Seele ein. War sie in Farnheim noch ein Labyrinth aus engen Gängen und Sackgassen, ist sie nun weitläufig und grenzenlos. Ihre Mauern zerfallen zu Schutt wie die Ruinen von Engwith, als du sie durchquerst.
 
 Du reist eine schier endlose Zeit, auf einen bekannten Ort zueilend, eine Erinnerung, auf die du schon einmal einen Blick erhascht hast. Endlich siehst du sie, nicht mehr als ein winziges Licht am Ende eines langen Tunnels, das sich langsam vergrößert, je näher du kommst.</DefaultText>
       <FemaleText />
@@ -65,7 +65,7 @@ Die Maschine wird langsamer und bleibt plötzlich stehen. Als das letzte Echo de
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Von allen Seiten beginnt die Realität in die Erinnerung durchzusickern und du findest dich wieder in deiner eigenen Haut, auf Thaos’ leblosen Körper blickend.</DefaultText>
+      <DefaultText>Von allen Seiten beginnt die Realität in die Erinnerung durchzusickern und du findest dich wieder in deiner eigenen Haut, auf Thaos' leblosen Körper blickend.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -119,7 +119,7 @@ Er tritt Thaos erneut. „Und um dem Vorschlag zuvorzukommen: Nein, ich esse sei
     </Entry>
     <Entry>
       <ID>22</ID>
-      <DefaultText>Du spürst eine Antriebslosigkeit in Thaos’ Seele, eine überwältigende Erschöpfung, die sie daran hindert, sofort zu entweichen&#160;– und die sie anfällig für Manipulationsversuche macht. Du hast das Gefühl, als hätte dein Sieg dir irgendeine Art Macht über sie verliehen und als könntest du mit ihr tun, was du willst.</DefaultText>
+      <DefaultText>Du spürst eine Antriebslosigkeit in Thaos' Seele, eine überwältigende Erschöpfung, die sie daran hindert, sofort zu entweichen&#160;– und die sie anfällig für Manipulationsversuche macht. Du hast das Gefühl, als hätte dein Sieg dir irgendeine Art Macht über sie verliehen und als könntest du mit ihr tun, was du willst.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -236,17 +236,17 @@ Er tritt Thaos erneut. „Und um dem Vorschlag zuvorzukommen: Nein, ich esse sei
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>Du ergreifst Thaos’ Seele und du spürst ihre Zerbrechlichkeit in der Niederlage. Sie fühlt sich an wie ein grober und zerschlissener Stoff, der kurz davor steht, völlig zu zerfallen. Du schlängelst dich zwischen die Fäden, zerteilst und entwirrst das Gewebe, bis es ohne jede Struktur ist, ein formloser Haufen, der durch nichts mehr zusammengehalten wird.</DefaultText>
+      <DefaultText>Du ergreifst Thaos' Seele und du spürst ihre Zerbrechlichkeit in der Niederlage. Sie fühlt sich an wie ein grober und zerschlissener Stoff, der kurz davor steht, völlig zu zerfallen. Du schlängelst dich zwischen die Fäden, zerteilst und entwirrst das Gewebe, bis es ohne jede Struktur ist, ein formloser Haufen, der durch nichts mehr zusammengehalten wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>Du betrachtest Thaos’ Seele, still und unterworfen, und deine Verkündigung scheint deinen Geist zu stärken. Dein Wille scheint nun eine dicke Kette zu sein. Du windest sie eng um Thaos, verhinderst jede Bewegung, eliminierst jede letzte Möglichkeit des Widerstands.</DefaultText>
+      <DefaultText>Du betrachtest Thaos' Seele, still und unterworfen, und deine Verkündigung scheint deinen Geist zu stärken. Dein Wille scheint nun eine dicke Kette zu sein. Du windest sie eng um Thaos, verhinderst jede Bewegung, eliminierst jede letzte Möglichkeit des Widerstands.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>52</ID>
-      <DefaultText>Du kehrst in die Landschaft von Thaos’ Erinnerungen zurück, in die gewaltige Welt aus Täuschungen und lähmender Verzweiflung. Du spürst nun deine Macht in dieser Welt, die Fähigkeit, die Launen deines dominanten Willens neu zu formen.
+      <DefaultText>Du kehrst in die Landschaft von Thaos' Erinnerungen zurück, in die gewaltige Welt aus Täuschungen und lähmender Verzweiflung. Du spürst nun deine Macht in dieser Welt, die Fähigkeit, die Launen deines dominanten Willens neu zu formen.
 
 Du konzentrierst dich auf eine Vision der puren Leere und dein Wille wird zu einem kreisenden Wirbel um dich herum. Er fegt durch die Landschaft und trägt Augenblicke und ganze Leben davon wie ein apokalyptischer Bîaŵac, der die Essenz des Planeten selbst davonreißt.</DefaultText>
       <FemaleText />
@@ -255,14 +255,14 @@ Du konzentrierst dich auf eine Vision der puren Leere und dein Wille wird zu ein
       <ID>54</ID>
       <DefaultText>Du erstreckst deine Präsenz so weit, wie dein Geist es erlaubt. Du berührst einen dieser Pfade und zwischen ihm und dir öffnet sich ein langer Tunnel, steil und geriffelt wie der Schlund einer enormen Bestie.
 
-Du richtest deine Aufmerksamkeit auf Thaos’ Seele, die sich schwach an ihre besiegte Hülle klammert. Mit all deiner Konzentration reißt du sie los und schleuderst sie in den Kanal, bis sie in die Adra-Ader übergeht und nicht mehr zu spüren ist.</DefaultText>
+Du richtest deine Aufmerksamkeit auf Thaos' Seele, die sich schwach an ihre besiegte Hülle klammert. Mit all deiner Konzentration reißt du sie los und schleuderst sie in den Kanal, bis sie in die Adra-Ader übergeht und nicht mehr zu spüren ist.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>55</ID>
       <DefaultText>Du konzentrierst deine Aufmerksamkeit auf einen einzigen Gedanken&#160;– „zertrümmern“.
 
-Du konzentrierst dich und spürst, wie sich eine Kraft in deiner Seele aufbaut&#160;– ein nach außen gerichteter Druck, der sich gegen die Enge stemmt und droht, deinen Geist zu zerreißen. Als der Druck schließlich unerträglich wird, überträgst du ihn mit einem Schlag auf Thaos’ Seele und gibst ihn dort frei, eine Detonation des Willens, die sich in alle Richtungen ausstreckt und die Überreste seiner Essenz vertreibt und zerschlägt&#160;– zu einem einzigen Nichts.
+Du konzentrierst dich und spürst, wie sich eine Kraft in deiner Seele aufbaut&#160;– ein nach außen gerichteter Druck, der sich gegen die Enge stemmt und droht, deinen Geist zu zerreißen. Als der Druck schließlich unerträglich wird, überträgst du ihn mit einem Schlag auf Thaos' Seele und gibst ihn dort frei, eine Detonation des Willens, die sich in alle Richtungen ausstreckt und die Überreste seiner Essenz vertreibt und zerschlägt&#160;– zu einem einzigen Nichts.
 
 Du spürst seine Anwesenheit nicht länger.</DefaultText>
       <FemaleText />
@@ -276,7 +276,7 @@ Du wählst eine leere Säule und gießt dein Bewusstsein hinein. Du schaffst ein
     </Entry>
     <Entry>
       <ID>57</ID>
-      <DefaultText>Und nun hebst du Thaos’ Seele auf und trägst sie zu der Säule wie ein körperloser Kerkermeister, der von der Gerechtigkeit selbst gerufen wurde. Du spürst nun ihren Widerstand, die gewaltige Furcht, die sie ausstrahlt, doch deine Bindungen lassen sich nicht brechen.
+      <DefaultText>Und nun hebst du Thaos' Seele auf und trägst sie zu der Säule wie ein körperloser Kerkermeister, der von der Gerechtigkeit selbst gerufen wurde. Du spürst nun ihren Widerstand, die gewaltige Furcht, die sie ausstrahlt, doch deine Bindungen lassen sich nicht brechen.
 
 Als die Seele endlich versiegelt ist und du beginnst, dich wieder in deine Mitte zurückzuziehen, könntest du fast schwören, dass du weit entfernt ein wortloses Winseln um Gnade hörst.</DefaultText>
       <FemaleText />

--- a/text/conversations/14_burial_isle/14_cv_thaos_machine_vision.stringtable
+++ b/text/conversations/14_burial_isle/14_cv_thaos_machine_vision.stringtable
@@ -60,7 +60,7 @@ Deine Gedanken rasen, du betrachtest verschiedene mögliche Ansatzpunkte. Du has
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Thaos’ Gesicht bleibt eine unbeteiligte Maske. „Was IST ein Gott? Hm? Eine höhere Macht? Jemand, der gute Taten belohnt und böse bestraft? Etwas, dem man sich in seinen dunkelsten Augenblicken zuwenden kann, wenn die Tage wirken, als seien sie nur Brücken von einer Tragödie zur nächsten? Unsere Götter sind alle diese Dinge.“
+      <DefaultText>Thaos' Gesicht bleibt eine unbeteiligte Maske. „Was IST ein Gott? Hm? Eine höhere Macht? Jemand, der gute Taten belohnt und böse bestraft? Etwas, dem man sich in seinen dunkelsten Augenblicken zuwenden kann, wenn die Tage wirken, als seien sie nur Brücken von einer Tragödie zur nächsten? Unsere Götter sind alle diese Dinge.“
 
 Mit jedem Wort, das Thaos spricht, spürst du, wie du mehr und mehr die Kontrolle über einen siedenden Kessel des Zorns und des Zweifels und der Furcht und der Hoffnungslosigkeit verlierst, bis du es schließlich nicht mehr erträgst.</DefaultText>
       <FemaleText />

--- a/text/conversations/14_burial_isle/14_cv_wael.stringtable
+++ b/text/conversations/14_burial_isle/14_cv_wael.stringtable
@@ -261,7 +261,7 @@ Wie auf Befehl lichtet sich der Nebel vor dir plötzlich genug, dass du ein paar
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>Durance’ Kopf zuckt, als wäre ihm eine Mücke ins Ohr geflogen. Er fuchtelt mit seinem Stab halbherzig in die Luft.</DefaultText>
+      <DefaultText>Durance' Kopf zuckt, als wäre ihm eine Mücke ins Ohr geflogen. Er fuchtelt mit seinem Stab halbherzig in die Luft.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_aloth.stringtable
+++ b/text/conversations/companions/companion_cv_aloth.stringtable
@@ -52,7 +52,7 @@ Die Frau verschränkt ihre Arme. „Aha, willst unseren Stolz wohl mit ein paar 
     </Entry>
     <Entry>
       <ID>9</ID>
-      <DefaultText>„Jessas, kannst es wohl nimma dawoatn, dass’d deine Schwester schnackslt, oida Schlappschwanz.“</DefaultText>
+      <DefaultText>„Jessas, kannst es wohl nimma dawoatn, dass'd deine Schwester schnackslt, oida Schlappschwanz.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_aloth_act_3.stringtable
+++ b/text/conversations/companions/companion_cv_aloth_act_3.stringtable
@@ -504,12 +504,12 @@ Nach mehreren Sekunden seufzt er und schaut zu dir zurück.
     </Entry>
     <Entry>
       <ID>103</ID>
-      <DefaultText>Aloth nickt einmal. „Dann wollen wir Thaos gegenübertreten. Wenn das hier alles vorbei ist, werde ich mich daran erinnern, was wir durchgemacht haben. Ich werde dafür sorgen, dass der Bleierne Schlüssel in eine stärkere, bessere Führung für die Gestandenen umgewandelt wird&#160;… und ich werde Thaos’ Fehler nicht wiederholen.“</DefaultText>
+      <DefaultText>Aloth nickt einmal. „Dann wollen wir Thaos gegenübertreten. Wenn das hier alles vorbei ist, werde ich mich daran erinnern, was wir durchgemacht haben. Ich werde dafür sorgen, dass der Bleierne Schlüssel in eine stärkere, bessere Führung für die Gestandenen umgewandelt wird&#160;… und ich werde Thaos' Fehler nicht wiederholen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>104</ID>
-      <DefaultText>Seine Augenbrauen heben sich in die Dunkelheit seiner Kapuze. „Ah&#160;… nicht, dass du während unserer Reisen nicht der bestmöglichste Anführer gewesen wärst, aber ich hatte eigentlich erwartet, selbst Thaos’ Platz einzunehmen. Wer auch immer in diese Rolle schlüpft, muss sich mit der Infrastruktur und den Operationen des Bleiernen Schlüssels auskennen.“</DefaultText>
+      <DefaultText>Seine Augenbrauen heben sich in die Dunkelheit seiner Kapuze. „Ah&#160;… nicht, dass du während unserer Reisen nicht der bestmöglichste Anführer gewesen wärst, aber ich hatte eigentlich erwartet, selbst Thaos' Platz einzunehmen. Wer auch immer in diese Rolle schlüpft, muss sich mit der Infrastruktur und den Operationen des Bleiernen Schlüssels auskennen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_aloth_caed_nua.stringtable
+++ b/text/conversations/companions/companion_cv_aloth_caed_nua.stringtable
@@ -168,7 +168,7 @@
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>„Also, spuck’s schon aus.“</DefaultText>
+      <DefaultText>„Also, spuck's schon aus.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_aloth_voice_set.stringtable
+++ b/text/conversations/companions/companion_cv_aloth_voice_set.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>9</ID>
-      <DefaultText>„Pack ma’s o!“</DefaultText>
+      <DefaultText>„Pack ma's o!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -136,7 +136,7 @@
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>„I kennt a Nickerchen g’brauch’n.“</DefaultText>
+      <DefaultText>„I kennt a Nickerchen g'brauch'n.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_durance_hub_ashfall_v2.stringtable
+++ b/text/conversations/companions/companion_cv_durance_hub_ashfall_v2.stringtable
@@ -94,7 +94,7 @@ Er hält inne. „Ich hatte sie schon mal Kathedrale genannt. Das ist aber nicht
       <ID>23</ID>
       <DefaultText>„Massiv. Wunderschön. Gesegnet von der Göttin können ihr Flammen nichts mehr anhaben.“
 
-Durance’ Augen wandern zu seinem aschgrauen Stab und studieren die Einkerbungen. „Darunter? Tunnel und Kammern, Blasebälge und Feuergruben&#160;… und viele der Gläubigen, die nach Wegen suchen, das Feuer in die Welt zu bringen.“</DefaultText>
+Durance' Augen wandern zu seinem aschgrauen Stab und studieren die Einkerbungen. „Darunter? Tunnel und Kammern, Blasebälge und Feuergruben&#160;… und viele der Gläubigen, die nach Wegen suchen, das Feuer in die Welt zu bringen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -197,8 +197,8 @@ Durance schließt einen Moment die Augen, als ob er nachdenken würde. „Manche
     </Entry>
     <Entry>
       <ID>42</ID>
-      <DefaultText>„Wenn du mich also nach dem Grund fragst, Wächter, dem Grund, warum man keine Kathedrale braucht, um den Glauben aufrecht zu erhalten oder sich daran zu erinnern, so lass mich dir Folgendes sagen: Ich hasse es nicht, ich verachte es nicht, und ein wimmernder, verstoßener Narr bin ich auch nicht&#160;– ich bin wegen meines Glaubens auf Wanderschaft, und ich will ihn verbreiten.“ Er grunzt. „Und ich habe noch Jahrzehnte vor mir, bis mich Durance’ Prüfungen gehen lassen werden.“</DefaultText>
-      <FemaleText>„Wenn du mich also nach dem Grund fragst, Wächterin, dem Grund, warum man keine Kathedrale braucht, um den Glauben aufrecht zu erhalten oder sich daran zu erinnern, so lass mich dir Folgendes sagen: Ich hasse es nicht, ich verachte es nicht, und ein wimmernder, verstoßener Narr bin ich auch nicht&#160;– ich bin wegen meines Glaubens auf Wanderschaft, und ich will ihn verbreiten.“ Er grunzt. „Und ich habe noch Jahrzehnte vor mir, bis mich Durance’ Prüfungen gehen lassen werden.“</FemaleText>
+      <DefaultText>„Wenn du mich also nach dem Grund fragst, Wächter, dem Grund, warum man keine Kathedrale braucht, um den Glauben aufrecht zu erhalten oder sich daran zu erinnern, so lass mich dir Folgendes sagen: Ich hasse es nicht, ich verachte es nicht, und ein wimmernder, verstoßener Narr bin ich auch nicht&#160;– ich bin wegen meines Glaubens auf Wanderschaft, und ich will ihn verbreiten.“ Er grunzt. „Und ich habe noch Jahrzehnte vor mir, bis mich Durance' Prüfungen gehen lassen werden.“</DefaultText>
+      <FemaleText>„Wenn du mich also nach dem Grund fragst, Wächterin, dem Grund, warum man keine Kathedrale braucht, um den Glauben aufrecht zu erhalten oder sich daran zu erinnern, so lass mich dir Folgendes sagen: Ich hasse es nicht, ich verachte es nicht, und ein wimmernder, verstoßener Narr bin ich auch nicht&#160;– ich bin wegen meines Glaubens auf Wanderschaft, und ich will ihn verbreiten.“ Er grunzt. „Und ich habe noch Jahrzehnte vor mir, bis mich Durance' Prüfungen gehen lassen werden.“</FemaleText>
     </Entry>
     <Entry>
       <ID>43</ID>
@@ -239,7 +239,7 @@ Einen Augenblick später schüttelt er den Kopf und runzelt irritiert die Stirn.
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>„Bei der Flamme, du bist aber auch eine hartnäckige Schlampe.“ Durance’ Gesicht errötet ärgerlich. „Manche Dinge sind nur mir heilig. Spar dir deine Neugier für andere Narren unterwegs auf, denn mich ermüdet sie.“</DefaultText>
+      <DefaultText>„Bei der Flamme, du bist aber auch eine hartnäckige Schlampe.“ Durance' Gesicht errötet ärgerlich. „Manche Dinge sind nur mir heilig. Spar dir deine Neugier für andere Narren unterwegs auf, denn mich ermüdet sie.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_durance_hub_self_v2.stringtable
+++ b/text/conversations/companions/companion_cv_durance_hub_self_v2.stringtable
@@ -119,7 +119,7 @@
     </Entry>
     <Entry>
       <ID>36</ID>
-      <DefaultText>Durance’ Gesicht spannt sich an. „An dem Tag, an dem wir keine Fragen mehr austauschen, ist der Tag, an dem wir nicht mehr eines gemeinsamen Weges gehen müssen, und die Prüfung&#160;…“ Durance umklammert den Stab mit seiner Hand. „…&#160;die Prüfung ist abgeschlossen.“</DefaultText>
+      <DefaultText>Durance' Gesicht spannt sich an. „An dem Tag, an dem wir keine Fragen mehr austauschen, ist der Tag, an dem wir nicht mehr eines gemeinsamen Weges gehen müssen, und die Prüfung&#160;…“ Durance umklammert den Stab mit seiner Hand. „…&#160;die Prüfung ist abgeschlossen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -250,14 +250,14 @@ Sein Kichern wird langsamer und kommt zum Erliegen, worauf er dich anschaut. „
     </Entry>
     <Entry>
       <ID>59</ID>
-      <DefaultText>Durance’ Gesicht legt sich zu einem Stirnrunzeln in Falten, dann tippt er auf den Stab in seiner Hand. „Es gibt keine Schriften, Dichtungen oder Wortspiele, die offene Auslegung zuließen. Ihre Jünger sind oftmals nicht willkommen, also gehen sie auf Wanderschaft&#160;… eine physische Andacht.“ Durance grunzt. „Schon oft wurde ein Mann von Metaphern getötet, wenn es das Beste gewesen wäre, ihm die Wahrheit zu zeigen, so hässlich sie auch zu sein schien.“
+      <DefaultText>Durance' Gesicht legt sich zu einem Stirnrunzeln in Falten, dann tippt er auf den Stab in seiner Hand. „Es gibt keine Schriften, Dichtungen oder Wortspiele, die offene Auslegung zuließen. Ihre Jünger sind oftmals nicht willkommen, also gehen sie auf Wanderschaft&#160;… eine physische Andacht.“ Durance grunzt. „Schon oft wurde ein Mann von Metaphern getötet, wenn es das Beste gewesen wäre, ihm die Wahrheit zu zeigen, so hässlich sie auch zu sein schien.“
 
 „Vor Durance habe ich meinen Glauben und viele derartig große Worte geknüpft und andere ermutigt, es mir gleichzutun. Und alle wurden dadurch schwächer. Der Flamme unwürdig.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>60</ID>
-      <DefaultText>Durance’ Gesicht verdunkelt sich. „Die Andachten stammen aus den Tagen, als Magran nicht jedem begierigen jungen Initiierten einfach ihre Schenkel öffnete.“
+      <DefaultText>Durance' Gesicht verdunkelt sich. „Die Andachten stammen aus den Tagen, als Magran nicht jedem begierigen jungen Initiierten einfach ihre Schenkel öffnete.“
 
 „Stattdessen wies sie diese ‚Gläubigen‘ ab, und forderte sie auch, zum Beweis ihrer Frömmigkeit auf Wanderschaft zu gehen.“</DefaultText>
       <FemaleText />
@@ -448,7 +448,7 @@ Er grinst, worauf sich seine Gesichtsnarben unter dem rauen Bartwuchs bündeln.<
     </Entry>
     <Entry>
       <ID>173</ID>
-      <DefaultText>„Es gab nicht viele von uns.“ Durance knurrt. „Ich bin der Letzte, und während es keine Worte oder Dichtungen gibt, die Durance’ Lehren verunstalten können, so gibt es doch wenig, was sie am Leben erhalten könnte, falls das Feuer stirbt&#160;… aber das ist in sich selbst eine Prüfung.“</DefaultText>
+      <DefaultText>„Es gab nicht viele von uns.“ Durance knurrt. „Ich bin der Letzte, und während es keine Worte oder Dichtungen gibt, die Durance' Lehren verunstalten können, so gibt es doch wenig, was sie am Leben erhalten könnte, falls das Feuer stirbt&#160;… aber das ist in sich selbst eine Prüfung.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_durance_hub_v2.stringtable
+++ b/text/conversations/companions/companion_cv_durance_hub_v2.stringtable
@@ -118,7 +118,7 @@
     </Entry>
     <Entry>
       <ID>98</ID>
-      <DefaultText>„Das ist ein Fluch, der tiefer geht.“ Durance’ Stimme wird verbittert. „Es ist ein Götterhammer einer anderen Art und wie der Götterhammer ist auch das ein Werk der Sterblichen.“</DefaultText>
+      <DefaultText>„Das ist ein Fluch, der tiefer geht.“ Durance' Stimme wird verbittert. „Es ist ein Götterhammer einer anderen Art und wie der Götterhammer ist auch das ein Werk der Sterblichen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -201,7 +201,7 @@ Er wendet sich ab. „Das ist der Grund, weshalb ich Hohlgeborene korrigiere, we
     </Entry>
     <Entry>
       <ID>114</ID>
-      <DefaultText>Durance spottet. „Mord ist ein altes Wort&#160;– Gnade ist, wenn man eine Seele frei in den nächsten Körper fliegen lässt. Echte Bestrafung? Jemanden bis in die Seele ruinieren.“ Durance’ Hand festigt ihren Griff um seinen Stab, als ob er ein Gebet aufsagen würde – „Ihre Seele spalten, wie man ihre Schädel mit einem Stab aufschlagen würde&#160;…“
+      <DefaultText>Durance spottet. „Mord ist ein altes Wort&#160;– Gnade ist, wenn man eine Seele frei in den nächsten Körper fliegen lässt. Echte Bestrafung? Jemanden bis in die Seele ruinieren.“ Durance' Hand festigt ihren Griff um seinen Stab, als ob er ein Gebet aufsagen würde – „Ihre Seele spalten, wie man ihre Schädel mit einem Stab aufschlagen würde&#160;…“
 
 „…&#160;sie schlagen, an Verstand und Körper verletzen, damit ihre Seelen zersplittern&#160;… aber man belässt sie in dem Gefäß wie einen Beutel Glasscherben, um entweder daran zu ersticken oder sie mit ihrem blutigen Stuhl auszuscheiden.“</DefaultText>
       <FemaleText />
@@ -227,7 +227,7 @@ Er wendet sich ab. „Das ist der Grund, weshalb ich Hohlgeborene korrigiere, we
     </Entry>
     <Entry>
       <ID>118</ID>
-      <DefaultText>„Ist das ein Teil von Durance’ Lehren?“</DefaultText>
+      <DefaultText>„Ist das ein Teil von Durance' Lehren?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -251,7 +251,7 @@ Er wendet sich ab. „Das ist der Grund, weshalb ich Hohlgeborene korrigiere, we
 
 „Man kann auch die Seele verbrennen. Es ist eine Kunst, und ich finde keine Freude daran, aber hier steht mehr auf dem Spiel als Vergebung.“
 
-„In den Säuberungen nach dem Krieg des Heiligen wurden viele von Eothas’ Anhängern bestraft&#160;… und jene, die Kindern geschadet hatten, die erlitten noch Schlimmeres.“</DefaultText>
+„In den Säuberungen nach dem Krieg des Heiligen wurden viele von Eothas' Anhängern bestraft&#160;… und jene, die Kindern geschadet hatten, die erlitten noch Schlimmeres.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -287,7 +287,7 @@ Er wendet sich ab. „Das ist der Grund, weshalb ich Hohlgeborene korrigiere, we
     </Entry>
     <Entry>
       <ID>128</ID>
-      <DefaultText>„Ja. Eothas’ letzter Racheversuch, nachdem man ihn umgebracht hatte.“
+      <DefaultText>„Ja. Eothas' letzter Racheversuch, nachdem man ihn umgebracht hatte.“
 
 Durance runzelt die Stirn. „Eothas war der Gott der Wiedergeburt und sein Licht fällt nicht auf den Dyrwald. Ich habe gehört, dass manche behaupten, dass es sein Werk wäre, sein Tod&#160;… er hat die Hallen für neue Seelen geschlossen.“</DefaultText>
       <FemaleText />
@@ -395,12 +395,12 @@ Durance runzelt die Stirn. „Eothas war der Gott der Wiedergeburt und sein Lich
     </Entry>
     <Entry>
       <ID>150</ID>
-      <DefaultText>„Fast auch Eothas’ Marionetten. Dem wurde ein Ende gesetzt. Sie baumelten an seinen Strängen, Waidwen an ihren&#160;… wäre ihr Gott nicht herabgestiegen, hätten sie auf dem Schlachtfeld niemals Erfolge erzielt. Der Krieg des Heiligen&#160;…“ Durance knurrt. „Mussten ihren Gott herbeirufen, um eine Chance zu haben.“</DefaultText>
+      <DefaultText>„Fast auch Eothas' Marionetten. Dem wurde ein Ende gesetzt. Sie baumelten an seinen Strängen, Waidwen an ihren&#160;… wäre ihr Gott nicht herabgestiegen, hätten sie auf dem Schlachtfeld niemals Erfolge erzielt. Der Krieg des Heiligen&#160;…“ Durance knurrt. „Mussten ihren Gott herbeirufen, um eine Chance zu haben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>151</ID>
-      <DefaultText>Durance’ Augenbrauen ziehen sie zu einem Stirnrunzeln zusammen, dann grunzt er. „Ich vergesse immer, dass deine Füße neu im Dyrwald sind&#160;… also, der Krieg des Heiligen.“</DefaultText>
+      <DefaultText>Durance' Augenbrauen ziehen sie zu einem Stirnrunzeln zusammen, dann grunzt er. „Ich vergesse immer, dass deine Füße neu im Dyrwald sind&#160;… also, der Krieg des Heiligen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -422,7 +422,7 @@ Durance runzelt die Stirn. „Eothas war der Gott der Wiedergeburt und sein Lich
     </Entry>
     <Entry>
       <ID>155</ID>
-      <DefaultText>„Der ‚Krieg‘ war ein Akt der Arroganz, direkt aus Readceras’ zuckenden Beinen geboren. Ein Mann, der sich für mehr als einen Mann hält.“ Durance schnaubt verächtlich. „Du möchtest jemanden umbringen? Sag ihm, dass ein Gott durch ihn spricht.“
+      <DefaultText>„Der ‚Krieg‘ war ein Akt der Arroganz, direkt aus Readceras' zuckenden Beinen geboren. Ein Mann, der sich für mehr als einen Mann hält.“ Durance schnaubt verächtlich. „Du möchtest jemanden umbringen? Sag ihm, dass ein Gott durch ihn spricht.“
 
 „Dann sag ihm, dass er ihn zum Anführer auserkoren hat, was ihn an die Spitze einer Armee bringt. Und wie man es bei Readceras erwarten konnte, einem von Beginn an kranken Land, war es eine starke Armee&#160;– und dennoch war ein Krieg wahrscheinlich genau das, was sie brauchten.“</DefaultText>
       <FemaleText />
@@ -448,7 +448,7 @@ Durance runzelt die Stirn. „Eothas war der Gott der Wiedergeburt und sein Lich
       <ID>159</ID>
       <DefaultText>„Sie krönen ihn.“ Durance tippt sich an den Kopf, macht eine leichte Verbeugung, und als sich sein Gesicht dir wieder zuwendet, lächelt er wild. „Sie machen ihn zum König, der schlimmsten Art von Gotteslästerung.“
 
-„Und kaum trägt er die Krone auf seinem Haupt und den Gott in seinem Fleisch&#160;– nun, da beginnt er, Änderungen vorzunehmen, göttliche Änderungen.“ Durance’ Augen lodern auf.
+„Und kaum trägt er die Krone auf seinem Haupt und den Gott in seinem Fleisch&#160;– nun, da beginnt er, Änderungen vorzunehmen, göttliche Änderungen.“ Durance' Augen lodern auf.
 
 „Und dann beschließt er, uns zu ändern. Uns zu retten.“</DefaultText>
       <FemaleText />
@@ -482,7 +482,7 @@ Durance runzelt die Stirn. „Eothas war der Gott der Wiedergeburt und sein Lich
     </Entry>
     <Entry>
       <ID>165</ID>
-      <DefaultText>„Eothas marschiert weiter. Die Dyrwälder ziehen sich in die Wälder zurück und attackieren seine Flanken, seine Späher, seine Truppen. Es schien fast hoffnungslos zu sein.“ Durance’ Gesicht wird düster, dann lächelt er leicht. „Bis zur Zitadelle von Halgot, bis zum Götterhammer.“</DefaultText>
+      <DefaultText>„Eothas marschiert weiter. Die Dyrwälder ziehen sich in die Wälder zurück und attackieren seine Flanken, seine Späher, seine Truppen. Es schien fast hoffnungslos zu sein.“ Durance' Gesicht wird düster, dann lächelt er leicht. „Bis zur Zitadelle von Halgot, bis zum Götterhammer.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -655,7 +655,7 @@ Er lächelt höhnisch. „Er ließ sich nur von Sterblichen verspotten&#160;… 
     </Entry>
     <Entry>
       <ID>231</ID>
-      <DefaultText>Durance’ Starren wird härter. „Ich hätte alles darum gegeben, sie mit denen, die sie ‚retteten‘, in einen Käfig zu sperren und mir anzusehen, wie ihr Handwerk den Handwerker formt&#160;– diese Kinder ihre Peiniger in Stücke reißen lassen.“
+      <DefaultText>Durance' Starren wird härter. „Ich hätte alles darum gegeben, sie mit denen, die sie ‚retteten‘, in einen Käfig zu sperren und mir anzusehen, wie ihr Handwerk den Handwerker formt&#160;– diese Kinder ihre Peiniger in Stücke reißen lassen.“
 
 „Ich kann nur eine Kostprobe dessen geben, was sie erleiden sollten. Das ist magere Kost für uns beide.“</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_durance_scripted_sequences.stringtable
+++ b/text/conversations/companions/companion_cv_durance_scripted_sequences.stringtable
@@ -109,9 +109,9 @@ Er scheint dich nicht bemerkt zu haben&#160;… oder auf das Geschehene reagiert
     </Entry>
     <Entry>
       <ID>30</ID>
-      <DefaultText>Durance’ Stimme bleibt leise und gleichmäßig, als würde er etwas wiederholen, das er schon viele Male gesagt hat&#160;– entweder laut oder zu sich selbst. „Er hat den Krieg des Heiligen beendet&#160;… und einen Gott von seinem hohen Ross gestoßen.“
+      <DefaultText>Durance' Stimme bleibt leise und gleichmäßig, als würde er etwas wiederholen, das er schon viele Male gesagt hat&#160;– entweder laut oder zu sich selbst. „Er hat den Krieg des Heiligen beendet&#160;… und einen Gott von seinem hohen Ross gestoßen.“
 
-Durance’ Gesichtszüge versteinern sich. „Es gibt nur wenige, die abstreiten würden, dass es Eothas&#160;… übertrieben hat. Der Götterhammer erinnerte Eothas daran.“</DefaultText>
+Durance' Gesichtszüge versteinern sich. „Es gibt nur wenige, die abstreiten würden, dass es Eothas&#160;… übertrieben hat. Der Götterhammer erinnerte Eothas daran.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -227,7 +227,7 @@ Durance starrt wieder auf die tote Spitze des Stabs. „Der Zweifel folgte und d
       <ID>55</ID>
       <DefaultText>„Ich erinnerte mich an Magrans Lehren&#160;– weshalb die Mahnungen auf dem Fleisch wichtiger als der Tod eines Gefäßes sind.“ Durance runzelt die Stirn. „Und ich fragte mich, ob Eothas&#160;… ob wir ihn in Wirklichkeit befreiten, als wir ihn umbrachten. Hatte ihm das gar gestattet, seiner Strafe zu entgehen und zum Rad gebracht zu werden?“
 
-Durance’ Stimme geht seltsam nach oben&#160;… zum ersten Mal wirkt es so, als würde er wirklich eine Frage stellen. „Wie ein Sterblicher?“ Er schüttelt den Kopf.</DefaultText>
+Durance' Stimme geht seltsam nach oben&#160;… zum ersten Mal wirkt es so, als würde er wirklich eine Frage stellen. „Wie ein Sterblicher?“ Er schüttelt den Kopf.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -290,7 +290,7 @@ Durance’ Stimme geht seltsam nach oben&#160;… zum ersten Mal wirkt es so, al
     </Entry>
     <Entry>
       <ID>66</ID>
-      <DefaultText>„Wir wählten die Brücke aus, weil wir sie kontrollieren konnten.“ Durance’ Hände verstärken ihren Griff um die Spitze des Stabs, als er ihn am Hals packen würden. „Es war ein Ort, wo wir Eothas auf seinem Marsch die Kehle zuschnüren konnten, von dem wir wussten, dass ihn seine Schritte dort hinlenken würden&#160;– ein steinerner Engpass.“</DefaultText>
+      <DefaultText>„Wir wählten die Brücke aus, weil wir sie kontrollieren konnten.“ Durance' Hände verstärken ihren Griff um die Spitze des Stabs, als er ihn am Hals packen würden. „Es war ein Ort, wo wir Eothas auf seinem Marsch die Kehle zuschnüren konnten, von dem wir wussten, dass ihn seine Schritte dort hinlenken würden&#160;– ein steinerner Engpass.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -300,7 +300,7 @@ Durance’ Stimme geht seltsam nach oben&#160;… zum ersten Mal wirkt es so, al
     </Entry>
     <Entry>
       <ID>68</ID>
-      <DefaultText>Durance’ Gesichtsausdruck verhärtet sich. Seine Augen brennen und er runzelt die Stirn. „Ich vermute, Eothas wusste das ebenfalls&#160;… und auch sein Gefäß, in seiner&#160;… Arroganz.“ Seine Hand festigt ihren Griff um den Stab. „Er beabsichtigte die Brücke zu passieren, ganz so, als würde er auf den Rücken des Dyrwalds treten.“
+      <DefaultText>Durance' Gesichtsausdruck verhärtet sich. Seine Augen brennen und er runzelt die Stirn. „Ich vermute, Eothas wusste das ebenfalls&#160;… und auch sein Gefäß, in seiner&#160;… Arroganz.“ Seine Hand festigt ihren Griff um den Stab. „Er beabsichtigte die Brücke zu passieren, ganz so, als würde er auf den Rücken des Dyrwalds treten.“
 
 „Und WIR beabsichtigten, ihn im Licht unseres Glaubens –&#160;und dem seinen&#160;– zu verbrennen. Zwölf auf der Brücke und zwölf im Schatten, und wir opferten uns auf.“</DefaultText>
       <FemaleText />
@@ -331,7 +331,7 @@ Durance’ Stimme geht seltsam nach oben&#160;… zum ersten Mal wirkt es so, al
       <ID>73</ID>
       <DefaultText>„Jeder der Zwölf, die den Götterhammer hervorbrachten, hätten alles getan, um den Dyrwald und seine Bevölkerung zu retten. Das war der Grund, weshalb man uns ausgewählt hatte.“
 
-„Jeder von uns&#160;…“ Durance’ Gesicht verzerrt sich zu einem Zähnefletschen. „Jeder von uns hasste diesen Heuchler. Dieser Zorn, diese Tatkraft, diese Rebellion floss in unsere Arbeit ein.“
+„Jeder von uns&#160;…“ Durance' Gesicht verzerrt sich zu einem Zähnefletschen. „Jeder von uns hasste diesen Heuchler. Dieser Zorn, diese Tatkraft, diese Rebellion floss in unsere Arbeit ein.“
 
 „Und in unser Studium über ihn ebenfalls.“</DefaultText>
       <FemaleText />
@@ -397,7 +397,7 @@ Durance’ Stimme geht seltsam nach oben&#160;… zum ersten Mal wirkt es so, al
     </Entry>
     <Entry>
       <ID>88</ID>
-      <DefaultText>Durance will dich schon anblaffen, hält aber dann doch inne und nickt. „Es schien mir an der Zeit zu sein, die Lehren zu finden, die ich verloren hatte. Und um den Willen der Göttin während der Säuberungen zu erfüllen&#160;… Der Glaube an Eothas’ Glauben existierte noch immer.“</DefaultText>
+      <DefaultText>Durance will dich schon anblaffen, hält aber dann doch inne und nickt. „Es schien mir an der Zeit zu sein, die Lehren zu finden, die ich verloren hatte. Und um den Willen der Göttin während der Säuberungen zu erfüllen&#160;… Der Glaube an Eothas' Glauben existierte noch immer.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -460,7 +460,7 @@ Er bewegt den Mund, aber seine Worte bleiben lautlos. Ausnahmsweise ist auch er 
       <ID>126</ID>
       <DefaultText>Deine Augen öffnen sich zu einer vertrauten Szene: Durance sitzt mit dem Stab über seinem Schoß auf dem Boden und auf einer Seite des Stabes lodert eine bösartige Flamme.
 
-Er ist nur schwer zu erkennen und seine weichen Gesichtszüge scheinen ineinander zu verschwimmen. Den Stab aber, dessen Einkerbungen in einem geschmolzenen Orange leuchten, kannst du deutlich erkennen. Obwohl du Durance’ Gesicht nur schwer erkennen kannst, hat er einen unverkennbar harten Gesichtsausdruck und seine Stirn ist gerunzelt. Seine leise und unverständliche Stimme zischt und stottert, als ob er ein Streitgespräch mit dem Stab führen würde. Im Feuerschein kannst du einzelne Speicheltropfen erkennen, als sie wie Funken von seinen Lippen fliegen.</DefaultText>
+Er ist nur schwer zu erkennen und seine weichen Gesichtszüge scheinen ineinander zu verschwimmen. Den Stab aber, dessen Einkerbungen in einem geschmolzenen Orange leuchten, kannst du deutlich erkennen. Obwohl du Durance' Gesicht nur schwer erkennen kannst, hat er einen unverkennbar harten Gesichtsausdruck und seine Stirn ist gerunzelt. Seine leise und unverständliche Stimme zischt und stottert, als ob er ein Streitgespräch mit dem Stab führen würde. Im Feuerschein kannst du einzelne Speicheltropfen erkennen, als sie wie Funken von seinen Lippen fliegen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_durance_v2.stringtable
+++ b/text/conversations/companions/companion_cv_durance_v2.stringtable
@@ -260,10 +260,10 @@ Als du aufblickst, siehst du den Mann, der dich beim Studieren des Stabs beobach
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>„Du siehst mich als Last?“ Durance’ Gesicht verzerrt sich zu einem Zähnefletschen. „Ich bin gekommen, um dir zu helfen, Wächter. Du wiederum könntest mir gar nicht mehr helfen, als mich mit dir ziehen zu lassen.“
+      <DefaultText>„Du siehst mich als Last?“ Durance' Gesicht verzerrt sich zu einem Zähnefletschen. „Ich bin gekommen, um dir zu helfen, Wächter. Du wiederum könntest mir gar nicht mehr helfen, als mich mit dir ziehen zu lassen.“
 
 „Die Schlacht ist mir nicht fremd, solltest du diesbezügliche Sorgen haben. Außerdem kann ich Wunden versorgen und mit Rat zur Seite stehen&#160;… aber beides nur, wenn du mich darum bittest.“</DefaultText>
-      <FemaleText>„Du siehst mich als Last?“ Durance’ Gesicht verzerrt sich zu einem Zähnefletschen. „Ich bin gekommen, um dir zu helfen, Wächterin. Du wiederum könntest mir gar nicht mehr helfen, als mich mit dir ziehen zu lassen.“
+      <FemaleText>„Du siehst mich als Last?“ Durance' Gesicht verzerrt sich zu einem Zähnefletschen. „Ich bin gekommen, um dir zu helfen, Wächterin. Du wiederum könntest mir gar nicht mehr helfen, als mich mit dir ziehen zu lassen.“
 
 „Die Schlacht ist mir nicht fremd, solltest du diesbezügliche Sorgen haben. Außerdem kann ich Wunden versorgen und mit Rat zur Seite stehen&#160;… aber beides nur, wenn du mich darum bittest.“</FemaleText>
     </Entry>
@@ -279,8 +279,8 @@ Als du aufblickst, siehst du den Mann, der dich beim Studieren des Stabs beobach
     </Entry>
     <Entry>
       <ID>54</ID>
-      <DefaultText>Ein Lächeln zieht über Durance’ Gesicht. „Dann lass uns zusammen losziehen, Wächter.“</DefaultText>
-      <FemaleText>Ein Lächeln zieht über Durance’ Gesicht. „Dann lass uns zusammen losziehen, Wächterin.“</FemaleText>
+      <DefaultText>Ein Lächeln zieht über Durance' Gesicht. „Dann lass uns zusammen losziehen, Wächter.“</DefaultText>
+      <FemaleText>Ein Lächeln zieht über Durance' Gesicht. „Dann lass uns zusammen losziehen, Wächterin.“</FemaleText>
     </Entry>
     <Entry>
       <ID>55</ID>
@@ -390,7 +390,7 @@ Er sieht aus, als würde er etwas sagen wollen, dann fällt die Anspannung aber 
     </Entry>
     <Entry>
       <ID>109</ID>
-      <DefaultText>Durance’ Gesicht ist voller Wut und sein Körper zittert. „MÜSSEN wir denn immer die Werkzeuge der Götter sein?! Sollten Woedica&#160;… und Magran&#160;… wenn sie der Grund für all das sind&#160;… die Hohlgeburten&#160;… wenn die Säuberungen niemals notwendig waren&#160;… wenn sich Eothas nur wehrte&#160;…“</DefaultText>
+      <DefaultText>Durance' Gesicht ist voller Wut und sein Körper zittert. „MÜSSEN wir denn immer die Werkzeuge der Götter sein?! Sollten Woedica&#160;… und Magran&#160;… wenn sie der Grund für all das sind&#160;… die Hohlgeburten&#160;… wenn die Säuberungen niemals notwendig waren&#160;… wenn sich Eothas nur wehrte&#160;…“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -430,7 +430,7 @@ Er sieht aus, als würde er etwas sagen wollen, dann fällt die Anspannung aber 
     </Entry>
     <Entry>
       <ID>118</ID>
-      <DefaultText>„So viele Lügen&#160;…“ Durance’ Körper zittert weiterhin, und seine Hände ballen sich so krampfhaft zu Fäusten, dass sie weiß werden. Er bricht in Schweiß aus, der im seitlich das Gesicht hinabläuft. „…&#160;und Woedica&#160;… vielleicht ist sie die nächste Göttin, die dem Götterhammer zum Opfer fallen wird.“</DefaultText>
+      <DefaultText>„So viele Lügen&#160;…“ Durance' Körper zittert weiterhin, und seine Hände ballen sich so krampfhaft zu Fäusten, dass sie weiß werden. Er bricht in Schweiß aus, der im seitlich das Gesicht hinabläuft. „…&#160;und Woedica&#160;… vielleicht ist sie die nächste Göttin, die dem Götterhammer zum Opfer fallen wird.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -635,7 +635,7 @@ Schließlich wendet er sich dir zu, sein Gesicht ruhig und gefasst.</DefaultText
     </Entry>
     <Entry>
       <ID>161</ID>
-      <DefaultText>„Wenn ich nur daran denke&#160;… Dass ich ihr diente. Dass ich ihr folgte.“ Durance’ Gesicht verzerrt sich zu einem Zähnefletschen. „Jetzt werde ich niemandem mehr dienen. Woedicas Lügen müssen gesühnt werden&#160;… und anscheinend muss ich jetzt auch noch Feuer und Krieg von den falschen Behauptungen einer Göttin ertragen.“
+      <DefaultText>„Wenn ich nur daran denke&#160;… Dass ich ihr diente. Dass ich ihr folgte.“ Durance' Gesicht verzerrt sich zu einem Zähnefletschen. „Jetzt werde ich niemandem mehr dienen. Woedicas Lügen müssen gesühnt werden&#160;… und anscheinend muss ich jetzt auch noch Feuer und Krieg von den falschen Behauptungen einer Göttin ertragen.“
 
 Sein Gesicht wird steinern und seine brennenden Augen wirken fast hungrig. „Ich beziehe immer noch Stärke von ihr, wie früher&#160;… so lange es geht.“ Durance knurrt. „Denn ich werde sie nicht beiseite stoßen, bis ich ihr alle Stärke geraubt und selbst genug habe&#160;… genau so, wie sie es mit mir vorhatte.“</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_durance_voice_set.stringtable
+++ b/text/conversations/companions/companion_cv_durance_voice_set.stringtable
@@ -221,7 +221,7 @@
     </Entry>
     <Entry>
       <ID>44</ID>
-      <DefaultText>„Für ihn gibt’s dieses Mal keine Wiedergeburt.“</DefaultText>
+      <DefaultText>„Für ihn gibt's dieses Mal keine Wiedergeburt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_eder_hub2.stringtable
+++ b/text/conversations/companions/companion_cv_eder_hub2.stringtable
@@ -210,7 +210,7 @@ Er lacht. „Er machte mir wirklich das Leben schwer, und ließ mich dumm ausseh
     </Entry>
     <Entry>
       <ID>40</ID>
-      <DefaultText>„In jüngeren Jahren dachte ich, ich würde einmal das Wort Eothas’ predigen. Nur in unserem Tempel dort.“
+      <DefaultText>„In jüngeren Jahren dachte ich, ich würde einmal das Wort Eothas' predigen. Nur in unserem Tempel dort.“
 
 „Meine Eltern standen dahinter. Ich hatte ihnen als Heranwachsender so viele Schwierigkeiten bereitet, dass sie immer sagten, ich sollte mich besser mit dem Gott der Erlösung gut stellen.“</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_eder_intro.stringtable
+++ b/text/conversations/companions/companion_cv_eder_intro.stringtable
@@ -260,19 +260,19 @@ Er betrachtet dich von Kopf bis Fuß und zieht eine Grimasse. „Glaube nicht, d
       <ID>48</ID>
       <DefaultText>Er zuckt mit den Achseln. „Hat sich den falschen Gott ausgesucht. Darauf läuft es doch hinaus.“
 
-„In Goldtal gab es mal viele Anhänger Eothas’. Dieser Haufen Felsbrocken da drüben war früher mal ein Eothas-Tempel, nur damit du dir eine Vorstellung machen kannst.“</DefaultText>
+„In Goldtal gab es mal viele Anhänger Eothas'. Dieser Haufen Felsbrocken da drüben war früher mal ein Eothas-Tempel, nur damit du dir eine Vorstellung machen kannst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>49</ID>
-      <DefaultText>„Dann tauchte eines Tages jemand namens Waidwen auf der Türschwelle des Dyrwalds auf. Das lebende Fleisch Eothas’ sei er, hieß es. Dass er eine Armee mitgebracht hätte, sagte er. Und auf einmal war Eothas hierzulande nicht mehr so beliebt.“
+      <DefaultText>„Dann tauchte eines Tages jemand namens Waidwen auf der Türschwelle des Dyrwalds auf. Das lebende Fleisch Eothas' sei er, hieß es. Dass er eine Armee mitgebracht hätte, sagte er. Und auf einmal war Eothas hierzulande nicht mehr so beliebt.“
 
 „Weder mein Bruder Woden noch ich glaubten das. Das konnte unmöglich Eothas sein. Er meldete sich zu den Waffen, und ich folgte ihm. Er aber kam nicht mehr zurück.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>„Nach dem Krieg begannen die Leute, die Anhänger Eothas’ zu bestrafen und sie des Verrats zu beschuldigen. Besonders nachdem das Vermächtnis begann, wurde es wirklich hässlich. Die Leute brauchten einfach einen Sündenbock.“
+      <DefaultText>„Nach dem Krieg begannen die Leute, die Anhänger Eothas' zu bestrafen und sie des Verrats zu beschuldigen. Besonders nachdem das Vermächtnis begann, wurde es wirklich hässlich. Die Leute brauchten einfach einen Sündenbock.“
 
 „Mir passierte nichts, weil ich gekämpft hatte, aber dann wurde dieses Gerücht verbreitet, dass mein Bruder auf der falschen Seite stand. Dann war ich auf einmal nicht mehr sicher&#160;– nicht bis mein Vorarbeiter einschritt und sagte, sie müssten ihn schon hängen, um an mich heranzukommen.“</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_eder_quest.stringtable
+++ b/text/conversations/companions/companion_cv_eder_quest.stringtable
@@ -361,7 +361,7 @@ Du öffnest die Augen.</DefaultText>
 
 Seine Stimme ist kaum mehr als ein Flüstern.
 
-„Das war’s wohl.“</DefaultText>
+„Das war's wohl.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_hiravias.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias.stringtable
@@ -207,7 +207,7 @@ Er richtet seine Aufmerksamkeit auf seine Schulter und zupft sich ein kleines Sa
     </Entry>
     <Entry>
       <ID>206</ID>
-      <DefaultText>„Siehst du das?“ Er hält das Samenkorn hoch. „Ich weiß, es ist nur ein Samenkorn&#160;– aber so eins habe ich noch nie gesehen, und ich kann kaum erwarten, was daraus wachsen wird. Jeden Tag sehe ich hier draußen etwas Neues. Eines Tages werde ich in die Heimat zurückkehren, aber für’s Erste übertrifft meine Neugier mein Heimweh um das Siebenfache.“</DefaultText>
+      <DefaultText>„Siehst du das?“ Er hält das Samenkorn hoch. „Ich weiß, es ist nur ein Samenkorn&#160;– aber so eins habe ich noch nie gesehen, und ich kann kaum erwarten, was daraus wachsen wird. Jeden Tag sehe ich hier draußen etwas Neues. Eines Tages werde ich in die Heimat zurückkehren, aber fürs Erste übertrifft meine Neugier mein Heimweh um das Siebenfache.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -738,7 +738,7 @@ Er spuckt auf den Boden. „Alles.“</DefaultText>
     </Entry>
     <Entry>
       <ID>355</ID>
-      <DefaultText>„Und danke dir für’s Zuhören“, sagt er mit einer leichten Verbeugung, bevor er hinter dir wieder in die Marschordnung einfällt.</DefaultText>
+      <DefaultText>„Und danke dir fürs Zuhören“, sagt er mit einer leichten Verbeugung, bevor er hinter dir wieder in die Marschordnung einfällt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -822,7 +822,7 @@ Mit fast flüsternder Stimme sagt er schließlich: „Ich frage mich, ob sie woh
     </Entry>
     <Entry>
       <ID>372</ID>
-      <DefaultText>„Ich will es gar nicht wissen&#160;… weiter geht’s&#160;…“</DefaultText>
+      <DefaultText>„Ich will es gar nicht wissen&#160;… weiter geht's&#160;…“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_hiravias_intro.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias_intro.stringtable
@@ -84,7 +84,7 @@ Er geht einen Schritt zurück, wobei er die Arme ausbreitet und dir den Kadaver 
       <ID>18</ID>
       <DefaultText>Er kneift sein gutes Auge zusammen und legt seine Stirn in Falten. „Naja, vielleicht überlegst du es dir ja nochmal.“
 
-Er beugt seinen Kopf zu dir und kaut weiter an einem Fetzen Hirschfleisch. „Mach’s gut, Reisender, und pass in der Schlucht auf, wohin du trittst.“</DefaultText>
+Er beugt seinen Kopf zu dir und kaut weiter an einem Fetzen Hirschfleisch. „Mach's gut, Reisender, und pass in der Schlucht auf, wohin du trittst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -104,7 +104,7 @@ Er beugt seinen Kopf zu dir und kaut weiter an einem Fetzen Hirschfleisch. „Ma
     </Entry>
     <Entry>
       <ID>22</ID>
-      <DefaultText>Er richtet sich auf und verschränkt seine Arme. „Ich bin in dieser Gegend fremd und für’s Erste habe ich genug davon, alleine zu reisen.“ Er starrt dich mit besorgtem Gesichtsausdruck an und kratzt sich im Fell um sein halb abgetrenntes Ohr herum.
+      <DefaultText>Er richtet sich auf und verschränkt seine Arme. „Ich bin in dieser Gegend fremd und fürs Erste habe ich genug davon, alleine zu reisen.“ Er starrt dich mit besorgtem Gesichtsausdruck an und kratzt sich im Fell um sein halb abgetrenntes Ohr herum.
 
 „Aber das war nur ein Angebot, Freund. Wenn du keinen Bedarf für einen erfahrenen Druiden hast, dann sei es eben so.“</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_hiravias_quest.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias_quest.stringtable
@@ -211,7 +211,7 @@ Seine Hände zupfen an seinem Waffenrock und er richtet seinen Körper auf. „I
     </Entry>
     <Entry>
       <ID>38</ID>
-      <DefaultText>„Das ist&#160;…“ Hiravias’ gesundes Ohr stellt sich auf und ihm zieht ein Lächeln übers Gesicht. „Das ist ein äußerst gutes Argument. Warum habe ich nicht selbst daran gedacht?“
+      <DefaultText>„Das ist&#160;…“ Hiravias' gesundes Ohr stellt sich auf und ihm zieht ein Lächeln übers Gesicht. „Das ist ein äußerst gutes Argument. Warum habe ich nicht selbst daran gedacht?“
 
 Er fährt mit den seinen Händen die Narben an seinem Auge entlang, und seine Körperhaltung wird durch nervöse Gedanken belebt.
 

--- a/text/conversations/companions/companion_cv_hiravias_voice_set.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias_voice_set.stringtable
@@ -431,7 +431,7 @@
     </Entry>
     <Entry>
       <ID>146</ID>
-      <DefaultText>„Um was geht’s denn hier überhaupt?“</DefaultText>
+      <DefaultText>„Um was geht's denn hier überhaupt?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_kana_hub.stringtable
+++ b/text/conversations/companions/companion_cv_kana_hub.stringtable
@@ -1156,7 +1156,7 @@ Kana lächelt. „Er mag meinen Worten zwar keinen Glauben schenken, aber wenigs
     </Entry>
     <Entry>
       <ID>243</ID>
-      <DefaultText>„Für sie habe ich es nicht getan. Es war lediglich der beste Weg, Thaos’ Pläne zu durchkreuzen.“</DefaultText>
+      <DefaultText>„Für sie habe ich es nicht getan. Es war lediglich der beste Weg, Thaos' Pläne zu durchkreuzen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1358,7 +1358,7 @@ Kana äugt dich an. „Mir ist aufgefallen, dass sie sich nicht sonderlich für 
     </Entry>
     <Entry>
       <ID>287</ID>
-      <DefaultText>„Das war vernünftig. Trotzdem fürchte ich, dass du Thaos’ Arbeit für ihn erledigt hast. Ich glaube, dass es für lange Zeit niemand mehr wagen wird, zugunsten der Beseelung das Wort zu ergreifen.“</DefaultText>
+      <DefaultText>„Das war vernünftig. Trotzdem fürchte ich, dass du Thaos' Arbeit für ihn erledigt hast. Ich glaube, dass es für lange Zeit niemand mehr wagen wird, zugunsten der Beseelung das Wort zu ergreifen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_kana_od_nua.stringtable
+++ b/text/conversations/companions/companion_cv_kana_od_nua.stringtable
@@ -103,7 +103,7 @@ Kana hält inne. „Naja, hier oben ist natürlich alles aedyrischer Bauart, abe
     </Entry>
     <Entry>
       <ID>20</ID>
-      <DefaultText>„Er war im Besitz des Tanvii ora Toha&#160;– oder der Form, die der uns bekannten vorausging. Ich habe es in den Ruinen neben Gabrannos’ Namen gesehen&#160;– Reste derselben Symbole und Verse, die wir auch in Rauatai kennen. Er muss die Worte in hohen Ehren gehalten haben, oder vielleicht hat er sie sogar geschrieben&#160;…“</DefaultText>
+      <DefaultText>„Er war im Besitz des Tanvii ora Toha&#160;– oder der Form, die der uns bekannten vorausging. Ich habe es in den Ruinen neben Gabrannos' Namen gesehen&#160;– Reste derselben Symbole und Verse, die wir auch in Rauatai kennen. Er muss die Worte in hohen Ehren gehalten haben, oder vielleicht hat er sie sogar geschrieben&#160;…“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -365,7 +365,7 @@ Er beugt sich über die zerschmetterten Fragmente und legt die größten von ihn
     </Entry>
     <Entry>
       <ID>73</ID>
-      <DefaultText>„Ein Studierzimmer! Gabrannos’ Arbeit muss&#160;–“</DefaultText>
+      <DefaultText>„Ein Studierzimmer! Gabrannos' Arbeit muss&#160;–“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -446,7 +446,7 @@ Kana seufzt. „Lass uns die Tafel finden und von hier verschwinden.“</Default
     </Entry>
     <Entry>
       <ID>88</ID>
-      <DefaultText>„Ich dachte, hier würde sich eine Art Erklärung dafür finden. Eine Art Rechtfertigung.“ Kana seufzt und legt seinen Holzkohlestift ab. „Für mein ganzes Suchen. Gabrannos’ Arbeit. Die ganze Arbeit.“</DefaultText>
+      <DefaultText>„Ich dachte, hier würde sich eine Art Erklärung dafür finden. Eine Art Rechtfertigung.“ Kana seufzt und legt seinen Holzkohlestift ab. „Für mein ganzes Suchen. Gabrannos' Arbeit. Die ganze Arbeit.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -552,7 +552,7 @@ Er beäugt dich neugierig. „Du sprichst Engwithanisch. Vielleicht könntest du
       <ID>108</ID>
       <DefaultText>Kana guckt ein wenig finster drein und legt die Stirn gedankenverloren in Falten. „Das ist allerdings wahr. Es gab bereits Unterschiede bei der Formulierung, und ein Großteil des Gesangs hat sich sogar während der letzten paar Jahrhunderte verändert&#160;…“
 
-„…&#160;Wir sollten besser unseren eigenen Weg gehen, als Gabrannos’ Beispiel zu folgen.“</DefaultText>
+„…&#160;Wir sollten besser unseren eigenen Weg gehen, als Gabrannos' Beispiel zu folgen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -714,7 +714,7 @@ Er beäugt dich neugierig. „Du sprichst Engwithanisch. Vielleicht könntest du
     </Entry>
     <Entry>
       <ID>138</ID>
-      <DefaultText>„So ist’s recht. Wir werden uns diese Kirche ansehen, von der er gesprochen hat. Ich freue mich schon darauf, herauszufinden, wie genau der Bleierne Schlüssel in all das verwickelt ist.“</DefaultText>
+      <DefaultText>„So ist's recht. Wir werden uns diese Kirche ansehen, von der er gesprochen hat. Ich freue mich schon darauf, herauszufinden, wie genau der Bleierne Schlüssel in all das verwickelt ist.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_pallegina_voice_set.stringtable
+++ b/text/conversations/companions/companion_cv_pallegina_voice_set.stringtable
@@ -101,7 +101,7 @@
     </Entry>
     <Entry>
       <ID>23</ID>
-      <DefaultText>„Das war’s für mich.“</DefaultText>
+      <DefaultText>„Das war's für mich.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -196,7 +196,7 @@
     </Entry>
     <Entry>
       <ID>43</ID>
-      <DefaultText>„Ja, ich bin’s: Pallegina, der Paladin, deine Freundin.“</DefaultText>
+      <DefaultText>„Ja, ich bin's: Pallegina, der Paladin, deine Freundin.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_sagani_clues.stringtable
+++ b/text/conversations/companions/companion_cv_sagani_clues.stringtable
@@ -406,7 +406,7 @@ Du spürst eine Gegenwart in dem Biest, etwas Uraltes und Vertrautes. Bevor du a
     </Entry>
     <Entry>
       <ID>80</ID>
-      <DefaultText>„Aurochs’ Schatten.“ Sagani schließt zu dir auf. Ihre weit aufgerissenen Augen starren auf den sterbenden Hirsch.</DefaultText>
+      <DefaultText>„Aurochs' Schatten.“ Sagani schließt zu dir auf. Ihre weit aufgerissenen Augen starren auf den sterbenden Hirsch.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_sagani_main.stringtable
+++ b/text/conversations/companions/companion_cv_sagani_main.stringtable
@@ -468,7 +468,7 @@ Sie zählt an ihren schwieligen Fingern ab. „Karibus, Robben und kleine Wale v
     </Entry>
     <Entry>
       <ID>180</ID>
-      <DefaultText>„Die lange Version. Na gut, los geht’s.“ Ihr Schultern heben und senken sich, als sie tief einatmet.
+      <DefaultText>„Die lange Version. Na gut, los geht's.“ Ihr Schultern heben und senken sich, als sie tief einatmet.
 
 „Ich komme von einer Insel weit im Süden, die man Naasitaq nennt. Ich bin auf der Suche nach einem Dorfältesten hierher gekommen, einen Mann, den wir als Persoq kannten. Zuhause bin ich eine Jägerin, deshalb fiele es mir unter normalen Umständen nicht schwer, jemanden aufzuspüren.“
 
@@ -721,7 +721,7 @@ Als sie es dir hinhält, spürst du schwache Empfindungen. Keine echten Erinneru
     </Entry>
     <Entry>
       <ID>229</ID>
-      <DefaultText>„Ich mein’s ernst.“</DefaultText>
+      <DefaultText>„Ich mein's ernst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_sagani_voice_set.stringtable
+++ b/text/conversations/companions/companion_cv_sagani_voice_set.stringtable
@@ -136,7 +136,7 @@
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>„Den Großen hat’s erwischt!“</DefaultText>
+      <DefaultText>„Den Großen hat's erwischt!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -196,7 +196,7 @@
     </Entry>
     <Entry>
       <ID>45</ID>
-      <DefaultText>„Sieht so als, als wäre Durance’ Flamme gerade erloschen.“</DefaultText>
+      <DefaultText>„Sieht so als, als wäre Durance' Flamme gerade erloschen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_sun_in_shadows_end.stringtable
+++ b/text/conversations/companions/companion_cv_sun_in_shadows_end.stringtable
@@ -43,7 +43,7 @@ Hiravias kratzt sich am Kinn und betrachtet dich von oben bis unten. „[Player 
     </Entry>
     <Entry>
       <ID>9</ID>
-      <DefaultText>Die Trauernde Mutter schließt die Augen und nickt dir einmal kurz zu. „Es war mir eine Ehre, mit dir zu reisen&#160;… und dabei zu helfen, den Dyrwald von Thaos’ bösen Taten zu säubern.“
+      <DefaultText>Die Trauernde Mutter schließt die Augen und nickt dir einmal kurz zu. „Es war mir eine Ehre, mit dir zu reisen&#160;… und dabei zu helfen, den Dyrwald von Thaos' bösen Taten zu säubern.“
 
 Die Glocken an ihren Handgelenken klingen, als sie die Finger wringt. „Und nun steht du vor einer weiteren Entscheidung. Bitte, Wächter&#160;– bringe diese Seelen zurück in ihre Zuhause, zu ihren Familien. Gib den Leuten die Erinnerung an die Heilung, die auf das Vermächtnis folgte.“</DefaultText>
       <FemaleText />
@@ -90,7 +90,7 @@ Die Glocken an ihren Handgelenken klingen, als sie die Finger wringt. „Und nun
     </Entry>
     <Entry>
       <ID>19</ID>
-      <DefaultText>Die Trauernde Mutter schließt die Augen und nickt dir einmal kurz zu. „Es war mir eine Ehre, mit dir zu reisen&#160;… und dabei zu helfen, den Dyrwald von Thaos’ bösen Taten zu säubern.“
+      <DefaultText>Die Trauernde Mutter schließt die Augen und nickt dir einmal kurz zu. „Es war mir eine Ehre, mit dir zu reisen&#160;… und dabei zu helfen, den Dyrwald von Thaos' bösen Taten zu säubern.“
 
 Die Glocken an ihren Handgelenken klingen, als sie die Finger wringt. „Und doch&#160;… wenn wir uns von diesem Vermächtnis befreien wollen, musst du zunächst die Seelen befreien, die er gefangen hat. Seine Arbeit kann nicht ungeschehen gemacht werden&#160;… diese Seelen an gebrochene Leben zu ketten wird sie nur verlängern.“</DefaultText>
       <FemaleText />

--- a/text/conversations/endgameslides.stringtable
+++ b/text/conversations/endgameslides.stringtable
@@ -34,7 +34,7 @@ Nachdem sein Heimweh abgestorben war, fand er wieder Freude und Ruhe darin, die 
       <ID>7</ID>
       <DefaultText>Beginnend mit dem ältesten forderte Hiravias einen nach dem anderen jedes Mitglied des Rats zum Kampf heraus&#160;– und blamierte die Rîow in einer Reihe gnadenloser Duelle.
 
-Nachdem der halbe Rat blutverschmiert und bis auf die Knochen blamiert war, erkannten die Ältesten endlich Hiravias’ Stärke an und ernannten ihn zu einem Jäger des Fischerkranich-Stamms.
+Nachdem der halbe Rat blutverschmiert und bis auf die Knochen blamiert war, erkannten die Ältesten endlich Hiravias' Stärke an und ernannten ihn zu einem Jäger des Fischerkranich-Stamms.
 
 Kaum war ihm dieser Titel verliehen worden, verließ Hiravias seelenruhig das Dorf und begann wieder sein Leben auf Wanderschaft.</DefaultText>
       <FemaleText />
@@ -290,7 +290,7 @@ Paradoxerweise wurde Edérs Glaube an Eothas durch die Erkenntnis, dass die Göt
       <ID>56</ID>
       <DefaultText>Nachdem der Staub in Sonne im Schatten sich gelegt hatte, blickte Aloth auf die Überreste seines ehemaligen Meisters Thaos ix Arkannon. Er sah, wo der Großmeister irrgegangen war, und er wusste, dass er es besser machen würde.
 
-Die Geheimnisse der Götter würden bewahrt werden und damit die geistige Gesundheit und das Wohlergehen aller Gestandenen. Er kleidete sich in den Überresten von Thaos’ zeremoniellem Gewand und rüstete sich für die lange und einsame Aufgabe, die vor ihm lag.</DefaultText>
+Die Geheimnisse der Götter würden bewahrt werden und damit die geistige Gesundheit und das Wohlergehen aller Gestandenen. Er kleidete sich in den Überresten von Thaos' zeremoniellem Gewand und rüstete sich für die lange und einsame Aufgabe, die vor ihm lag.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -385,7 +385,7 @@ Er wanderte weiter durch die Welt, mittellos und arm&#160;– nicht mehr auf der
     </Entry>
     <Entry>
       <ID>71</ID>
-      <DefaultText>Durance gab Woedica weiterhin die Schuld an den Gräueltaten des Kriegs des Heiligen. Durance glaubte, dass Magran eine Marionette in den Plänen der Königin, die Gewesen war, war. Und er sah in Thaos’ Vertreibung einen Schritt hin zu einer Versöhnung mit seiner Göttin. Daher versuchte er einige Zeit lang, die Kommunikation mit ihr wieder aufzunehmen. Als er jedoch nur Schweigen als Antwort erhielt, sah er das als eine Verdammung seiner fortdauernden Existenz.
+      <DefaultText>Durance gab Woedica weiterhin die Schuld an den Gräueltaten des Kriegs des Heiligen. Durance glaubte, dass Magran eine Marionette in den Plänen der Königin, die Gewesen war, war. Und er sah in Thaos' Vertreibung einen Schritt hin zu einer Versöhnung mit seiner Göttin. Daher versuchte er einige Zeit lang, die Kommunikation mit ihr wieder aufzunehmen. Als er jedoch nur Schweigen als Antwort erhielt, sah er das als eine Verdammung seiner fortdauernden Existenz.
 
 Schließlich errichtete er einen Scheiterhaufen, warf sich darauf und entzündete ihn mit seinem eigenen zertrümmerten Stab.</DefaultText>
       <FemaleText />
@@ -419,7 +419,7 @@ In ihrer Heimat wurde sie jubelnd empfangen, doch die Worte der Freude und die G
     </Entry>
     <Entry>
       <ID>77</ID>
-      <DefaultText>Thaos’ Tod setzte deinen Wachträumen ein Ende und ließ das Flüstern der Vergangenheit verstummen. Du konntest wieder schlafen.
+      <DefaultText>Thaos' Tod setzte deinen Wachträumen ein Ende und ließ das Flüstern der Vergangenheit verstummen. Du konntest wieder schlafen.
 
 Die Fragen eines weit zurückliegenden Lebens belasteten deine Seele nicht länger. Nur eines blieb dir noch zu tun: Zu entscheiden, was du mit der Antwort tun solltest.</DefaultText>
       <FemaleText />
@@ -431,7 +431,7 @@ Die Fragen eines weit zurückliegenden Lebens belasteten deine Seele nicht läng
     </Entry>
     <Entry>
       <ID>79</ID>
-      <DefaultText>Mit einer kurzen Bewegung seines Handgelenks verbrannte er Thaos’ Robe und Kopfschmuck und sämtliche anderen Symbole für die Macht des Mannes. Nie wieder, so schwor er sich, sollten Gestandene in Furcht und blindem Gehorsam einer Autorität gegenüber leben, die sie nicht verstehen.
+      <DefaultText>Mit einer kurzen Bewegung seines Handgelenks verbrannte er Thaos' Robe und Kopfschmuck und sämtliche anderen Symbole für die Macht des Mannes. Nie wieder, so schwor er sich, sollten Gestandene in Furcht und blindem Gehorsam einer Autorität gegenüber leben, die sie nicht verstehen.
 
 Bewaffnet mit dem Wissen und dem Mut, die er auf seinen Reisen mit dem Wächter gewonnen hatte, begann er mit der langen und einsamen Aufgabe, den Bleiernen Schlüssel zu zerschlagen.</DefaultText>
       <FemaleText />

--- a/text/conversations/prototype_2/p2_cv_hendyna.stringtable
+++ b/text/conversations/prototype_2/p2_cv_hendyna.stringtable
@@ -320,7 +320,7 @@ Sie beugt sich näher zu dir heran. „Und komm immer bei mir vorbei, wenn du Tr
     </Entry>
     <Entry>
       <ID>93</ID>
-      <DefaultText>„Komm schon, spuck’s aus.“</DefaultText>
+      <DefaultText>„Komm schon, spuck's aus.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/prototype_2/p2_cv_pool.stringtable
+++ b/text/conversations/prototype_2/p2_cv_pool.stringtable
@@ -351,7 +351,7 @@ Er hebt die Hände schützend vor sein Gesicht, um den blutigen Anblick nicht zu
     </Entry>
     <Entry>
       <ID>135</ID>
-      <DefaultText>„Er&#160;… er ist fort! Welche dunkle Magie haben wir mitangesehen?“ Hiravias’ gesundes Ohr steht auf, der Orlaner blickt sich in alle Richtungen um.
+      <DefaultText>„Er&#160;… er ist fort! Welche dunkle Magie haben wir mitangesehen?“ Hiravias' gesundes Ohr steht auf, der Orlaner blickt sich in alle Richtungen um.
 
 „Wir müssen hier fort, solange wir es noch können!“</DefaultText>
       <FemaleText />
@@ -522,7 +522,7 @@ Du spürst eine andere Präsenz im Blutbecken, verwirrt und wütend. Die anderen
     </Entry>
     <Entry>
       <ID>168</ID>
-      <DefaultText>„Sie ist fort! Welche dunkle Magie haben wir eben gesehen?“ Hiravias’ gesundes Ohr steht auf, der Orlaner blickt sich in alle Richtungen um.
+      <DefaultText>„Sie ist fort! Welche dunkle Magie haben wir eben gesehen?“ Hiravias' gesundes Ohr steht auf, der Orlaner blickt sich in alle Richtungen um.
 
 „Wir müssen hier fort, solange wir es noch können!“</DefaultText>
       <FemaleText />

--- a/text/conversations/prototype_2/p2_cv_rumbald.stringtable
+++ b/text/conversations/prototype_2/p2_cv_rumbald.stringtable
@@ -123,7 +123,7 @@
     </Entry>
     <Entry>
       <ID>77</ID>
-      <DefaultText>„Ich hab’s dir ja gesagt! Lass mich und meine Schweine in Ruhe!“</DefaultText>
+      <DefaultText>„Ich hab's dir ja gesagt! Lass mich und meine Schweine in Ruhe!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
- Apostrophe im conversations Ordner zurückgesetzt.
- Deppenapostrophe bei "fürs [Erste]" entfernt. (Weil ich das gerade gesehen hab)
