### PR TITLE
Ausländer -> Fremde

### DIFF
--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_harassing_thug_leader_01.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_harassing_thug_leader_01.stringtable
@@ -41,8 +41,8 @@
     </Entry>
     <Entry>
       <ID>13</ID>
-      <DefaultText>„Das ist uns wohl ein Hochwohlgeborener ins Netz gegangen, ein ausländischer noch dazu.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns ihn gebührend willkommen heißen.“</DefaultText>
-      <FemaleText>„Da ist uns wohl eine Hochwohlgeborene ins Netz gegangen, eine ausländische noch dazu.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns sie gebührend willkommen heißen.“</FemaleText>
+      <DefaultText>„Das ist uns wohl ein Hochwohlgeborener ins Netz gegangen, ein fremdländischer noch dazu.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns ihn gebührend willkommen heißen.“</DefaultText>
+      <FemaleText>„Da ist uns wohl eine Hochwohlgeborene ins Netz gegangen, eine fremdländische noch dazu.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns sie gebührend willkommen heißen.“</FemaleText>
     </Entry>
   </Entries>
 </StringTableFile>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_harassing_thug_leader_01.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_harassing_thug_leader_01.stringtable
@@ -36,8 +36,8 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>„Also, wenn das nicht der beliebteste Ausländer in Trutzbucht ist.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns ihn gebührend willkommen heißen.“</DefaultText>
-      <FemaleText>„Also, wenn das nicht der beliebteste Ausländer in Trutzbucht ist.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns sie gebührend willkommen heißen.“</FemaleText>
+      <DefaultText>„Also, wenn das nicht der beliebteste Fremde in Trutzbucht ist.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns ihn gebührend willkommen heißen.“</DefaultText>
+      <FemaleText>„Also, wenn das nicht die beliebteste Fremde in Trutzbucht ist.“ Er nickt seinen zwielichtigen Gefährten zu. „Lasst uns sie gebührend willkommen heißen.“</FemaleText>
     </Entry>
     <Entry>
       <ID>13</ID>

--- a/text/conversations/03_defiance_bay_ondra_gift/03_cv_llines.stringtable
+++ b/text/conversations/03_defiance_bay_ondra_gift/03_cv_llines.stringtable
@@ -26,7 +26,7 @@
     </Entry>
     <Entry>
       <ID>36</ID>
-      <DefaultText>Sie hebt eine Augenbraue. „Jeder ausländische Seemann und jeder fremde Dorfbewohner kennt den Salzigen Mast. Er ist das berühmteste Bordell in ganz Trutzbucht.“
+      <DefaultText>Sie hebt eine Augenbraue. „Jeder fremdländische Seemann und jeder fremde Dorfbewohner kennt den Salzigen Mast. Er ist das berühmteste Bordell in ganz Trutzbucht.“
 
 Sie deutet auf eine Aumaua-Frau. „Wenn du mehr wissen willst, frag einfach Maea.“</DefaultText>
       <FemaleText />

--- a/text/conversations/06_stronghold/06_cv_maerwald.stringtable
+++ b/text/conversations/06_stronghold/06_cv_maerwald.stringtable
@@ -101,7 +101,7 @@ Als er sich dir wieder zudreht, hat er eine selbstbewusste Körperhaltung angeno
     </Entry>
     <Entry>
       <ID>18</ID>
-      <DefaultText>Er neigt seinen Kopf nach vorne und grollt dich mit rauer Stimme an. „Der Wunsch der Götter war es, dass wir dieses Land beschützen. Mein Weg war der einzig mögliche, um die Ausländer loszuwerden!“</DefaultText>
+      <DefaultText>Er neigt seinen Kopf nach vorne und grollt dich mit rauer Stimme an. „Der Wunsch der Götter war es, dass wir dieses Land beschützen. Mein Weg war der einzig mögliche, um die Fremden loszuwerden!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -576,7 +576,7 @@ Er sieht neben sich, als ob jemand in seiner Nähe stünde. „Anzünden.“</De
     </Entry>
     <Entry>
       <ID>110</ID>
-      <DefaultText>„Dein Betrug ist umsonst. Deine Warnungen an diesen Ausländer sind verschwendet und heute Nacht wird ihr Blut Galawain zum Tribut gereichen. Ich habe die Älteren um die Ehre gebeten, dein Haupt als meine erste Trophäe zu nehmen, und sie haben es mir gestattet. Bitte den Gott der Suche, dass er dir einen schnellen Tod gewährt.“</DefaultText>
+      <DefaultText>„Dein Betrug ist umsonst. Deine Warnungen an diese Fremden sind verschwendet und heute Nacht wird ihr Blut Galawain zum Tribut gereichen. Ich habe die Älteren um die Ehre gebeten, dein Haupt als meine erste Trophäe zu nehmen, und sie haben es mir gestattet. Bitte den Gott der Suche, dass er dir einen schnellen Tod gewährt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/06_stronghold/06_cv_memory_raider.stringtable
+++ b/text/conversations/06_stronghold/06_cv_memory_raider.stringtable
@@ -30,7 +30,7 @@
       <ID>5</ID>
       <DefaultText>Seine geisterhafte Faust segelt durch deine Schulter hindurch. „Keine Sorge, jedermann erinnert sich daran, dass der Angriff deine Idee war. Die Rîow mussten mitmachen, nachdem du den Rest des Clans angestachelt hattest.“
 
-„Niemand möchte, dass den Neun Klauen Feigheit vorgeworfen wird, wenn es darum geht, mit dem Rest des Stammes den Ausländern die Stirn zu bieten, die unsere Ruinen entweiht haben.“</DefaultText>
+„Niemand möchte, dass den Neun Klauen Feigheit vorgeworfen wird, wenn es darum geht, mit dem Rest des Stammes den Fremden die Stirn zu bieten, die unsere Ruinen entweiht haben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -64,7 +64,7 @@ Er greift nach deiner Wange, hält aber auf halbem Weg inne, als ein Zweifel sei
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Er lässt seine Hand stattdessen wieder an seiner Seite fallen und zieht eine schartige Klinge aus seinem Gürtel. „Du hattest Recht. Wir waren zu weich, als die Ausländer zum ersten Mal hier auftauchten. Und jetzt? Jetzt erniedrigen sie uns!“
+      <DefaultText>Er lässt seine Hand stattdessen wieder an seiner Seite fallen und zieht eine schartige Klinge aus seinem Gürtel. „Du hattest Recht. Wir waren zu weich, als die Fremden zum ersten Mal hier auftauchten. Und jetzt? Jetzt erniedrigen sie uns!“
 
 „Niemals wieder werden wir weich sein, und die Eindringlinge werden schon bald begreifen, dass sie uns ein für alle Mal in Ruhe lassen sollten.“</DefaultText>
       <FemaleText />

--- a/text/conversations/07_gilded_vale/07_bs_forton_bystanders.stringtable
+++ b/text/conversations/07_gilded_vale/07_bs_forton_bystanders.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>„Richtig, schön bezahlen. Der andere Ausländer hat gewonnen.“</DefaultText>
+      <DefaultText>„Richtig, schön bezahlen. Der andere Fremde hat gewonnen.“</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/07_gilded_vale/07_bs_raedric_men_generic.stringtable
+++ b/text/conversations/07_gilded_vale/07_bs_raedric_men_generic.stringtable
@@ -66,8 +66,8 @@
     </Entry>
     <Entry>
       <ID>14</ID>
-      <DefaultText>„Die Leben, die du genommen hast, Ausländer, die werden wir nicht vergessen.“</DefaultText>
-      <FemaleText />
+      <DefaultText>„Die Leben, die du genommen hast, Fremder, die werden wir nicht vergessen.“</DefaultText>
+      <FemaleText>„Die Leben, die du genommen hast, Fremde, die werden wir nicht vergessen.“</FemaleText>
     </Entry>
     <Entry>
       <ID>15</ID>

--- a/text/conversations/07_gilded_vale/07_cv_magistrate_urgeat.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_magistrate_urgeat.stringtable
@@ -503,7 +503,7 @@ Während er sich im Dorf umsieht, ist sein Gesicht wie eine Maske nüchterner Zu
     </Entry>
     <Entry>
       <ID>105</ID>
-      <DefaultText>Er blinzelt. „Manchmal vergesse ich, dass ihr Ausländer diese Seuche in euren Heimatländern nicht kennt. Die Hohlgeburten sind jetzt schon seit fast fünfzehn Jahren die Geißel des Dyrwalds.“ Er senkt seine Stimme und flüstert nur noch. „Ohne Seelen geborene Kinder.“</DefaultText>
+      <DefaultText>Er blinzelt. „Manchmal vergesse ich, dass ihr Fremden diese Seuche in euren Heimatländern nicht kennt. Die Hohlgeburten sind jetzt schon seit fast fünfzehn Jahren die Geißel des Dyrwalds.“ Er senkt seine Stimme und flüstert nur noch. „Ohne Seelen geborene Kinder.“</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/text/conversations/07_gilded_vale/07_cv_raedric.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_raedric.stringtable
@@ -164,7 +164,7 @@ Er schüttelt den Kopf. „Und mit dem Vermächtnis kam die Verzweiflung. Wie h�
     </Entry>
     <Entry>
       <ID>38</ID>
-      <DefaultText>„Söldner anzuwerben ist gar nicht nach Kolscs Art.“ Raedrics Stimme spricht tief und krächzend. Er starrt dich an. „Oder Ausländer, was das betrifft. Und du gehörst nicht zu meinen Leuten.“ Er lächelt grimmig, wodurch seine weißen Zähne zum Vorschein kommen. „Das heißt auch, dass ich dich nicht des Verrats beschuldigen kann.“ Seine Finger schließen sich locker um den Knauf seines Dolchs, als wolle er überprüfen, ob er immer noch da ist, und zucken dann zurück.</DefaultText>
+      <DefaultText>„Söldner anzuwerben ist gar nicht nach Kolscs Art.“ Raedrics Stimme spricht tief und krächzend. Er starrt dich an. „Oder Fremde, was das betrifft. Und du gehörst nicht zu meinen Leuten.“ Er lächelt grimmig, wodurch seine weißen Zähne zum Vorschein kommen. „Das heißt auch, dass ich dich nicht des Verrats beschuldigen kann.“ Seine Finger schließen sich locker um den Knauf seines Dolchs, als wolle er überprüfen, ob er immer noch da ist, und zucken dann zurück.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -456,7 +456,7 @@ Edérs Gesicht ist zwar ruhig, aber du bemerkst, wie seine Hand zu seiner Waffe 
       <ID>97</ID>
       <DefaultText>„…&#160;Nein. Dafür&#160;… ist es nun zu spät.“
 
-„Dann hat er dich gekauft. Ein Söldner? Ansonsten haben seine schönen Worte eben noch einen gutgesinnten Ausländer in die Falle gelockt.“</DefaultText>
+„Dann hat er dich gekauft. Ein Söldner? Ansonsten haben seine schönen Worte eben noch einen gutgesinnten Fremden in die Falle gelockt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/07_gilded_vale/07_cv_sweynur.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_sweynur.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>„Ich weiß nicht, wer du bist, und es ist mir auch ziemlich egal. Geh weiter, wir sind nicht hierher gekommen, um mit Ausländern zu plaudern.“</DefaultText>
+      <DefaultText>„Ich weiß nicht, wer du bist, und es ist mir auch ziemlich egal. Geh weiter, wir sind nicht hierher gekommen, um mit Fremden zu plaudern.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -66,8 +66,8 @@
     </Entry>
     <Entry>
       <ID>16</ID>
-      <DefaultText>„Oh, das wundert mich gar nicht. Was für ein Adliger, dieser Trumbel. Zwei große, starke Kinder. Die reinste Seele in ganz Goldtal.“ Der Zwerg schnaubt. „Der Feigling sendet Boten aus, um seine Angelegenheiten für ihn zu erledigen? Na, du kannst zu ihm gehen und ihm sagen, dass wir seinetwegen schon seit Tagen nichts Festes mehr gegessen haben, dass wir uns seinetwegen die Schänke nicht mehr leisten können&#160;… aber dass wir uns nicht an seiner Statt von irgendeinem Ausländer einschüchtern lassen!“</DefaultText>
-      <FemaleText />
+      <DefaultText>„Oh, das wundert mich gar nicht. Was für ein Adliger, dieser Trumbel. Zwei große, starke Kinder. Die reinste Seele in ganz Goldtal.“ Der Zwerg schnaubt. „Der Feigling sendet Boten aus, um seine Angelegenheiten für ihn zu erledigen? Na, du kannst zu ihm gehen und ihm sagen, dass wir seinetwegen schon seit Tagen nichts Festes mehr gegessen haben, dass wir uns seinetwegen die Schänke nicht mehr leisten können&#160;… aber dass wir uns nicht an seiner Statt von irgendeinem Fremden einschüchtern lassen!“</DefaultText>
+      <FemaleText>„Oh, das wundert mich gar nicht. Was für ein Adliger, dieser Trumbel. Zwei große, starke Kinder. Die reinste Seele in ganz Goldtal.“ Der Zwerg schnaubt. „Der Feigling sendet Boten aus, um seine Angelegenheiten für ihn zu erledigen? Na, du kannst zu ihm gehen und ihm sagen, dass wir seinetwegen schon seit Tagen nichts Festes mehr gegessen haben, dass wir uns seinetwegen die Schänke nicht mehr leisten können&#160;… aber dass wir uns nicht an seiner Statt von irgendeiner Fremden einschüchtern lassen!“</FemaleText>
     </Entry>
     <Entry>
       <ID>17</ID>
@@ -311,8 +311,8 @@
     </Entry>
     <Entry>
       <ID>68</ID>
-      <DefaultText>„Sieh an, sieh an. Alle im Dorf reden über dich, und du gewährst UNS die Gunst deines Besuchs? Weswegen bist du hier, Ausländer? Ein Trinkspruch? Ein bisschen Applaus?“ Er hebt seinen Krug zum gespielten Gruß.</DefaultText>
-      <FemaleText>„Sieh an, sieh an. Alle im Dorf reden über dich, und du gewährst UNS die Gunst deines Besuchs? Weswegen bist du hier, Ausländerin? Ein Trinkspruch? Ein bisschen Applaus?“ Er hebt seinen Krug zum gespielten Gruß.</FemaleText>
+      <DefaultText>„Sieh an, sieh an. Alle im Dorf reden über dich, und du gewährst UNS die Gunst deines Besuchs? Weswegen bist du hier, Fremder? Ein Trinkspruch? Ein bisschen Applaus?“ Er hebt seinen Krug zum gespielten Gruß.</DefaultText>
+      <FemaleText>„Sieh an, sieh an. Alle im Dorf reden über dich, und du gewährst UNS die Gunst deines Besuchs? Weswegen bist du hier, Fremde? Ein Trinkspruch? Ein bisschen Applaus?“ Er hebt seinen Krug zum gespielten Gruß.</FemaleText>
     </Entry>
     <Entry>
       <ID>69</ID>

--- a/text/conversations/07_gilded_vale/07_cv_trumbel.stringtable
+++ b/text/conversations/07_gilded_vale/07_cv_trumbel.stringtable
@@ -36,7 +36,7 @@
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>Der Müller zögert und senkt die Keule ein wenig. „Wer bist du? Spannt Sweynur jetzt auch noch Ausländer in seinen kleinen Kreuzzug ein?“</DefaultText>
+      <DefaultText>Der Müller zögert und senkt die Keule ein wenig. „Wer bist du? Spannt Sweynur jetzt auch noch Fremde in seinen kleinen Kreuzzug ein?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/10_od_nua/1008_cv_masters_servant.stringtable
+++ b/text/conversations/10_od_nua/1008_cv_masters_servant.stringtable
@@ -181,7 +181,7 @@
     </Entry>
     <Entry>
       <ID>46</ID>
-      <DefaultText>Der Mann wirkt erschrocken, und lacht kurz. „Du verstehst mich. Hier unten sprechen jetzt selbst die Ausländer unsere Sprache. Wir sind wahrlich ein unsterbliches Volk.“ Er lacht abermals.</DefaultText>
+      <DefaultText>Der Mann wirkt erschrocken, und lacht kurz. „Du verstehst mich. Hier unten sprechen jetzt selbst die Fremden unsere Sprache. Wir sind wahrlich ein unsterbliches Volk.“ Er lacht abermals.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_aloth.stringtable
+++ b/text/conversations/companions/companion_cv_aloth.stringtable
@@ -42,7 +42,7 @@ Die Frau verschränkt ihre Arme. „Aha, willst unseren Stolz wohl mit ein paar 
       <ID>7</ID>
       <DefaultText>Einer der anderen Männer deutet auf den Elf mit der Kapuze. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. „Verspottet uns sogar noch, während er in unserem Dorf wohnt. Soviel zum Thema, was diese feinen aedyrischen Manieren wirklich wert sind.“
 
-„So eine Behandlung lassen wir uns nicht gefallen. Nicht von Ausländern, und von Aedyrern erst recht nicht.“</DefaultText>
+„So eine Behandlung lassen wir uns nicht gefallen. Nicht von Fremden, und von Aedyrern erst recht nicht.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -57,12 +57,12 @@ Die Frau verschränkt ihre Arme. „Aha, willst unseren Stolz wohl mit ein paar 
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. „Du bist ganz schön frech, uns in unserem eigenen Dorf zu verspotten. Von Ausländern lassen wir uns nicht schlecht behandeln. Von Aedyrern erst recht nicht.“</DefaultText>
+      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. „Du bist ganz schön frech, uns in unserem eigenen Dorf zu verspotten. Von Fremden lassen wir uns nicht schlecht behandeln. Von Aedyrern erst recht nicht.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. „Wir sind einfache Leute, aber dumm sind wir nicht. Das scheint er aber anders zu sehen, da er uns verspottet, während er in unserem Dorf wohnt. So lassen wir uns von Ausländern nicht anreden, und von Aedyrern erst recht nicht.“</DefaultText>
+      <DefaultText>Einer der anderen Männer starrt den Elf mit der Kapuze an. Seine Augen sind rot vom Alkohol, aber sein Blick ist fixiert. „Wir sind einfache Leute, aber dumm sind wir nicht. Das scheint er aber anders zu sehen, da er uns verspottet, während er in unserem Dorf wohnt. So lassen wir uns von Fremden nicht anreden, und von Aedyrern erst recht nicht.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -144,8 +144,8 @@ Er stellt sich fest hin. In seinen Augen flackert etwas Mürrisches und Rohes au
     </Entry>
     <Entry>
       <ID>27</ID>
-      <DefaultText>„Niemand gibt uns Befehle, Ausländer.“</DefaultText>
-      <FemaleText />
+      <DefaultText>„Niemand gibt uns Befehle, Fremder.“</DefaultText>
+      <FemaleText>„Niemand gibt uns Befehle, Fremde.“</FemaleText>
     </Entry>
     <Entry>
       <ID>28</ID>
@@ -154,8 +154,8 @@ Er stellt sich fest hin. In seinen Augen flackert etwas Mürrisches und Rohes au
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>Sie greifen dich mit hasserfüllten Augen an. „Oh nein, das wirst du nicht, Ausländer.“</DefaultText>
-      <FemaleText />
+      <DefaultText>Sie greifen dich mit hasserfüllten Augen an. „Oh nein, das wirst du nicht, Fremder.“</DefaultText>
+      <FemaleText>Sie greifen dich mit hasserfüllten Augen an. „Oh nein, das wirst du nicht, Fremde.“</FemaleText>
     </Entry>
     <Entry>
       <ID>33</ID>
@@ -169,8 +169,8 @@ Er stellt sich fest hin. In seinen Augen flackert etwas Mürrisches und Rohes au
     </Entry>
     <Entry>
       <ID>35</ID>
-      <DefaultText>„Deine Mildtätigkeit wollen wir auch nicht, Ausländer.“</DefaultText>
-      <FemaleText />
+      <DefaultText>„Deine Mildtätigkeit wollen wir auch nicht, Fremder.“</DefaultText>
+      <FemaleText>„Deine Mildtätigkeit wollen wir auch nicht, Fremde.“</FemaleText>
     </Entry>
     <Entry>
       <ID>36</ID>

--- a/text/conversations/companions/companion_cv_hiravias.stringtable
+++ b/text/conversations/companions/companion_cv_hiravias.stringtable
@@ -284,7 +284,7 @@ Er schaut misstrauisch und verschränkt die Arme. „Aber mein Verdacht, dass si
     </Entry>
     <Entry>
       <ID>233</ID>
-      <DefaultText>Hiravias spuckt aus. „Ausländische Plünderer, besessen mit Reichtümern und Wein. Mögen ihre Eingeweide von nässenden Geschwüren verstopft werden&#160;– und zwar alle!“
+      <DefaultText>Hiravias spuckt aus. „Fremdländische Plünderer, besessen mit Reichtümern und Wein. Mögen ihre Eingeweide von nässenden Geschwüren verstopft werden&#160;– und zwar alle!“
 
 Während er sich an seinem Ohrstummel kratzt, bleibt seine Stirn weiter in Falten. „Nicht dass du in mir einen neutralen Gesprächspartner hättest: Wenn ich, wie so häufig, ein unausstehliches Kind war, sagten mir meine Eltern, Dyrwälder würden mich im jetzigen UND im nächsten Leben versklaven, wenn ich mich nicht benehme.“</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_kana_hub.stringtable
+++ b/text/conversations/companions/companion_cv_kana_hub.stringtable
@@ -782,7 +782,7 @@ Kana kichert. „Tut mir leid.“</DefaultText>
     </Entry>
     <Entry>
       <ID>164</ID>
-      <DefaultText>„…&#160;Aber anscheinend ist es von diesem Gedankengut zur Auffassung, dass wir alle ausländischen Einflüsse vertreiben müssen, kein weiter Schritt mehr.“</DefaultText>
+      <DefaultText>„…&#160;Aber anscheinend ist es von diesem Gedankengut zur Auffassung, dass wir alle fremdländischen Einflüsse vertreiben müssen, kein weiter Schritt mehr.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_kana_hub.stringtable
+++ b/text/conversations/companions/companion_cv_kana_hub.stringtable
@@ -584,7 +584,7 @@ Kana kichert. „Tut mir leid.“</DefaultText>
     </Entry>
     <Entry>
       <ID>122</ID>
-      <DefaultText>„Die Pahari bekommen mehr Einfluss. Sie veranlassten den Ranga Nui, unsere Bemühungen auf die nördliche Expansion zu konzentrieren, und alle Häfen für aus dem Süden kommende Ausländer zu sperren.“
+      <DefaultText>„Die Pahari bekommen mehr Einfluss. Sie veranlassten den Ranga Nui, unsere Bemühungen auf die nördliche Expansion zu konzentrieren, und alle Häfen für aus dem Süden kommende Fremden zu sperren.“
 
 „Tâkowa zumindest kommt einem kleiner vor. Nach der Fertigstellung des Tors der Großen Zähne hat der Handel nachgelassen.“</DefaultText>
       <FemaleText />

--- a/text/conversations/companions/companion_cv_kana_observations.stringtable
+++ b/text/conversations/companions/companion_cv_kana_observations.stringtable
@@ -91,7 +91,7 @@
     </Entry>
     <Entry>
       <ID>21</ID>
-      <DefaultText>„Ich verstehe nicht, warum die Glanfathaner darauf bestehen, Ausländer von diesen Ort zu vertreiben. Eigentlich sollte doch jedermann Zeugnis über die engwithanischen Errungenschaften ablegen können?“</DefaultText>
+      <DefaultText>„Ich verstehe nicht, warum die Glanfathaner darauf bestehen, Fremde von diesen Ort zu vertreiben. Eigentlich sollte doch jedermann Zeugnis über die engwithanischen Errungenschaften ablegen können?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_kana_od_nua.stringtable
+++ b/text/conversations/companions/companion_cv_kana_od_nua.stringtable
@@ -128,7 +128,7 @@ Kana hält inne. „Naja, hier oben ist natürlich alles aedyrischer Bauart, abe
     </Entry>
     <Entry>
       <ID>25</ID>
-      <DefaultText>„Es gibt da jene, die behaupten, wir hätten uns nicht an seine Anleitungen gehalten, dass wir uns gestattet haben, schwach zu werden, und dass wir unsere Traditionen durch die Aufnahme von Ausländern beschmutzt haben, anstatt die Lande um uns herum zu beanspruchen. Dass wir uns an diese Traditionen halten müssen, wenn wir aus uns eine gefürchtete Nation machen wollen.“</DefaultText>
+      <DefaultText>„Es gibt da jene, die behaupten, wir hätten uns nicht an seine Anleitungen gehalten, dass wir uns gestattet haben, schwach zu werden, und dass wir unsere Traditionen durch die Aufnahme von Fremden beschmutzt haben, anstatt die Lande um uns herum zu beanspruchen. Dass wir uns an diese Traditionen halten müssen, wenn wir aus uns eine gefürchtete Nation machen wollen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/companion_cv_sagani_main.stringtable
+++ b/text/conversations/companions/companion_cv_sagani_main.stringtable
@@ -443,7 +443,7 @@ Sie zählt an ihren schwieligen Fingern ab. „Karibus, Robben und kleine Wale v
       <ID>175</ID>
       <DefaultText>„Vorwiegend Enutanik wie ich. Die Leute hier nennen uns ‚Nordzwerge‘.“
 
-„Manchmal verbringen Nomadenclans aus Glamfellen aus dem Ewigen Weiß die kälteren Jahreszeiten auf Naasitaq. Wir bekommen aber nicht allzu viele Ausländer zu Gesicht, die mit der Witterung klarkommen.“</DefaultText>
+„Manchmal verbringen Nomadenclans aus Glamfellen aus dem Ewigen Weiß die kälteren Jahreszeiten auf Naasitaq. Wir bekommen aber nicht allzu viele Fremde zu Gesicht, die mit der Witterung klarkommen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/poi/poi_bs_caed_nua.stringtable
+++ b/text/conversations/companions/poi/poi_bs_caed_nua.stringtable
@@ -56,7 +56,7 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>„Das Letzte, was der Dyrwald braucht, ist NOCH eine ausländische Kolonie.“</DefaultText>
+      <DefaultText>„Das Letzte, was der Dyrwald braucht, ist NOCH eine fremdländische Kolonie.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/companions/poi/poi_bs_expedition_hall.stringtable
+++ b/text/conversations/companions/poi/poi_bs_expedition_hall.stringtable
@@ -21,7 +21,7 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>„Die Dutzenden mögen uns Ausländer ja nicht besonders gut leiden, gegen unsere Münzen aber scheinen sie nichts zu haben.“</DefaultText>
+      <DefaultText>„Die Dutzenden mögen uns Fremde ja nicht besonders gut leiden, gegen unsere Münzen aber scheinen sie nichts zu haben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/conversations/prototype_2/p2_cv_osmaer.stringtable
+++ b/text/conversations/prototype_2/p2_cv_osmaer.stringtable
@@ -230,8 +230,8 @@
     </Entry>
     <Entry>
       <ID>87</ID>
-      <DefaultText>„In letzter Zeit hat es keine Spur mehr von ihm gegeben. Gerüchten zufolge hat ihn irgendein Ausländer getötet.“ Er mustert dich berechnend.</DefaultText>
-      <FemaleText />
+      <DefaultText>„In letzter Zeit hat es keine Spur mehr von ihm gegeben. Gerüchten zufolge hat ihn irgendein Fremder getötet.“ Er mustert dich berechnend.</DefaultText>
+      <FemaleText>„In letzter Zeit hat es keine Spur mehr von ihm gegeben. Gerüchten zufolge hat ihn irgendeine Fremde getötet.“ Er mustert dich berechnend.</FemaleText>
     </Entry>
     <Entry>
       <ID>88</ID>

--- a/text/game/interactables.stringtable
+++ b/text/game/interactables.stringtable
@@ -2779,7 +2779,7 @@ Während Ihre Ambitionen jedem Sohn der Republiken gut zu Gesicht stünden, so k
     </Entry>
     <Entry>
       <ID>646</ID>
-      <DefaultText>Die Außenhäute sehen derart glänzend rot aus, dass es so wirkt, als ob sich jemand die Zeit genommen hätte, jede Frucht einzeln zu polieren.</DefaultText>
+      <DefaultText>Die Schalen sehen derart glänzend rot aus, dass es so wirkt, als ob sich jemand die Zeit genommen hätte, jede Frucht einzeln zu polieren.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/items.stringtable
+++ b/text/game/items.stringtable
@@ -6006,7 +6006,7 @@ Anstatt eine einzelne Person den Bogen besitzen zu lassen, betrachtete der Stamm
     </Entry>
     <Entry>
       <ID>1217</ID>
-      <DefaultText>Zu den berühmten Rezepten der Rauatai, mit deren Liebe für Süßes es nur die Aedyrer aufnehmen können, gehören viele köstliche Nachspeisen und reichhaltige Leckerbissen. Zu den Spezialitäten, die bei reichen Feinschmeckern der bekannten Welt am höchsten im Kurs stehen, gehört auch der „schwärzeste“ Schokoladenkeks. Diese Kekse werden von Rauatai-Botschafter gerne als kleine Aufmerksamkeiten verteilt, und viele ausländische Würdenträger empfangen Rauatai-Delegationen vor allem deshalb sehr warmherzig, weil sie auf Gastgeschenke in Form dieser Kekse hoffen.</DefaultText>
+      <DefaultText>Zu den berühmten Rezepten der Rauatai, mit deren Liebe für Süßes es nur die Aedyrer aufnehmen können, gehören viele köstliche Nachspeisen und reichhaltige Leckerbissen. Zu den Spezialitäten, die bei reichen Feinschmeckern der bekannten Welt am höchsten im Kurs stehen, gehört auch der „schwärzeste“ Schokoladenkeks. Diese Kekse werden von Rauatai-Botschafter gerne als kleine Aufmerksamkeiten verteilt, und viele fremdländische Würdenträger empfangen Rauatai-Delegationen vor allem deshalb sehr warmherzig, weil sie auf Gastgeschenke in Form dieser Kekse hoffen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6051,7 +6051,7 @@ Anstatt eine einzelne Person den Bogen besitzen zu lassen, betrachtete der Stamm
     </Entry>
     <Entry>
       <ID>1226</ID>
-      <DefaultText>Der Casità-Auflauf, auch „Kapitänsauflauf“ genannt, stammt ursprünglich aus den Küstenschänken des Dyrwalds, sich durch die Übernahme ausländischer Rezepte auf vailianische Handelsinteressen auszurichten. Die Ergebnisse waren letztendlich bei den Einheimischen viel beliebter als bei Besuchern aus den Republiken, und in vielen Städten des Dyrwalds sind Fischaufläufe weiterhin weit verbreitet.</DefaultText>
+      <DefaultText>Der Casità-Auflauf, auch „Kapitänsauflauf“ genannt, stammt ursprünglich aus den Küstenschänken des Dyrwalds, sich durch die Übernahme fremdländischer Rezepte auf vailianische Handelsinteressen auszurichten. Die Ergebnisse waren letztendlich bei den Einheimischen viel beliebter als bei Besuchern aus den Republiken, und in vielen Städten des Dyrwalds sind Fischaufläufe weiterhin weit verbreitet.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -6132,7 +6132,7 @@ Doch wieder stand Mabec ungläubig vor dem Baum&#160;– er fand weder einen Hoh
     </Entry>
     <Entry>
       <ID>1242</ID>
-      <DefaultText>Perlholz-Huhn wird von den Siedlern entlang der Perlenküste und in Trutzbucht gerne gegessen, aber die Beliebtheit des Gerichts hat sich nicht weit in den Norden oder gar ins Ausland verbreitet. Die Einheimischen behaupten, dass die Zwerge von Talaneir für die Erfindung des Gerichts verantwortlich waren. Aufgrund der merkwürdigen Zutaten, oftmals eine Besonderheit der zwergischen Küche, neigen viele dazu, die Behauptung für bare Münze zu nehmen. Es gibt Gerüchte, dass der Duc von Ozia Geschmack an Perlholz-Huhn gefunden hätte und zur Zubereitung für seine besonderen Vorlieben lebendig aus Alt-Vailia importierte Graubrusthühner benutzen würde. Da das Gericht in den vailianischen Republiken noch nicht beliebt ist, sind sich die Einheimischen von Ozia nicht sicher, ob sie den vermeintlichen Kochstil des Ducs nachahmen oder ihn Ausländern energisch verweigern sollen.</DefaultText>
+      <DefaultText>Perlholz-Huhn wird von den Siedlern entlang der Perlenküste und in Trutzbucht gerne gegessen, aber die Beliebtheit des Gerichts hat sich nicht weit in den Norden oder gar ins Ausland verbreitet. Die Einheimischen behaupten, dass die Zwerge von Talaneir für die Erfindung des Gerichts verantwortlich waren. Aufgrund der merkwürdigen Zutaten, oftmals eine Besonderheit der zwergischen Küche, neigen viele dazu, die Behauptung für bare Münze zu nehmen. Es gibt Gerüchte, dass der Duc von Ozia Geschmack an Perlholz-Huhn gefunden hätte und zur Zubereitung für seine besonderen Vorlieben lebendig aus Alt-Vailia importierte Graubrusthühner benutzen würde. Da das Gericht in den vailianischen Republiken noch nicht beliebt ist, sind sich die Einheimischen von Ozia nicht sicher, ob sie den vermeintlichen Kochstil des Ducs nachahmen oder ihn Fremdländern energisch verweigern sollen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/text/game/items.stringtable
+++ b/text/game/items.stringtable
@@ -6006,7 +6006,7 @@ Anstatt eine einzelne Person den Bogen besitzen zu lassen, betrachtete der Stamm
     </Entry>
     <Entry>
       <ID>1217</ID>
-      <DefaultText>Zu den berühmten Rezepten der Rauatai, mit deren Liebe für Süßes es nur die Aedyrer aufnehmen können, gehören viele köstliche Nachspeisen und reichhaltige Leckerbissen. Zu den Spezialitäten, die bei reichen Feinschmeckern der bekannten Welt am höchsten im Kurs stehen, gehört auch der „schwärzeste“ Schokoladenkeks. Diese Kekse werden von Rauatai-Botschafter gerne als kleine Aufmerksamkeiten verteilt, und viele fremdländische Würdenträger empfangen Rauatai-Delegationen vor allem deshalb sehr warmherzig, weil sie auf Gastgeschenke in Form dieser Kekse hoffen.</DefaultText>
+      <DefaultText>Zu den berühmten Rezepten der Rauatai, mit deren Liebe für Süßes es nur die Aedyrer aufnehmen können, gehören viele köstliche Nachspeisen und reichhaltige Leckerbissen. Zu den Spezialitäten, die bei reichen Feinschmeckern der bekannten Welt am höchsten im Kurs stehen, gehört auch der „schwärzeste“ Schokoladenkeks. Diese Kekse werden von Rauatai-Botschaftern gerne als kleine Aufmerksamkeiten verteilt, und viele fremdländische Würdenträger empfangen Rauatai-Delegationen vor allem deshalb sehr warmherzig, weil sie auf Gastgeschenke in Form dieser Kekse hoffen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Habe mal die meisten Ausländer in Fremde geändert.
Kann sein, dass hier und da noch eine weibliche Variante fehlt.

Manche Texte ließen sich schlecht ändern, da habe ich Ausländer, ausländisch, etc gelassen.
